### PR TITLE
fix facets trying to remove an already removed filterbox

### DIFF
--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -322,6 +322,7 @@ export default class FacetsComponent extends Component {
 
     if (this._filterbox) {
       this._filterbox.remove();
+      this._filterbox = null;
     }
 
     let { filters, isNoResults, filterOptionsConfigs } = this._state.get();

--- a/tests/ui/components/filters/facetscomponent.js
+++ b/tests/ui/components/filters/facetscomponent.js
@@ -5,6 +5,7 @@ import StorageKeys from '../../../../src/core/storage/storagekeys';
 import DynamicFilters from '../../../../src/core/models/dynamicfilters';
 import Storage from '../../../../src/core/storage/storage';
 import FilterRegistry from '../../../../src/core/filters/filterregistry';
+import ResultsContext from '../../../../src/core/storage/resultscontext';
 
 describe('Facets Component', () => {
   DOM.setup(document, new DOMParser());
@@ -136,5 +137,20 @@ describe('Facets Component', () => {
     const firstFacetDisplayName = firstFacet.text().trim();
 
     expect(firstFacetDisplayName).toEqual(expectedFacetDisplayName);
+  });
+
+  it('does not try to remove the child filterbox when it was already removed', () => {
+    const remove = jest.fn();
+    COMPONENT_MANAGER.remove = remove;
+    const component = COMPONENT_MANAGER.create('Facets', defaultConfig);
+    const storage = component.core.storage;
+    const dynamicFilters = DynamicFilters.fromCore(coreFacets);
+    storage.set(StorageKeys.DYNAMIC_FILTERS, dynamicFilters);
+    mount(component);
+    expect(remove).toHaveBeenCalledTimes(4);
+    storage.set(StorageKeys.DYNAMIC_FILTERS, { resultsContext: ResultsContext.NO_RESULTS });
+    expect(remove).toHaveBeenCalledTimes(8);
+    storage.set(StorageKeys.DYNAMIC_FILTERS, { resultsContext: ResultsContext.NO_RESULTS });
+    expect(remove).toHaveBeenCalledTimes(8);
   });
 });


### PR DESCRIPTION
This commit fixes the facets component trying to call
remove() on an already removed child filterbox. Even after an
SDK component's remove() method is called, the object still
hangs around and can be interacted in most of the same ways as before.
This caused strange behavior where ComponentManager would try
to remove a component that was no longer registered in
ComponentManager._activeComponents.

This bug has been present since facets were added to the SDK
(v0.10.0) and will need to be back patched. This issue can be
reproduced on any page using the SDK by
1. going to a page with facets
2. running a search that returns no results
3. log ANSWERS.components._activeComponents
4. repeat the search a number of times
5. log ANSWERS.components._activeComponents again, a large
number of components will be missing
6. eventually all the components will be removed

ComponentManager's remove() works by looking for the index of the
component to be removed in _activeComponents using the component's
name. Then, it will remove that index from the _activeComponents
array. If the component's name is not found, then the index will
be set to -1, and the SDK will remove the component found at -1
(the last component in _activeComponents). This is incorrect behavior
and will be fixed in a separate PR. Component names are also not unique,
and we should use some kind of unique id system to remove components.
This will also be addressed in a separate PR.

J=SLAP-1238
TEST=manual,auto

test that running repeated searches on no results no longer removes extra components
test that a page with collapsible filters no longer bugs out when you
run many repeated no results searches