### PR TITLE
Update filterParamsForExperienceLink() with new params

### DIFF
--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -122,13 +122,14 @@ export function filterParamsForExperienceLink (
     ComponentTypes.GEOLOCATION_FILTER,
     ComponentTypes.FILTER_SEARCH
   ];
-  let paramsToFilter = componentTypesToExclude.flatMap(type => {
-    let params = getComponentNamesForComponentTypes([type]);
-    if (type === ComponentTypes.GEOLOCATION_FILTER || type === ComponentTypes.FILTER_SEARCH) {
-      params = params.map(param => `${StorageKeys.QUERY}.${param}`);
-    }
+  const paramsToFilter = componentTypesToExclude.reduce((params, type) => {
+    getComponentNamesForComponentTypes([type])
+      .forEach(componentName => {
+        params.push(`${StorageKeys.QUERY}.${componentName}`);
+        params.push(`${StorageKeys.FILTER}.${componentName}`);
+      });
     return params;
-  });
+  }, []);
 
   const newParams = removeParamsWithPrefixes(params, paramsToFilter);
   const paramsToDelete = [

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -119,9 +119,6 @@ export function filterParamsForExperienceLink (
   getComponentNamesForComponentTypes
 ) {
   const componentTypesToExclude = [
-    ComponentTypes.RANGE_FILTER,
-    ComponentTypes.DATE_RANGE_FILTER,
-    ComponentTypes.SORT_OPTIONS,
     ComponentTypes.GEOLOCATION_FILTER,
     ComponentTypes.FILTER_SEARCH
   ];
@@ -132,11 +129,15 @@ export function filterParamsForExperienceLink (
     }
     return params;
   });
-  paramsToFilter = paramsToFilter.concat([StorageKeys.FILTER]);
 
   const newParams = removeParamsWithPrefixes(params, paramsToFilter);
-  newParams.delete(StorageKeys.SEARCH_OFFSET);
-  newParams.delete(StorageKeys.PERSISTED_FILTER);
-  newParams.delete(StorageKeys.PERSISTED_LOCATION_RADIUS);
+  const paramsToDelete = [
+    StorageKeys.SEARCH_OFFSET,
+    StorageKeys.PERSISTED_FILTER,
+    StorageKeys.PERSISTED_LOCATION_RADIUS,
+    StorageKeys.PERSISTED_FACETS,
+    StorageKeys.SORT_BYS
+  ];
+  paramsToDelete.forEach(storageKey => newParams.delete(storageKey));
   return newParams;
 }

--- a/tests/acceptance/acceptancesuites/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuites/acceptancesuite.js
@@ -15,6 +15,7 @@ import {
   registerIE11NoCacheHook
 } from '../utils';
 import { getMostRecentQueryParamsFromLogger } from '../requestUtils';
+import StorageKeys from '../../../src/core/storage/storagekeys';
 
 /**
  * This file contains acceptance tests for a universal search page.
@@ -198,11 +199,13 @@ fixture`Experience links work as expected`
   .after(shutdownServer)
   .page`${FACETS_PAGE}`;
 
-test('Pagination, filters, and locationRadius do not persist accross experience links', async t => {
+test('experience links are clean', async t => {
   const verifyCleanLink = async () => {
-    await t.expect(universalUrl).notContains('locationRadius');
-    await t.expect(universalUrl).notContains('filters');
-    await t.expect(universalUrl).notContains('search-offset');
+    await t.expect(universalUrl).notContains(StorageKeys.PERSISTED_FACETS + '=');
+    await t.expect(universalUrl).notContains(StorageKeys.SEARCH_OFFSET + '=');
+    await t.expect(universalUrl).notContains(StorageKeys.PERSISTED_LOCATION_RADIUS + '=');
+    await t.expect(universalUrl).notContains(StorageKeys.PERSISTED_FILTER + '=');
+    await t.expect(universalUrl).notContains(StorageKeys.SORT_BYS + '=');
   };
 
   // When you land, nav links should be clean


### PR DESCRIPTION
This commit updates filterParamsForExperienceLink() with the
new applied filters from URLs params. A few were missed in the later
stages of the feature. Also removes the older params, which aren't
used anymore.
Also adds a missing case for FilterSearch and the GeolocationFilter, since those components
store both a `query.<componentName>` and a `filter.<componentName>`,
but we were only accounting for `query.<componentName>`

J=SLAP-1209
TEST=manual, auto

checked that navigation tabs don't have the new persisted params
(location radius, filters, facets, sort bys)