### PR TITLE
trigger SEARCH_LOADING state before geolocation api is called

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -20,6 +20,7 @@ import AutoCompleteResponseTransformer from './search/autocompleteresponsetransf
 import { PRODUCTION, ENDPOINTS } from './constants';
 import { getCachedLiveApiUrl, getLiveApiUrl, getKnowledgeApiUrl } from './utils/urlutils';
 import { SearchParams } from '../ui';
+import SearchStates from './storage/searchstates';
 
 /** @typedef {import('./storage/storage').default} Storage */
 
@@ -176,7 +177,10 @@ export default class Core {
   verticalSearch (verticalKey, options = {}, query = {}) {
     window.performance.mark('yext.answers.verticalQueryStart');
     if (!query.append) {
-      this.storage.set(StorageKeys.VERTICAL_RESULTS, VerticalResults.searchLoading());
+      const verticalResults = this.storage.get(StorageKeys.VERTICAL_RESULTS);
+      if (!verticalResults || verticalResults.searchState !== SearchStates.SEARCH_LOADING) {
+        this.storage.set(StorageKeys.VERTICAL_RESULTS, VerticalResults.searchLoading());
+      }
       this.storage.set(StorageKeys.SPELL_CHECK, {});
       this.storage.set(StorageKeys.LOCATION_BIAS, {});
     }
@@ -328,7 +332,10 @@ export default class Core {
     }
 
     this.storage.set(StorageKeys.DIRECT_ANSWER, {});
-    this.storage.set(StorageKeys.UNIVERSAL_RESULTS, UniversalResults.searchLoading());
+    const universalResults = this.storage.get(StorageKeys.UNIVERSAL_RESULTS);
+    if (!universalResults || universalResults.searchState !== SearchStates.SEARCH_LOADING) {
+      this.storage.set(StorageKeys.UNIVERSAL_RESULTS, UniversalResults.searchLoading());
+    }
     this.storage.set(StorageKeys.QUESTION_SUBMISSION, {});
     this.storage.set(StorageKeys.SPELL_CHECK, {});
     this.storage.set(StorageKeys.LOCATION_BIAS, {});

--- a/src/core/statelisteners/queryupdatelistener.js
+++ b/src/core/statelisteners/queryupdatelistener.js
@@ -1,4 +1,6 @@
 import QueryTriggers from '../models/querytriggers';
+import UniversalResults from '../models/universalresults';
+import VerticalResults from '../models/verticalresults';
 import SearchOptionsFactory from '../search/searchoptionsfactory';
 import StorageKeys from '../storage/storagekeys';
 
@@ -64,10 +66,17 @@ export default class QueryUpdateListener {
         this.core.storage.get(StorageKeys.QUERY_TRIGGER) !== QueryTriggers.FILTER_COMPONENT)) {
       return;
     }
+    this._setSearchLoadingState();
 
     this._throttled = true;
     setTimeout(() => { this._throttled = false; }, this._searchCooldown);
     return this._search(query);
+  }
+
+  _setSearchLoadingState () {
+    this.config.verticalKey
+      ? this.core.storage.set(StorageKeys.VERTICAL_RESULTS, VerticalResults.searchLoading())
+      : this.core.storage.set(StorageKeys.UNIVERSAL_RESULTS, UniversalResults.searchLoading());
   }
 
   _search (query) {

--- a/src/core/storage/searchstates.js
+++ b/src/core/storage/searchstates.js
@@ -7,10 +7,11 @@
 /**
  * SearchStates is an ENUM for the various stages of searching,
  * used to show different templates
- * @enum {SearchState}
+ * @enum {string}
  */
-export default {
+const SearchStates = {
   PRE_SEARCH: 'pre-search',
   SEARCH_LOADING: 'search-loading',
   SEARCH_COMPLETE: 'search-complete'
 };
+export default SearchStates;

--- a/tests/core/statelisteners/queryupdatelistener.js
+++ b/tests/core/statelisteners/queryupdatelistener.js
@@ -1,6 +1,7 @@
 import { Storage } from '../../../src/core';
 import QueryTriggers from '../../../src/core/models/querytriggers';
 import QueryUpdateListener from '../../../src/core/statelisteners/queryupdatelistener';
+import SearchStates from '../../../src/core/storage/searchstates';
 import StorageKeys from '../../../src/core/storage/storagekeys';
 
 describe('registerMiddleware', () => {
@@ -67,6 +68,31 @@ describe('_debouncedSearch', () => {
     };
     expect(queryUpdateListener.core.verticalSearch)
       .toHaveBeenCalledWith('aVerticalKey', expectedSearchOptions, { input: 'query1' });
+  });
+});
+
+describe('sets the search loading state properly', () => {
+  it('no search loading state is set on init', () => {
+    const queryUpdateListener = initQueryUpdateListener();
+    const storage = queryUpdateListener.core.storage;
+    expect(storage.get(StorageKeys.VERTICAL_RESULTS)).toBeFalsy();
+    expect(storage.get(StorageKeys.UNIVERSAL_RESULTS)).toBeFalsy();
+  });
+  it('for universal results', () => {
+    const queryUpdateListener = initQueryUpdateListener();
+    const storage = queryUpdateListener.core.storage;
+    storage.set(StorageKeys.QUERY, 'test query');
+    expect(storage.get(StorageKeys.UNIVERSAL_RESULTS).searchState).toEqual(SearchStates.SEARCH_LOADING);
+    expect(storage.get(StorageKeys.VERTICAL_RESULTS)).toBeFalsy();
+  });
+  it('for vertical results', () => {
+    const queryUpdateListener = initQueryUpdateListener({
+      verticalKey: 'aVerticalKey'
+    });
+    const storage = queryUpdateListener.core.storage;
+    storage.set(StorageKeys.QUERY, 'test query');
+    expect(storage.get(StorageKeys.VERTICAL_RESULTS).searchState).toEqual(SearchStates.SEARCH_LOADING);
+    expect(storage.get(StorageKeys.UNIVERSAL_RESULTS)).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
This commit makes it so the SEARCH_LOADING state is triggered
as soon as a search as made, instead of right before the api call
itself is made (which would be after any processing between clicking search
and the api call). Specifically, for "near me" queries, the SEARCH_LOADING
state is now triggered before the geolocation api (navigator.geolocation) is
called.

J=SLAP-1231
TEST=manual, auto

search for "virginia near me" on vertical and universal
see that the yxt-Results--searchLoading css class is added
to the vertical/universal results container BEFORE the
browser's "can I use your location" popup