### PR TITLE
Fix acceptance test for updated api response

### DIFF
--- a/tests/acceptance/acceptancesuites/filterboxsuite.js
+++ b/tests/acceptance/acceptancesuites/filterboxsuite.js
@@ -131,10 +131,6 @@ test(`multioption filterbox works with back/forward navigation and page refresh`
 });
 
 test(`locationRadius of 0 is persisted`, async t => {
-  const searchComponent = FacetsPage.getSearchComponent();
-  await searchComponent.enterQuery('all');
-  await searchComponent.submitQuery();
-
   const filterBox = FacetsPage.getStaticFilterBox();
   const radiusFilter = await filterBox.getFilterOptions('DISTANCE');
   await radiusFilter.toggleOption('0 miles');


### PR DESCRIPTION
Fix an acceptance test that broke because the API response changed

Searching 'all' in that vertical does not return results any more, so we can remove it from the test. Instead, we can rely on the empty search for the test.

J=none
TEST=auto

Run the updated acceptance test.