### PR TITLE
DateRangeFilters on load

### DIFF
--- a/src/ui/components/filters/daterangefiltercomponent.js
+++ b/src/ui/components/filters/daterangefiltercomponent.js
@@ -79,6 +79,10 @@ export default class DateRangeFilterComponent extends Component {
     });
   }
 
+  /**
+   * Reseeds the component state from the PERSISTED_FILTER in storage.
+   * If there is an active filter, store it in core.
+   */
   seedFromPersistedFilter () {
     if (this.core.storage.has(StorageKeys.PERSISTED_FILTER)) {
       const persistedFilter = this.core.storage.get(StorageKeys.PERSISTED_FILTER);

--- a/src/ui/components/filters/daterangefiltercomponent.js
+++ b/src/ui/components/filters/daterangefiltercomponent.js
@@ -1,12 +1,15 @@
 /** @module DateFilterComponent */
 
-import Component from '../component';
-import Filter from '../../../core/models/filter';
 import DOM from '../../dom/dom';
-import FilterNodeFactory from '../../../core/filters/filternodefactory';
-import FilterMetadata from '../../../core/filters/filtermetadata';
+import Component from '../component';
 import ComponentTypes from '../../components/componenttypes';
 import TranslationFlagger from '../../i18n/translationflagger';
+import Filter from '../../../core/models/filter';
+import FilterNodeFactory from '../../../core/filters/filternodefactory';
+import FilterMetadata from '../../../core/filters/filtermetadata';
+import Matcher from '../../../core/filters/matcher';
+import StorageKeys from '../../../core/storage/storagekeys';
+import { getPersistedRangeFilterContents } from '../../tools/filterutils';
 
 /**
  * A filter for a range of dates
@@ -64,19 +67,48 @@ export default class DateRangeFilterComponent extends Component {
      */
     this._isExclusive = config.isExclusive;
 
-    const today = new Date();
-    const todayString = `${today.getFullYear()}-${`${today.getMonth() + 1}`.padStart(2, '0')}-${`${today.getDate()}`.padStart(2, '0')}`;
-    const minDate = this.core.storage.get(`${this.name}.min`);
-    const maxDate = this.core.storage.get(`${this.name}.max`);
+    this.seedFromPersistedFilter();
 
-    /**
-     * The current date range
-     * @private
-     */
-    this._date = {
-      min: [minDate, config.initialMin, todayString].find(v => v !== undefined),
-      max: [maxDate, config.initialMax, todayString].find(v => v !== undefined)
-    };
+    this.core.storage.registerListener({
+      storageKey: StorageKeys.HISTORY_POP_STATE,
+      eventType: 'update',
+      callback: () => {
+        this.seedFromPersistedFilter();
+        this.setState();
+      }
+    });
+  }
+
+  seedFromPersistedFilter () {
+    if (this.core.storage.has(StorageKeys.PERSISTED_FILTER)) {
+      const persistedFilter = this.core.storage.get(StorageKeys.PERSISTED_FILTER);
+      const persistedFilterContents = getPersistedRangeFilterContents(persistedFilter, this._field);
+      let minVal, maxVal;
+      if (this._isExclusive) {
+        minVal = persistedFilterContents[Matcher.GreaterThan];
+        maxVal = persistedFilterContents[Matcher.LessThan];
+      } else {
+        minVal = persistedFilterContents[Matcher.GreaterThanOrEqualTo];
+        maxVal = persistedFilterContents[Matcher.LessThanOrEqualTo];
+      }
+      this._date = {
+        min: minVal,
+        max: maxVal
+      };
+    } else {
+      const today = new Date();
+      const todayString = `${today.getFullYear()}-${`${today.getMonth() + 1}`.padStart(2, '0')}-${`${today.getDate()}`.padStart(2, '0')}`;
+
+      this._date = {
+        min: [this._config.initialMin, todayString].find(v => v !== undefined),
+        max: [this._config.initialMax, todayString].find(v => v !== undefined)
+      };
+    }
+
+    if (this._date.min != null || this._date.max != null) {
+      const filterNode = this.getFilterNode();
+      this.core.setStaticFilterNodes(this.name, filterNode);
+    }
   }
 
   static defaultTemplateName () {


### PR DESCRIPTION
This commit updates the RangeFilter component to apply filters on page load,
using the new `filters` url param. It will try to look for any relevant
range filters that have been persisted, and if any are found, pick the first
one, apply it, and set the component state using that information.
The main difference between this and RangeFilters on load is that
DateRangeFilters allow you to specify whether to use an inclusive or exclusive range.

J=SLAP-1088
TEST=manual,auto

test that date range filters will work with backnavigation and page refresh
the filter will be applied to the search, and a removable filter tag will
appear if there is an AppliedFilterss component on the page

tested with isExclusive true and false