### PR TITLE
Allow range/daterange filters to set initialMin/initialMax to null

### DIFF
--- a/README.md
+++ b/README.md
@@ -1644,9 +1644,9 @@ ANSWERS.addComponent('RangeFilter', {
   maxLabel: 'Not More Than',
   // Optional, the placeholder text for the max value, defaults to 'Max'
   maxPlaceholderText: 'Max',
-  // Optional, the initial min value to show, defaults to 0
+  // Optional, the initial min value to show, defaults to 0. Set this to null to clear the value.
   initialMin: 1,
-  // Optional, the initial max value to show, defaults to 10
+  // Optional, the initial max value to show, defaults to 10. Set this to null to clear the value.
   initialMax: 5,
   // Optional, the callback function to call when changed
   onChange: function() {}
@@ -1673,9 +1673,9 @@ ANSWERS.addComponent('DateRangeFilter', {
   minLabel: 'Earliest',
   // Optional, the label to show next to the max date, defaults to no label
   maxLabel: 'Latest',
-  // Optional, the initial min date to show in yyyy-mm-dd format, defaults to today
+  // Optional, the initial min date to show in yyyy-mm-dd format, defaults to today. Set this to null to clear the value.
   initialMin: '2019-08-01',
-  // Optional, the initial max date to show in yyyy-mm-dd format, defaults to today
+  // Optional, the initial max date to show in yyyy-mm-dd format, defaults to today. Set this to null to clear the value.
   initialMax: '2019-09-01',
   // Optional, whether to store the filter on change to input
   storeOnChange: true,

--- a/src/ui/components/filters/daterangefiltercomponent.js
+++ b/src/ui/components/filters/daterangefiltercomponent.js
@@ -74,8 +74,8 @@ export default class DateRangeFilterComponent extends Component {
      * @private
      */
     this._date = {
-      min: minDate || config.initialMin || todayString,
-      max: maxDate || config.initialMax || todayString
+      min: [minDate, config.initialMin, todayString].find(v => v !== undefined),
+      max: [maxDate, config.initialMax, todayString].find(v => v !== undefined)
     };
   }
 

--- a/src/ui/components/filters/rangefiltercomponent.js
+++ b/src/ui/components/filters/rangefiltercomponent.js
@@ -63,8 +63,8 @@ export default class RangeFilterComponent extends Component {
      * @private
      */
     this._range = {
-      min: this.getFirstValidValue(minVal, config.initialMin, 0),
-      max: this.getFirstValidValue(maxVal, config.initialMax, 10)
+      min: [minVal, config.initialMin, 0].find(v => v !== undefined),
+      max: [maxVal, config.initialMax, 10].find(v => v !== undefined)
     };
 
     /**
@@ -87,14 +87,6 @@ export default class RangeFilterComponent extends Component {
      * @private
      */
     this._maxLabel = config.maxLabel || null;
-  }
-
-  getFirstValidValue (...values) {
-    for (const value of values) {
-      if (value || value === 0) {
-        return value;
-      }
-    }
   }
 
   static get type () {

--- a/tests/ui/components/filters/daterangecomponent.js
+++ b/tests/ui/components/filters/daterangecomponent.js
@@ -359,4 +359,21 @@ describe('date range filter component', () => {
     expect(component.getFilterNode().getFilter()).toEqual(filter);
     expect(component.getFilterNode().getMetadata()).toEqual(metadata);
   });
+
+  it('interprets a null initialMin/Max as unset', () => {
+    const config = {
+      ...defaultConfig,
+      initialMin: null,
+      initialMax: null
+    };
+
+    const component = COMPONENT_MANAGER.create('DateRangeFilter', config);
+    const wrapper = mount(component);
+    const minInputs = wrapper.find('input[data-key="min"]');
+    expect(minInputs).toHaveLength(1);
+    expect(minInputs.props().value).toBeFalsy();
+    const maxInputs = wrapper.find('input[data-key="max"]');
+    expect(maxInputs).toHaveLength(1);
+    expect(maxInputs.props().value).toBeFalsy();
+  });
 });

--- a/tests/ui/components/filters/rangefiltercomponent.js
+++ b/tests/ui/components/filters/rangefiltercomponent.js
@@ -183,4 +183,23 @@ describe('range filter component', () => {
     expect(component.getFilterNode().getFilter()).toEqual(filter);
     expect(component.getFilterNode().getMetadata()).toEqual(metadata);
   });
+
+  it('interprets a null initialMin/Max as unset', () => {
+    const config = {
+      ...defaultConfig,
+      field: 'yorha',
+      title: 'Flowers for m[A]chines',
+      initialMin: null,
+      initialMax: null
+    };
+
+    const component = COMPONENT_MANAGER.create('RangeFilter', config);
+    const wrapper = mount(component);
+    const minInputs = wrapper.find('input[data-key="min"]');
+    expect(minInputs).toHaveLength(1);
+    expect(minInputs.props().value).toBeFalsy();
+    const maxInputs = wrapper.find('input[data-key="max"]');
+    expect(maxInputs).toHaveLength(1);
+    expect(maxInputs.props().value).toBeFalsy();
+  });
 });


### PR DESCRIPTION
This PR allows somebody to set the initial values of a Range/DateRange filter
to null. Previously, the only way to do this was to set the initialMin/Max to blank string,
which felt unintuitive for a range filter specifically, since for a range filter initialMin/Max
is supposed to be a number.

J=SLAP-1088
TEST=manual

test that I can set the initial values in config to null, and that will
unset them. See that they still work with values persisted in the url.