### PR TITLE
Correct logic for determining if a facet is a Boolean facet or not.

### DIFF
--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -280,7 +280,7 @@ export default class FacetsComponent extends Component {
    */
   _applyDefaultFormatting (facet) {
     const isBooleanFacet = facet => {
-      const firstOption = (facet.options && facet.options[1]) || {};
+      const firstOption = (facet.options && facet.options[0]) || {};
       return firstOption['value'] === true || firstOption['value'] === false;
     };
 


### PR DESCRIPTION
The logic for determining whether or not a facet was a Boolean facet was a bit
off. It looked for the second facet option, instead of the first, and checked
if it's value was a boolean. If a facet had only one boolean option, it would
be incorrectly labeled as a non-Boolean facet. This led to Boolean translations
not appearing intermittently.

J=SLAP-1220
TEST=manual

Used the local test site Bowen reported the issues on. Verified that the
Boolean translations appeared for all languages consistently.