### PR TITLE
RangeFilters on page load

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -5,7 +5,7 @@ module.exports = [
   },
   {
     path: 'dist/answers-modern.min.js',
-    limit: '120kb'
+    limit: '130kb'
   },
   {
     path: 'dist/answerstemplates.compiled.min.js',

--- a/src/core/filters/matcher.js
+++ b/src/core/filters/matcher.js
@@ -1,0 +1,10 @@
+const Matcher = {
+  Equals: '$eq',
+  NotEquals: '!$eq',
+  LessThan: '$lt',
+  LessThanOrEqualTo: '$le',
+  GreaterThan: '$gt',
+  GreaterThanOrEqualTo: '$ge',
+  Near: '$near'
+};
+export default Matcher;

--- a/src/core/filters/matcher.js
+++ b/src/core/filters/matcher.js
@@ -1,3 +1,6 @@
+/**
+ * A Matcher is a filtering operation for {@link Filter}s.
+ */
 const Matcher = {
   Equals: '$eq',
   NotEquals: '!$eq',

--- a/src/core/models/filter.js
+++ b/src/core/models/filter.js
@@ -25,7 +25,7 @@ export default class Filter {
   }
 
   /**
-   * Whether the this filter is a range filter.
+   * Whether this filter is a range filter.
    *
    * @param {Filter} filter
    * @returns {boolean}

--- a/src/core/models/filter.js
+++ b/src/core/models/filter.js
@@ -3,6 +3,13 @@
 import FilterCombinators from '../filters/filtercombinators';
 import Matcher from '../filters/matcher';
 
+const RANGE_MATCHERS = new Set([
+  Matcher.GreaterThan,
+  Matcher.GreaterThanOrEqualTo,
+  Matcher.LessThanOrEqualTo,
+  Matcher.LessThan
+]);
+
 /**
  * Represents an api filter and provides static methods for easily constructing Filters.
  * See https://developer.yext.com/docs/api-reference/#operation/listEntities for structure details
@@ -27,7 +34,6 @@ export default class Filter {
   /**
    * Whether this filter is a range filter.
    *
-   * @param {Filter} filter
    * @returns {boolean}
    */
   isRangeFilter () {
@@ -36,13 +42,7 @@ export default class Filter {
       return false;
     }
     const matchers = Object.keys(this[filterKey]);
-    const rangeMatchers = new Set([
-      Matcher.GreaterThan,
-      Matcher.GreaterThanOrEqualTo,
-      Matcher.LessThanOrEqualTo,
-      Matcher.LessThan
-    ]);
-    return matchers.every(m => rangeMatchers.has(m));
+    return matchers.every(m => RANGE_MATCHERS.has(m));
   }
 
   /**

--- a/src/core/models/filter.js
+++ b/src/core/models/filter.js
@@ -1,6 +1,7 @@
 /** @module Filter */
 
 import FilterCombinators from '../filters/filtercombinators';
+import Matcher from '../filters/matcher';
 
 /**
  * Represents an api filter and provides static methods for easily constructing Filters.
@@ -21,6 +22,27 @@ export default class Filter {
     if (Object.keys(this).length > 0) {
       return Object.keys(this)[0];
     }
+  }
+
+  /**
+   * Whether the this filter is a range filter.
+   *
+   * @param {Filter} filter
+   * @returns {boolean}
+   */
+  isRangeFilter () {
+    const filterKey = this.getFilterKey();
+    if (!filterKey) {
+      return false;
+    }
+    const matchers = Object.keys(this[filterKey]);
+    const rangeMatchers = new Set([
+      Matcher.GreaterThan,
+      Matcher.GreaterThanOrEqualTo,
+      Matcher.LessThanOrEqualTo,
+      Matcher.LessThan
+    ]);
+    return matchers.every(m => rangeMatchers.has(m));
   }
 
   /**
@@ -125,7 +147,7 @@ export default class Filter {
    * @returns {Filter}
    */
   static equal (field, value) {
-    return Filter._fromMatcher(field, '$eq', value);
+    return Filter._fromMatcher(field, Matcher.Equals, value);
   }
 
   /**
@@ -135,7 +157,7 @@ export default class Filter {
    * @returns {Filter}
    */
   static lessThan (field, value) {
-    return Filter._fromMatcher(field, '$lt', value);
+    return Filter._fromMatcher(field, Matcher.LessThan, value);
   }
 
   /**
@@ -145,7 +167,7 @@ export default class Filter {
    * @returns {Filter}
    */
   static lessThanEqual (field, value) {
-    return Filter._fromMatcher(field, '$le', value);
+    return Filter._fromMatcher(field, Matcher.LessThanOrEqualTo, value);
   }
 
   /**
@@ -155,7 +177,7 @@ export default class Filter {
    * @returns {Filter}
    */
   static greaterThan (field, value) {
-    return Filter._fromMatcher(field, '$gt', value);
+    return Filter._fromMatcher(field, Matcher.GreaterThan, value);
   }
 
   /**
@@ -165,7 +187,7 @@ export default class Filter {
    * @returns {Filter}
    */
   static greaterThanEqual (field, value) {
-    return Filter._fromMatcher(field, '$ge', value);
+    return Filter._fromMatcher(field, Matcher.GreaterThanOrEqualTo, value);
   }
 
   /**
@@ -178,8 +200,8 @@ export default class Filter {
   static inclusiveRange (field, min, max) {
     return new Filter({
       [field]: {
-        '$ge': min,
-        '$le': max
+        [Matcher.GreaterThanOrEqualTo]: min,
+        [Matcher.LessThanOrEqualTo]: max
       }
     });
   }
@@ -194,8 +216,8 @@ export default class Filter {
   static exclusiveRange (field, min, max) {
     return new Filter({
       [field]: {
-        '$gt': min,
-        '$lt': max
+        [Matcher.GreaterThan]: min,
+        [Matcher.LessThan]: max
       }
     });
   }
@@ -207,7 +229,7 @@ export default class Filter {
    * @param {number} radius The search radius (in meters)
    */
   static position (lat, lng, radius) {
-    return Filter._fromMatcher('builtin.location', '$near', { lat, lng, radius });
+    return Filter._fromMatcher('builtin.location', Matcher.Near, { lat, lng, radius });
   }
 
   /**

--- a/src/ui/components/filters/rangefiltercomponent.js
+++ b/src/ui/components/filters/rangefiltercomponent.js
@@ -1,15 +1,15 @@
 /** @module RangeFilterComponent */
 
-import Filter from '../../../core/models/filter';
 import DOM from '../../dom/dom';
 import Component from '../component';
-import FilterNodeFactory from '../../../core/filters/filternodefactory';
-import FilterMetadata from '../../../core/filters/filtermetadata';
 import ComponentTypes from '../../components/componenttypes';
 import TranslationFlagger from '../../i18n/translationflagger';
+import Filter from '../../../core/models/filter';
+import FilterNodeFactory from '../../../core/filters/filternodefactory';
+import FilterMetadata from '../../../core/filters/filtermetadata';
+import Matcher from '../../../core/filters/matcher';
 import StorageKeys from '../../../core/storage/storagekeys';
 import { getPersistedRangeFilterContents } from '../../tools/filterutils';
-import Matcher from '../../../core/filters/matcher';
 
 const DEFAULT_CONFIG = {
   minPlaceholderText: TranslationFlagger.flag({

--- a/src/ui/tools/filterutils.js
+++ b/src/ui/tools/filterutils.js
@@ -24,16 +24,17 @@ export function filterIsPersisted (filter, persistedFilter) {
  * Given a filter, return an array of all it's descendants, including itself, that
  * filter on the given fieldId.
  *
- * @param {string} fieldId
  * @param {Filter} persistedFilter
+ * @param {string} fieldId
+ *
  * @returns {Array<Filter>}
  */
-export function findSimpleFiltersWithFieldId (fieldId, persistedFilter) {
+export function findSimpleFiltersWithFieldId (persistedFilter, fieldId) {
   const childFilters =
     persistedFilter[FilterCombinators.AND] || persistedFilter[FilterCombinators.OR];
   if (childFilters) {
     return childFilters.flatMap(
-      childFilter => findSimpleFiltersWithFieldId(fieldId, Filter.from(childFilter)));
+      childFilter => findSimpleFiltersWithFieldId(Filter.from(childFilter), persistedFilter));
   }
   if (Filter.from(persistedFilter).getFilterKey() === fieldId) {
     return [ persistedFilter ];
@@ -44,6 +45,8 @@ export function findSimpleFiltersWithFieldId (fieldId, persistedFilter) {
 /**
  * Finds a persisted range filter for the given fieldId, and returns its contents.
  *
+ * @param {Filter} persistedFilter
+ * @param {string} fieldId
  * @returns {{minVal: number, maxVal: number}}
  */
 export function getPersistedRangeFilterContents (persistedFilter, fieldId) {
@@ -51,7 +54,7 @@ export function getPersistedRangeFilterContents (persistedFilter, fieldId) {
     return {};
   }
   const rangeFiltersForFieldId =
-    findSimpleFiltersWithFieldId(fieldId, persistedFilter)
+    findSimpleFiltersWithFieldId(persistedFilter, fieldId)
       .filter(f => f.isRangeFilter());
   if (rangeFiltersForFieldId.length < 1) {
     return {};

--- a/src/ui/tools/filterutils.js
+++ b/src/ui/tools/filterutils.js
@@ -34,7 +34,7 @@ export function findSimpleFiltersWithFieldId (persistedFilter, fieldId) {
     persistedFilter[FilterCombinators.AND] || persistedFilter[FilterCombinators.OR];
   if (childFilters) {
     return childFilters.flatMap(
-      childFilter => findSimpleFiltersWithFieldId(Filter.from(childFilter), persistedFilter));
+      childFilter => findSimpleFiltersWithFieldId(Filter.from(childFilter), fieldId));
   }
   if (Filter.from(persistedFilter).getFilterKey() === fieldId) {
     return [ persistedFilter ];

--- a/src/ui/tools/filterutils.js
+++ b/src/ui/tools/filterutils.js
@@ -19,3 +19,42 @@ export function filterIsPersisted (filter, persistedFilter) {
   }
   return isEqual(filter, persistedFilter);
 }
+
+/**
+ * Given a filter, return an array of all it's descendants, including itself, that
+ * filter on the given fieldId.
+ *
+ * @param {string} fieldId
+ * @param {Filter} persistedFilter
+ * @returns {Array<Filter>}
+ */
+export function findSimpleFiltersWithFieldId (fieldId, persistedFilter) {
+  const childFilters =
+    persistedFilter[FilterCombinators.AND] || persistedFilter[FilterCombinators.OR];
+  if (childFilters) {
+    return childFilters.flatMap(
+      childFilter => findSimpleFiltersWithFieldId(fieldId, Filter.from(childFilter)));
+  }
+  if (Filter.from(persistedFilter).getFilterKey() === fieldId) {
+    return [ persistedFilter ];
+  }
+  return [];
+}
+
+/**
+ * Finds a persisted range filter for the given fieldId, and returns its contents.
+ *
+ * @returns {{minVal: number, maxVal: number}}
+ */
+export function getPersistedRangeFilterContents (persistedFilter, fieldId) {
+  if (!persistedFilter || !persistedFilter.getFilterKey()) {
+    return {};
+  }
+  const rangeFiltersForFieldId =
+    findSimpleFiltersWithFieldId(fieldId, persistedFilter)
+      .filter(f => f.isRangeFilter());
+  if (rangeFiltersForFieldId.length < 1) {
+    return {};
+  }
+  return rangeFiltersForFieldId[0][fieldId];
+}

--- a/tests/ui/tools/filterutils.js
+++ b/tests/ui/tools/filterutils.js
@@ -1,5 +1,5 @@
 import Filter from '../../../src/core/models/filter';
-import { filterIsPersisted } from '../../../src/ui/tools/filterutils';
+import { filterIsPersisted, findSimpleFiltersWithFieldId, getPersistedRangeFilterContents } from '../../../src/ui/tools/filterutils';
 
 describe('filterIsPersisted', () => {
   it('can detect when a filter is equal to the persisted filter', () => {
@@ -88,5 +88,84 @@ describe('filterIsPersisted', () => {
       }
     });
     expect(filterIsPersisted(rawFilter, persistedFilter)).toBeFalsy();
+  });
+});
+
+describe('findSimpleFiltersWithFieldId', () => {
+  it('returns an array of filters that have the given fieldId', () => {
+    const fieldId = 'c_differentField';
+    const filter1 = {
+      c_aField: { $eq: 5 }
+    };
+    const filter2 = {
+      [fieldId]: { $gt: 123 }
+    };
+    const filter3 = {
+      [fieldId]: { $eq: 'someValue' }
+    };
+    const filter4 = {
+      [fieldId]: { $eq: 'otherValue' }
+    };
+    const persistedFilter = Filter.from({
+      $or: [
+        {
+          $and: [filter1, filter2]
+        },
+        filter3,
+        filter4
+      ]
+    });
+    expect(findSimpleFiltersWithFieldId(fieldId, persistedFilter))
+      .toContainEqual(filter2, filter3, filter4);
+  });
+
+  it('returns an empty array when none match', () => {
+    const filter1 = {
+      c_aField: { $eq: 5 }
+    };
+    const filter2 = {
+      c_anotherOne: { $gt: 123 }
+    };
+    const persistedFilter = Filter.from({
+      $or: [filter1, filter2]
+    });
+    expect(findSimpleFiltersWithFieldId('bob_id', persistedFilter)).toEqual([]);
+  });
+
+  it('works when the persisted filter is a simple filter', () => {
+    const filter1 = Filter.from({
+      c_aField: { $eq: 5 }
+    });
+    expect(findSimpleFiltersWithFieldId('c_aField', filter1)).toEqual([ filter1 ]);
+  });
+});
+
+describe('getPersistedRangeFilterContents', () => {
+  it('will find the persisted min and max range for a fieldId', () => {
+    const persistedFilter = Filter.from({
+      c_aField: {
+        $ge: 5,
+        $lt: 10
+      }
+    });
+    expect(getPersistedRangeFilterContents(persistedFilter, 'c_aField')).toMatchObject({
+      $ge: 5,
+      $lt: 10
+    });
+  });
+
+  it('ignores non range filters', () => {
+    const persistedFilter = Filter.from({
+      c_aField: {
+        $gab: 5,
+        $lab: 10
+      }
+    });
+    expect(getPersistedRangeFilterContents(persistedFilter, 'c_aField')).toEqual({});
+  });
+
+  it('will return empty object if persisted filter is empty', () => {
+    const persistedFilter = Filter.from({});
+    expect(getPersistedRangeFilterContents(persistedFilter, 'c_aField')).toEqual({});
   });
 });

--- a/tests/ui/tools/filterutils.js
+++ b/tests/ui/tools/filterutils.js
@@ -1,5 +1,9 @@
 import Filter from '../../../src/core/models/filter';
-import { filterIsPersisted, findSimpleFiltersWithFieldId, getPersistedRangeFilterContents } from '../../../src/ui/tools/filterutils';
+import {
+  filterIsPersisted,
+  findSimpleFiltersWithFieldId,
+  getPersistedRangeFilterContents
+} from '../../../src/ui/tools/filterutils';
 
 describe('filterIsPersisted', () => {
   it('can detect when a filter is equal to the persisted filter', () => {
@@ -115,7 +119,7 @@ describe('findSimpleFiltersWithFieldId', () => {
         filter4
       ]
     });
-    expect(findSimpleFiltersWithFieldId(fieldId, persistedFilter))
+    expect(findSimpleFiltersWithFieldId(persistedFilter, fieldId))
       .toContainEqual(filter2, filter3, filter4);
   });
 
@@ -129,14 +133,14 @@ describe('findSimpleFiltersWithFieldId', () => {
     const persistedFilter = Filter.from({
       $or: [filter1, filter2]
     });
-    expect(findSimpleFiltersWithFieldId('bob_id', persistedFilter)).toEqual([]);
+    expect(findSimpleFiltersWithFieldId(persistedFilter, 'bob_id')).toEqual([]);
   });
 
   it('works when the persisted filter is a simple filter', () => {
     const filter1 = Filter.from({
       c_aField: { $eq: 5 }
     });
-    expect(findSimpleFiltersWithFieldId('c_aField', filter1)).toEqual([ filter1 ]);
+    expect(findSimpleFiltersWithFieldId(filter1, 'c_aField')).toEqual([ filter1 ]);
   });
 });
 


### PR DESCRIPTION
This commit updates the RangeFilter component to apply filters on page load,
using the new `filters` url param. It will try to look for any relevant
range filters that have been persisted, and if any are found, pick the first
one, apply it, and set the component state using that information.

J=SLAP-1088
TEST=manual,auto

test that range filters will work with backnavigation and page refresh
the filter will be applied to the search, and a removable filter tag will
appear if there is an AppliedFilterss component on the page