### PR TITLE
Transform filters with multiple matchers into combined filters

### DIFF
--- a/src/core/filters/filterregistry.js
+++ b/src/core/filters/filterregistry.js
@@ -123,6 +123,7 @@ export default class FilterRegistry {
   /**
    * Transforms a {@link SimpleFilterNode} to answers-core's {@link Filter} or {@link CombinedFilter}
    * if there are multiple matchers.
+   * TODO(SLAP-1183): remove the parsing for multiple matchers.
    *
    * @param {SimpleFilterNode} filterNode
    * @returns {Filter}

--- a/src/core/filters/filterregistry.js
+++ b/src/core/filters/filterregistry.js
@@ -121,7 +121,8 @@ export default class FilterRegistry {
   }
 
   /**
-   * Transforms a {@link SimpleFilterNode} to answers-core's {@link Filter}
+   * Transforms a {@link SimpleFilterNode} to answers-core's {@link Filter} or {@link CombinedFilter}
+   * if there are multiple matchers.
    *
    * @param {SimpleFilterNode} filterNode
    * @returns {Filter}
@@ -129,13 +130,26 @@ export default class FilterRegistry {
   _transformSimpleFilterNode (filterNode) {
     const fieldId = Object.keys(filterNode.filter)[0];
     const filterComparison = filterNode.filter[fieldId];
-    const matcher = Object.keys(filterComparison)[0];
-    const value = filterComparison[matcher];
-    return {
-      fieldId: fieldId,
-      matcher: matcher,
-      value: value
-    };
+    const matchers = Object.keys(filterComparison);
+    if (matchers.length === 1) {
+      const matcher = matchers[0];
+      const value = filterComparison[matcher];
+      return {
+        fieldId: fieldId,
+        matcher: matcher,
+        value: value
+      };
+    } else if (matchers.length > 1) {
+      const childFilters = matchers.map(matcher => ({
+        fieldId: fieldId,
+        matcher: matcher,
+        value: filterComparison[matcher]
+      }));
+      return {
+        combinator: FilterCombinators.AND,
+        filters: childFilters
+      };
+    }
   }
 
   /**

--- a/src/core/filters/simplefilternode.js
+++ b/src/core/filters/simplefilternode.js
@@ -6,7 +6,7 @@ import FilterNode from './filternode';
 
 /**
  * A SimpleFilterNode represents a single, atomic filter.
- * An atomic filter is a filter that filters by a single value on a single field id,
+ * An atomic filter is a filter that filters on a single field id,
  * and does not contain any children filters.
  */
 export default class SimpleFilterNode extends FilterNode {

--- a/tests/core/filters/filterregistry.js
+++ b/tests/core/filters/filterregistry.js
@@ -294,4 +294,31 @@ describe('FilterRegistry', () => {
     };
     expect(registry.createFacetsFromFilterNodes()).toEqual(expectedFacets);
   });
+  it('transforms static filters with multiple matchers into combined filters', () => {
+    const originalFilter = {
+      aField: {
+        $gt: 0,
+        $lt: 5
+      }
+    };
+    registry.setStaticFilterNodes('aName', FilterNodeFactory.from({
+      metadata: {},
+      filter: originalFilter
+    }));
+    expect(registry.getStaticFilterPayload()).toMatchObject({
+      combinator: '$and',
+      filters: [
+        {
+          fieldId: 'aField',
+          matcher: '$gt',
+          value: 0
+        },
+        {
+          fieldId: 'aField',
+          matcher: '$lt',
+          value: 5
+        }
+      ]
+    });
+  });
 });

--- a/tests/core/filters/filterregistry.js
+++ b/tests/core/filters/filterregistry.js
@@ -294,6 +294,7 @@ describe('FilterRegistry', () => {
     };
     expect(registry.createFacetsFromFilterNodes()).toEqual(expectedFacets);
   });
+
   it('transforms static filters with multiple matchers into combined filters', () => {
     const originalFilter = {
       aField: {


### PR DESCRIPTION
This commit updates FilterRegistry to transform simple filters with multiple matchers
into combined filters. Previously, we were assuming that all simple filters in the SDK
have only one matcher. This isn't true for range filters, which can have 2.

J=SLAP-1088
TEST=manual,auto

test that range filters will now create combined filters, and send them in the request