### PR TITLE
SortOptions on load

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -169,6 +169,7 @@ class Answers {
         this.core.storage.delete(StorageKeys.PERSISTED_LOCATION_RADIUS);
         this.core.storage.delete(StorageKeys.PERSISTED_FILTER);
         this.core.storage.delete(StorageKeys.PERSISTED_FACETS);
+        this.core.storage.delete(StorageKeys.SORT_BYS);
         this.core.filterRegistry.clearAllFilterNodes();
 
         if (!hasQuery) {
@@ -656,6 +657,7 @@ class Answers {
       case StorageKeys.PERSISTED_LOCATION_RADIUS:
         return parseFloat(value);
       case StorageKeys.PERSISTED_FACETS:
+      case StorageKeys.SORT_BYS:
         return JSON.parse(value);
       default:
         return value;

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -508,7 +508,7 @@ export default class Core {
         direction: option.direction
       };
     });
-    this.storage.set(StorageKeys.SORT_BYS, sortBys);
+    this.storage.setWithPersist(StorageKeys.SORT_BYS, sortBys);
   }
 
   /**

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -33,7 +33,7 @@ const StorageKeys = {
   SESSIONS_OPT_IN: 'sessions-opt-in',
   VERTICAL_PAGES_CONFIG: 'vertical-pages-config',
   LOCALE: 'locale',
-  SORT_BYS: 'sort-bys',
+  SORT_BYS: 'sortBys',
   NO_RESULTS_CONFIG: 'no-results-config',
   RESULTS_HEADER: 'results-header', // DEPRECATED
   API_CONTEXT: 'context',

--- a/src/ui/components/filters/sortoptionscomponent.js
+++ b/src/ui/components/filters/sortoptionscomponent.js
@@ -216,6 +216,7 @@ export default class SortOptionsComponent extends Component {
    * Trigger a search with all filters in storage
    */
   _search () {
+    console.log('trigger sort search')
     this.core.triggerSearch(QueryTriggers.FILTER_COMPONENT);
   }
 

--- a/src/ui/components/filters/sortoptionscomponent.js
+++ b/src/ui/components/filters/sortoptionscomponent.js
@@ -19,7 +19,7 @@ export default class SortOptionsComponent extends Component {
   constructor (config = {}, systemConfig = {}) {
     super(assignDefaults(config), systemConfig);
     this.options = this._config.options;
-    this.selectedOptionIndex = this.getPersistedOptionIndex();
+    this.selectedOptionIndex = this.getPersistedSelectedOptionIndex();
     this.options[this.selectedOptionIndex].isSelected = true;
     this.hideExcessOptions = this._config.showMore && this.selectedOptionIndex < this._config.showMoreLimit;
     this.searchOnChangeIsEnabled = this._config.searchOnChange;
@@ -48,7 +48,7 @@ export default class SortOptionsComponent extends Component {
       eventType: 'update',
       storageKey: StorageKeys.HISTORY_POP_STATE,
       callback: () => {
-        const persistedOptionIndex = this.getPersistedOptionIndex();
+        const persistedOptionIndex = this.getPersistedSelectedOptionIndex();
         this._updateSelectedOption(persistedOptionIndex);
         this.setState();
       }
@@ -60,7 +60,7 @@ export default class SortOptionsComponent extends Component {
    *
    * @returns {number|undefined}
    */
-  getPersistedOptionIndex () {
+  getPersistedSelectedOptionIndex () {
     const persistedSortBys = this.core.storage.get(StorageKeys.SORT_BYS) || [];
     const persistedIndex = this._config.options.findIndex(option => {
       return persistedSortBys.find(persistedOption =>

--- a/src/ui/components/filters/sortoptionscomponent.js
+++ b/src/ui/components/filters/sortoptionscomponent.js
@@ -216,7 +216,7 @@ export default class SortOptionsComponent extends Component {
    * Trigger a search with all filters in storage
    */
   _search () {
-    console.log('trigger sort search')
+    console.log('trigger sort search');
     this.core.triggerSearch(QueryTriggers.FILTER_COMPONENT);
   }
 

--- a/src/ui/components/filters/sortoptionscomponent.js
+++ b/src/ui/components/filters/sortoptionscomponent.js
@@ -216,7 +216,6 @@ export default class SortOptionsComponent extends Component {
    * Trigger a search with all filters in storage
    */
   _search () {
-    console.log('trigger sort search');
     this.core.triggerSearch(QueryTriggers.FILTER_COMPONENT);
   }
 

--- a/src/ui/components/filters/sortoptionscomponent.js
+++ b/src/ui/components/filters/sortoptionscomponent.js
@@ -19,7 +19,7 @@ export default class SortOptionsComponent extends Component {
   constructor (config = {}, systemConfig = {}) {
     super(assignDefaults(config), systemConfig);
     this.options = this._config.options;
-    this.selectedOptionIndex = parseInt(this.core.storage.get(this.name)) || 0;
+    this.selectedOptionIndex = this.getPersistedOptionIndex();
     this.options[this.selectedOptionIndex].isSelected = true;
     this.hideExcessOptions = this._config.showMore && this.selectedOptionIndex < this._config.showMoreLimit;
     this.searchOnChangeIsEnabled = this._config.searchOnChange;
@@ -43,6 +43,33 @@ export default class SortOptionsComponent extends Component {
         }
       }
     });
+
+    this.core.storage.registerListener({
+      eventType: 'update',
+      storageKey: StorageKeys.HISTORY_POP_STATE,
+      callback: () => {
+        const persistedOptionIndex = this.getPersistedOptionIndex();
+        this._updateSelectedOption(persistedOptionIndex);
+        this.setState();
+      }
+    });
+  }
+
+  /**
+   * Returns the option index matching the persisted sortBys, if one exists.
+   *
+   * @returns {number|undefined}
+   */
+  getPersistedOptionIndex () {
+    const persistedSortBys = this.core.storage.get(StorageKeys.SORT_BYS) || [];
+    const persistedIndex = this._config.options.findIndex(option => {
+      return persistedSortBys.find(persistedOption =>
+        persistedOption.direction === option.direction &&
+        persistedOption.type === option.type &&
+        persistedOption.field === option.field
+      );
+    });
+    return persistedIndex === -1 ? 0 : persistedIndex;
   }
 
   /**
@@ -176,7 +203,6 @@ export default class SortOptionsComponent extends Component {
 
     // searchOnChange really means sort on change here, just that the sort is done through a search,
     // This was done to have a consistent option name between filters.
-    this.core.storage.setWithPersist(this.name, optionIndex);
     if (this._config.storeOnChange && optionIndex === 0) {
       this.core.clearSortBys();
     } else if (this._config.storeOnChange) {

--- a/tests/ui/components/filters/sortoptionscomponent.js
+++ b/tests/ui/components/filters/sortoptionscomponent.js
@@ -4,6 +4,7 @@ import { mount } from 'enzyme';
 import { AnswersBasicError } from '../../../../src/core/errors/errors';
 import mockManager from '../../../setup/managermocker';
 import StorageKeys from '../../../../src/core/storage/storagekeys';
+import QueryTriggers from '../../../../src/core/models/querytriggers';
 
 const mockedCore = () => {
   return {
@@ -211,7 +212,7 @@ describe('sort options component', () => {
     expect(wrapper.find('.yxt-SortOptions-optionSelector').at(0).getDOMNode().checked).toBeTruthy();
   });
 
-  it('sets persisted sort option on back navigation', () => {
+  it('sets the selected sort option on HISTORY_POP_STATE', () => {
     const opts = {
       ...defaultConfig,
       options: threeOptions
@@ -225,7 +226,7 @@ describe('sort options component', () => {
     expect(wrapper.find('.yxt-SortOptions-optionSelector').at(3).getDOMNode().checked).toBeTruthy();
   });
 
-  it('resets persisted sort option when back navigating to blank url', () => {
+  it('sets the selected sort option to default on HISTORY_POP_STATE with no persisted sorts', () => {
     const opts = {
       ...defaultConfig,
       options: threeOptions
@@ -238,5 +239,30 @@ describe('sort options component', () => {
     COMPONENT_MANAGER.core.storage.set(StorageKeys.HISTORY_POP_STATE, {});
     wrapper.update();
     expect(wrapper.find('.yxt-SortOptions-optionSelector').at(0).getDOMNode().checked).toBeTruthy();
+  });
+
+  it('sets the selected sort option on back/forward navigation', () => {
+    const opts = {
+      ...defaultConfig,
+      options: threeOptions
+    };
+    const triggerSearch = jest.fn();
+    COMPONENT_MANAGER.core.triggerSearch = triggerSearch;
+    const component = COMPONENT_MANAGER.create('SortOptions', opts);
+    const wrapper = mount(component);
+    expect(wrapper.find('.yxt-SortOptions-optionSelector').at(0).getDOMNode().checked).toBeTruthy();
+    expect(triggerSearch).toHaveBeenCalledTimes(0);
+
+    const fourthOption = wrapper.find('.yxt-SortOptions-optionSelector').at(3);
+    fourthOption.simulate('click');
+    expect(triggerSearch).toHaveBeenCalledTimes(1);
+    expect(triggerSearch).toHaveBeenLastCalledWith(QueryTriggers.FILTER_COMPONENT);
+    expect(wrapper.find('.yxt-SortOptions-optionSelector').at(3).getDOMNode().checked).toBeTruthy();
+
+    COMPONENT_MANAGER.core.storage.delete(StorageKeys.SORT_BYS);
+    COMPONENT_MANAGER.core.storage.set(StorageKeys.HISTORY_POP_STATE, {});
+    wrapper.update();
+    expect(wrapper.find('.yxt-SortOptions-optionSelector').at(0).getDOMNode().checked).toBeTruthy();
+    expect(triggerSearch).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
This commit adds the ability for SortOptions to be applied
on page load and back navigation, using the new sortBys url param.
Now, the sortBys state is stored in the URL. The SortOptions component
will update it's component state if it sees a persisted sortBys
option that exists in its config.

J=SLAP-1090
TEST=manual, auto

test that I can apply sort options on load, and back nav
see that it works when back/forward naving to either a blank url,
or a url with sortBys in it