### PR TITLE
Fix failing acceptance tests using "all" search

### DIFF
--- a/tests/acceptance/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuite.js
@@ -153,7 +153,7 @@ test('Facets, pagination, and filters do not persist accross experience links', 
 
   // When you navigate with pagination, nav links should not have the
   // Facets/filter/pagination parameters
-  await searchComponent.enterQuery('all');
+  await searchComponent.enterQuery(' ');
   await searchComponent.submitQuery();
 
   await t.click(await Selector('.js-yxt-navItem').nth(2)); // Go to vertical page


### PR DESCRIPTION
The inter experience links acceptance test was relying on
searching for "all" returning all results. For some reason
this no longer occurs, probably some kind of api change.

TEST=auto