### PR TITLE
Improve error reporting for the renderer

### DIFF
--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -101,10 +101,15 @@ export default class HandlebarsRenderer extends Renderer {
       return config.template(data);
     }
 
+    if (!(config.templateName in this._templates)) {
+      throw new Error('Can\'t find tempate: ' + config.templateName);
+    }
+
     try {
       return this._templates[config.templateName](data);
     } catch (e) {
-      throw new Error('Can not find/render template: ' + config.templateName, e);
+      console.error('Error when trying to render the template: ' + config.templateName);
+      throw e;
     }
   }
 

--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -102,7 +102,7 @@ export default class HandlebarsRenderer extends Renderer {
     }
 
     if (!(config.templateName in this._templates)) {
-      throw new Error('Can\'t find tempate: ' + config.templateName);
+      throw new Error('Can\'t find template: ' + config.templateName);
     }
 
     try {


### PR DESCRIPTION
Improve error reporting for the renderer

Previously, when a template couldn't be found or rendered, the SDK produced a generic message which hid the underlying error and stack trace. This PR exposes the underlying error message (which is much more useful). Also if a template isn't found, an error is thrown which states which template could not be found.

J=SLAP-1079
TEST=manual

Create an invalid template and see a much more useful error message be reported.
