### PR TITLE
Default boolean facet formatting

### DIFF
--- a/conf/i18n/translations/de.po
+++ b/conf/i18n/translations/de.po
@@ -445,3 +445,13 @@ msgstr "Eine Fragen stellen"
 msgctxt "Verb, clears search"
 msgid "Clear"
 msgstr "entfernen"
+
+#: src/ui/components/filters/facetscomponent.js:277
+msgctxt "True or False"
+msgid "False"
+msgstr "Falsch"
+
+#: src/ui/components/filters/facetscomponent.js:274
+msgctxt "True or False"
+msgid "True"
+msgstr "Wahr"

--- a/conf/i18n/translations/es.po
+++ b/conf/i18n/translations/es.po
@@ -444,3 +444,13 @@ msgstr "Describa su problema"
 msgctxt "Verb, clears search"
 msgid "Clear"
 msgstr "Cancelar"
+
+#: src/ui/components/filters/facetscomponent.js:277
+msgctxt "True or False"
+msgid "False"
+msgstr "Falso"
+
+#: src/ui/components/filters/facetscomponent.js:274
+msgctxt "True or False"
+msgid "True"
+msgstr "Verdadero"

--- a/conf/i18n/translations/fr.po
+++ b/conf/i18n/translations/fr.po
@@ -444,3 +444,13 @@ msgid "[[resultsCount]] autocomplete option found"
 msgid_plural "[[resultsCount]] autocomplete options found"
 msgstr[0] "[[resultsCount]] option de saisie automatique trouvée"
 msgstr[1] "[[resultsCount]] options de saisie automatique trouvées"
+
+#: src/ui/components/filters/facetscomponent.js:277
+msgctxt "True or False"
+msgid "False"
+msgstr "Faux"
+
+#: src/ui/components/filters/facetscomponent.js:274
+msgctxt "True or False"
+msgid "True"
+msgstr "Vrai"

--- a/conf/i18n/translations/it.po
+++ b/conf/i18n/translations/it.po
@@ -444,3 +444,13 @@ msgstr "Fai una domanda"
 msgctxt "Verb, clears search"
 msgid "Clear"
 msgstr "Cancellare"
+
+#: src/ui/components/filters/facetscomponent.js:277
+msgctxt "True or False"
+msgid "False"
+msgstr "Falso"
+
+#: src/ui/components/filters/facetscomponent.js:274
+msgctxt "True or False"
+msgid "True"
+msgstr "Vero"

--- a/conf/i18n/translations/ja.po
+++ b/conf/i18n/translations/ja.po
@@ -443,3 +443,13 @@ msgid "[[resultsCount]] autocomplete option found"
 msgid_plural "[[resultsCount]] autocomplete options found"
 msgstr[0] "オートコンプリート選択が[[resultsCount]]件見つかりました"
 msgstr[1] "オートコンプリート選択が[[resultsCount]]件見つかりました"
+
+#: src/ui/components/filters/facetscomponent.js:277
+msgctxt "True or False"
+msgid "False"
+msgstr "False"
+
+#: src/ui/components/filters/facetscomponent.js:274
+msgctxt "True or False"
+msgid "True"
+msgstr "True"

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -252,10 +252,33 @@ export default class FacetsComponent extends Component {
       updatedFacets = previousFacets;
     }
 
+    updatedFacets = this._transformBooleanFacets(updatedFacets);
+
     return super.setState({
       ...data,
       filters: Facet.fromCore(updatedFacets),
       isNoResults: data.resultsContext === ResultsContext.NO_RESULTS
+    });
+  }
+
+  /**
+   * Applies default formatting to boolean facets
+   *
+   * @param {DisplayableFacet[]} facets from answers-core
+   */
+  _transformBooleanFacets (facets) {
+    return facets.map(facet => {
+      const options = facet.options.map(option => {
+        let displayName = option.displayName;
+        if (option.value === true && displayName === 'true') { 
+          displayName = TranslationFlagger.flag({ phrase: 'True' });
+        }
+        if (option.value === false && displayName === 'false') {
+          displayName = TranslationFlagger.flag({ phrase: 'False' });
+        }
+        return Object.assign({}, option, { displayName });
+      });
+      return Object.assign({}, facet, { options });
     });
   }
 

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -265,6 +265,7 @@ export default class FacetsComponent extends Component {
    * Applies default formatting to boolean facets
    *
    * @param {DisplayableFacet[]} facets from answers-core
+   * @returns {DisplayableFacet[]} from answers-core
    */
   _transformBooleanFacets (facets) {
     return facets.map(facet => {

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -270,7 +270,7 @@ export default class FacetsComponent extends Component {
     return facets.map(facet => {
       const options = facet.options.map(option => {
         let displayName = option.displayName;
-        if (option.value === true && displayName === 'true') { 
+        if (option.value === true && displayName === 'true') {
           displayName = TranslationFlagger.flag({ phrase: 'True' });
         }
         if (option.value === false && displayName === 'false') {

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -271,10 +271,10 @@ export default class FacetsComponent extends Component {
       const options = facet.options.map(option => {
         let displayName = option.displayName;
         if (option.value === true && displayName === 'true') {
-          displayName = TranslationFlagger.flag({ phrase: 'True' });
+          displayName = TranslationFlagger.flag({ phrase: 'True', context: 'True or False' });
         }
         if (option.value === false && displayName === 'false') {
-          displayName = TranslationFlagger.flag({ phrase: 'False' });
+          displayName = TranslationFlagger.flag({ phrase: 'False', context: 'True or False' });
         }
         return Object.assign({}, option, { displayName });
       });

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -262,48 +262,37 @@ export default class FacetsComponent extends Component {
    * @returns {DisplayableFacet[]} from answers-core
    */
   _processFacets (facets) {
-    const processedFacets = [];
-    const booleanFacets = [];
-
     const isBooleanFacet = facet => {
       const firstOption = (facet.options && facet.options[1]) || {};
       return firstOption['value'] === true || firstOption['value'] === false;
     };
 
-    facets.forEach(facet => {
+    return facets.map(facet => {
       if (isBooleanFacet(facet)) {
-        booleanFacets.push(facet);
-      } else {
-        processedFacets.push(facet);
+        return this._transformBooleanFacet(facet);
       }
+      return facet;
     });
-
-    const transformedBooleanFacets = this._transformBooleanFacets(booleanFacets);
-    processedFacets.push(...transformedBooleanFacets);
-
-    return processedFacets;
   }
 
   /**
-   * Applies default formatting to boolean facets
+   * Applies default formatting to a boolean facet
    *
-   * @param {DisplayableFacet[]} facets from answers-core
-   * @returns {DisplayableFacet[]} from answers-core
+   * @param {DisplayableFacet} facet from answers-core
+   * @returns {DisplayableFacet} from answers-core
    */
-  _transformBooleanFacets (facets) {
-    return facets.map(facet => {
-      const options = facet.options.map(option => {
-        let displayName = option.displayName;
-        if (option.value === true && displayName === 'true') {
-          displayName = TranslationFlagger.flag({ phrase: 'True', context: 'True or False' });
-        }
-        if (option.value === false && displayName === 'false') {
-          displayName = TranslationFlagger.flag({ phrase: 'False', context: 'True or False' });
-        }
-        return Object.assign({}, option, { displayName });
-      });
-      return Object.assign({}, facet, { options });
+  _transformBooleanFacet (facet) {
+    const options = facet.options.map(option => {
+      let displayName = option.displayName;
+      if (option.value === true && displayName === 'true') {
+        displayName = TranslationFlagger.flag({ phrase: 'True', context: 'True or False' });
+      }
+      if (option.value === false && displayName === 'false') {
+        displayName = TranslationFlagger.flag({ phrase: 'False', context: 'True or False' });
+      }
+      return Object.assign({}, option, { displayName });
     });
+    return Object.assign({}, facet, { options });
   }
 
   remove () {

--- a/tests/ui/components/filters/facetscomponent.js
+++ b/tests/ui/components/filters/facetscomponent.js
@@ -10,6 +10,27 @@ describe('Facets Component', () => {
   DOM.setup(document, new DOMParser());
   let COMPONENT_MANAGER, defaultConfig;
 
+  const coreFacets = [{
+    fieldId: 'c_acceptingNewPatients',
+    displayName: 'Accepting New Patients',
+    options: [
+      {
+        displayName: 'true',
+        count: 1,
+        selected: false,
+        matcher: '$eq',
+        value: true
+      },
+      {
+        displayName: 'false',
+        count: 1,
+        selected: false,
+        matcher: '$eq',
+        value: false
+      }
+    ]
+  }];
+
   beforeEach(() => {
     const bodyEl = DOM.query('body');
     DOM.empty(bodyEl);
@@ -52,27 +73,6 @@ describe('Facets Component', () => {
       });
       return facets;
     };
-    const coreFacets = [{
-      fieldId: 'c_acceptingNewPatients',
-      displayName: 'Accepting New Patients',
-      options: [
-        {
-          displayName: 'true',
-          count: 1,
-          selected: false,
-          matcher: '$eq',
-          value: true
-        },
-        {
-          displayName: 'false',
-          count: 1,
-          selected: false,
-          matcher: '$eq',
-          value: false
-        }
-      ]
-    }];
-
     const component = COMPONENT_MANAGER.create('Facets', {
       transformFacets,
       ...defaultConfig
@@ -84,6 +84,26 @@ describe('Facets Component', () => {
     const expectedDisplayNames = [
       'Not Accepting Patients',
       'Accepting Patients'
+    ];
+    const actualDisplayNames = [];
+
+    wrapper.find('.js-yxt-FilterOptions-optionLabel--name').forEach(node => {
+      const displayName = node.text().trim();
+      actualDisplayNames.push(displayName);
+    });
+
+    expect(actualDisplayNames).toEqual(expect.arrayContaining(expectedDisplayNames));
+  });
+
+  it('_transformBooleanFacets() makes boolean facets uppercase by default', () => {
+    const component = COMPONENT_MANAGER.create('Facets', defaultConfig);
+    const dynamicFilters = DynamicFilters.fromCore(coreFacets);
+    component.core.storage.set(StorageKeys.DYNAMIC_FILTERS, dynamicFilters);
+    const wrapper = mount(component);
+
+    const expectedDisplayNames = [
+      'True',
+      'False'
     ];
     const actualDisplayNames = [];
 


### PR DESCRIPTION
Format boolean facets as 'True' and 'False' by default

J=SLAP-1159
TEST=manual, auto

Open a test site with boolean facets and observe the correct display names for the options. Test that if `transformFacets` modifies the display name of a boolean facet, it takes precedence.
