### PR TITLE
remove flashing from location bias component

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -182,7 +182,7 @@ export default class Core {
         this.storage.set(StorageKeys.VERTICAL_RESULTS, VerticalResults.searchLoading());
       }
       this.storage.set(StorageKeys.SPELL_CHECK, {});
-      this.storage.set(StorageKeys.LOCATION_BIAS, {});
+      this.storage.set(StorageKeys.LOCATION_BIAS, LocationBias.searchLoading());
     }
 
     const { resetPagination, useFacets, sendQueryId, setQueryParams } = options;

--- a/src/core/models/locationbias.js
+++ b/src/core/models/locationbias.js
@@ -1,5 +1,7 @@
 /** @module LocationBias */
 
+import SearchStates from '../storage/searchstates';
+
 /**
  * LocationBias is the core state model
  * to power the LocationBias component
@@ -29,6 +31,19 @@ export default class LocationBias {
      * @type {string}
      */
     this.locationDisplayName = data.locationDisplayName || null;
+
+    /**
+     * Whether the search is loading or completed
+     */
+    this.searchState = data.searchState;
+  }
+
+  /**
+   * Construct a LocationBias object representing loading results
+   * @return {LocationBias}
+   */
+  static searchLoading () {
+    return new LocationBias({ searchState: SearchStates.SEARCH_LOADING });
   }
 
   /*
@@ -48,7 +63,8 @@ export default class LocationBias {
       accuracy: locationBias.method,
       latitude: locationBias.latitude,
       longitude: locationBias.longitude,
-      locationDisplayName: locationBias.displayName
+      locationDisplayName: locationBias.displayName,
+      searchState: SearchStates.SEARCH_COMPLETE
     });
   }
 }

--- a/src/ui/components/search/locationbiascomponent.js
+++ b/src/ui/components/search/locationbiascomponent.js
@@ -2,6 +2,8 @@ import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
 import DOM from '../../dom/dom';
 import TranslationFlagger from '../../i18n/translationflagger';
+import isEqual from 'lodash.isequal';
+import SearchStates from '../../../core/storage/searchstates';
 
 const DEFAULT_CONFIG = {
   ipAccuracyHelpText: TranslationFlagger.flag({
@@ -32,7 +34,16 @@ export default class LocationBiasComponent extends Component {
      * Recieve updates from storage based on this index
      * @type {StorageKey}
      */
-    this.moduleId = StorageKeys.LOCATION_BIAS;
+    this.core.storage.registerListener({
+      storageKey: StorageKeys.LOCATION_BIAS,
+      eventType: 'update',
+      callback: data => {
+        const searchIsLoading = data.searchState === SearchStates.SEARCH_LOADING;
+        if (!searchIsLoading && !isEqual(data, this.getState('locationBias'))) {
+          this.setState(data);
+        }
+      }
+    });
 
     /**
      * The optional vertical key for vertical search configuration
@@ -129,7 +140,8 @@ export default class LocationBiasComponent extends Component {
       isPreciseLocation: data.accuracy === 'DEVICE' && this._allowUpdate,
       isUnknownLocation: data.accuracy === 'UNKNOWN',
       shouldShow: data.accuracy !== undefined && data.accuracy !== null,
-      allowUpdate: this._allowUpdate
+      allowUpdate: this._allowUpdate,
+      locationBias: data
     }, val));
   }
 


### PR DESCRIPTION
This commit adds a searchState property to the
LOCATION_BIAS storage data, and updates the LocationBias
component to only setState
1. the search is not in a loading state and
2. when the data has changed from the previous setState

This improves the performance of the LocationBias component,
and removes unwanted flashing. This flashing was especially
prominent on the vertical-full-page-map in the
answers-hitchhiker-theme, and was making it difficult to
dynamically resize the map.

J=SLAP-1237
TEST=manual

test that, on both universal and vertical, the location bias
component no longer flashes
test that, when starting from a blank page with no visible
LocationBias, running a search, and then hitting the browser
back button, that LocationBias disappears