### PR TITLE
fix vertical results rendering during SEARCH_LOADING state

### DIFF
--- a/src/core/utils/resultsutils.js
+++ b/src/core/utils/resultsutils.js
@@ -14,7 +14,7 @@ export function getContainerClass (searchState) {
     case SearchStates.SEARCH_COMPLETE:
       return 'yxt-Results--searchComplete';
     default:
-      console.trace('encountered an unknown search state');
+      console.trace(`encountered an unknown search state: ${searchState}`);
       return '';
   }
 }

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -52,14 +52,22 @@ export default class UniversalResultsComponent extends Component {
     return true;
   }
 
+  /**
+   * Updates the search state css class on this component's container.
+   */
+  updateContainerClass (searchState) {
+    Object.values(SearchStates).forEach(searchState => {
+      this.removeContainerClass(getContainerClass(searchState));
+    });
+
+    this.addContainerClass(getContainerClass(searchState));
+  }
+
   setState (data, val) {
     const sections = data.sections || [];
     const query = this.core.storage.get(StorageKeys.QUERY);
     const searchState = data.searchState || SearchStates.PRE_SEARCH;
-    Object.entries(SearchStates).forEach(([k, searchState]) => {
-      this.removeContainerClass(getContainerClass(searchState));
-    });
-    this.addContainerClass(getContainerClass(searchState));
+    this.updateContainerClass(searchState);
     return super.setState(Object.assign(data, {
       isPreSearch: searchState === SearchStates.PRE_SEARCH,
       isSearchLoading: searchState === SearchStates.SEARCH_LOADING,

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -216,8 +216,8 @@ export default class VerticalResultsComponent extends Component {
       eventType: 'update',
       storageKey: StorageKeys.VERTICAL_RESULTS,
       callback: results => {
-        if (results.searchState === SearchStates.SEARCH_COMPLETE ||
-          results.searchState === SearchStates.SEARCH_LOADING) {
+        this.updateContainerClass(results.searchState);
+        if (results.searchState === SearchStates.SEARCH_COMPLETE) {
           this.setState(results);
         }
       }
@@ -254,6 +254,10 @@ export default class VerticalResultsComponent extends Component {
       hiddenFields: this._config.appliedFilters.hiddenFields,
       resultsCountTemplate: this._config.resultsCountTemplate
     };
+  }
+
+  onCreate () {
+    this.updateContainerClass(SearchStates.PRE_SEARCH);
   }
 
   mount () {
@@ -333,6 +337,17 @@ export default class VerticalResultsComponent extends Component {
     return replaceUrlParams(baseUrl, filteredParams);
   }
 
+  /**
+   * Updates the search state css class on this component's container.
+   */
+  updateContainerClass (searchState) {
+    Object.values(SearchStates).forEach(searchState => {
+      this.removeContainerClass(getContainerClass(searchState));
+    });
+
+    this.addContainerClass(getContainerClass(searchState));
+  }
+
   setState (data = {}, val) {
     /**
      * @type {Array<Result>}
@@ -346,11 +361,6 @@ export default class VerticalResultsComponent extends Component {
       this._displayAllResults ||
       data.resultsContext === ResultsContext.NORMAL;
     this.query = this.core.storage.get(StorageKeys.QUERY);
-    Object.entries(SearchStates).forEach(([k, searchState]) => {
-      this.removeContainerClass(getContainerClass(searchState));
-    });
-
-    this.addContainerClass(getContainerClass(searchState));
     return super.setState(Object.assign({ results: [] }, data, {
       searchState: searchState,
       isPreSearch: searchState === SearchStates.PRE_SEARCH,

--- a/src/ui/dom/dom.js
+++ b/src/ui/dom/dom.js
@@ -147,15 +147,14 @@ export default class DOM {
   /**
    * Removes classes from a specified element.
    * @param {HTMLElement} node The html element to be acted upon
-   * @param {string} className A comma separated list of classes to be removed
+   * @param {string} className A css class to be removed
    */
   static removeClass (node, className) {
     if (!node) {
       return;
     }
 
-    const classes = className.split(',');
-    classes.forEach(className => node.classList.remove(className));
+    node.classList.remove(className);
   }
 
   static empty (parent) {

--- a/tests/ui/components/results/verticalresultscomponent.js
+++ b/tests/ui/components/results/verticalresultscomponent.js
@@ -187,4 +187,24 @@ describe('vertical results component', () => {
       expect(component.getVerticalURL()).toEqual('vertical-url?query=my-query&otherParam=123&tabOrder=&referrerPageUrl=');
     });
   });
+
+  it('only remounts the component during the SEARCH_LOADING state of vertical results', () => {
+    const component = COMPONENT_MANAGER.create(VerticalResultsComponent.type, {
+      ...defaultConfig,
+      template: '{{{searchState}}}'
+    });
+    const wrapper = mount(component);
+    expect(wrapper.text()).toEqual('pre-search');
+    const { storage } = component.core;
+
+    storage.set(StorageKeys.VERTICAL_RESULTS, VerticalResults.searchLoading());
+    wrapper.update();
+    expect(wrapper.text()).toEqual('pre-search');
+
+    storage.set(StorageKeys.VERTICAL_RESULTS, {
+      searchState: SearchStates.SEARCH_COMPLETE
+    });
+    wrapper.update();
+    expect(wrapper.text()).toEqual('search-complete');
+  });
 });


### PR DESCRIPTION
This commit fixes a regression where we were re-mounting the
VerticalResults component during the SEARCH_LOADING state of
vertical results data.

It also removes unneeded functionality from the DOM.removeClass
method which was recently added (as in, does not exist in an officially released
SDK version).

J=SLAP-1217
TEST=manual,auto

check that on universal and vertical, UniversalResults and VerticalResults
still display the search state css classes on their component containers
correctly