### PR TITLE
use component `uniqueId` for removal

### DIFF
--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -23,6 +23,7 @@ export default class Component {
 
     /**
      * UUID for the component.
+     * @type {number}
      */
     this.uuid = systemConfig.uuid;
 

--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -22,10 +22,10 @@ export default class Component {
     this.moduleId = null;
 
     /**
-     * UUID for the component.
+     * A unique id number for the component.
      * @type {number}
      */
-    this.uuid = systemConfig.uuid;
+    this.uniqueId = systemConfig.uniqueId;
 
     /**
      * Name of this component instance.

--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -22,7 +22,12 @@ export default class Component {
     this.moduleId = null;
 
     /**
-     * Unique name of this component instance
+     * UUID for the component.
+     */
+    this.uuid = systemConfig.uuid;
+
+    /**
+     * Name of this component instance
      * Used to distinguish between other components of the same type
      * @type {String}
      */

--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -28,8 +28,7 @@ export default class Component {
     this.uuid = systemConfig.uuid;
 
     /**
-     * Name of this component instance
-     * Used to distinguish between other components of the same type
+     * Name of this component instance.
      * @type {String}
      */
     this.name = config.name || this.constructor.type;

--- a/src/ui/components/componentmanager.js
+++ b/src/ui/components/componentmanager.js
@@ -197,6 +197,7 @@ export default class ComponentManager {
    */
   removeByName (name) {
     const component = Object.values(this._activeComponents).find(c => c.name === name);
+    component.remove();
     this.remove(component);
     DOM.empty(component._container);
   }

--- a/src/ui/components/componentmanager.js
+++ b/src/ui/components/componentmanager.js
@@ -122,7 +122,7 @@ export default class ComponentManager {
       renderer: this._renderer,
       analyticsReporter: this._analyticsReporter,
       componentManager: this,
-      uuid: this._componentIdCounter
+      uniqueId: this._componentIdCounter
     };
     this._componentIdCounter++;
 
@@ -185,7 +185,7 @@ export default class ComponentManager {
   remove (component) {
     this._core.storage.removeListener(this._componentToModuleIdListener.get(component));
 
-    const index = this._activeComponents.findIndex(c => c.uuid === component.uuid);
+    const index = this._activeComponents.findIndex(c => c.uniqueId === component.uniqueId);
     if (index !== -1) {
       this._activeComponents.splice(index, 1);
     }

--- a/src/ui/components/componentmanager.js
+++ b/src/ui/components/componentmanager.js
@@ -198,7 +198,6 @@ export default class ComponentManager {
   removeByName (name) {
     const component = Object.values(this._activeComponents).find(c => c.name === name);
     component.remove();
-    this.remove(component);
     DOM.empty(component._container);
   }
 

--- a/src/ui/components/componentmanager.js
+++ b/src/ui/components/componentmanager.js
@@ -196,7 +196,7 @@ export default class ComponentManager {
    * @param {string} name The name of the compnent to remove
    */
   removeByName (name) {
-    const component = Object.values(this._activeComponents).find(c => c.name === name);
+    const component = this._activeComponents.find(c => c.name === name);
     component.remove();
     DOM.empty(component._container);
   }

--- a/src/ui/components/componentmanager.js
+++ b/src/ui/components/componentmanager.js
@@ -22,6 +22,11 @@ export default class ComponentManager {
     this._activeComponents = [];
 
     /**
+     * A counter for the id the give to the next component that is created.
+     */
+    this._componentIdCounter = 0;
+
+    /**
      * A local reference to the core library dependency
      *
      * The Core contains both the storage AND services that are needed for performing operations
@@ -116,8 +121,10 @@ export default class ComponentManager {
       core: this._core,
       renderer: this._renderer,
       analyticsReporter: this._analyticsReporter,
-      componentManager: this
+      componentManager: this,
+      uuid: this._componentIdCounter
     };
+    this._componentIdCounter++;
 
     let componentClass = COMPONENT_REGISTRY[componentType];
     if (!componentClass) {
@@ -178,8 +185,10 @@ export default class ComponentManager {
   remove (component) {
     this._core.storage.removeListener(this._componentToModuleIdListener.get(component));
 
-    const index = this._activeComponents.findIndex(c => c.name === component.name);
-    this._activeComponents.splice(index, 1);
+    const index = this._activeComponents.findIndex(c => c.uuid === component.uuid);
+    if (index !== -1) {
+      this._activeComponents.splice(index, 1);
+    }
   }
 
   /**
@@ -187,8 +196,8 @@ export default class ComponentManager {
    * @param {string} name The name of the compnent to remove
    */
   removeByName (name) {
-    const component = this._activeComponents.find(c => c.name === name);
-    component.remove();
+    const component = Object.values(this._activeComponents).find(c => c.name === name);
+    this.remove(component);
     DOM.empty(component._container);
   }
 


### PR DESCRIPTION
ComponentManager's remove() works by looking for the index of the
component to be removed in _activeComponents using the component's
name. Then, it will remove that index from the _activeComponents
array. If the component's name is not found, then the index will
be set to -1, and the SDK will remove the component found at -1
(the last component in _activeComponents). This should not be happening.
If the component is not found, we should not remove an unrelated component.

Component names are also not unique, and we should use some kind of
unique id system to remove components. Otherwise, when remove() is called
on something like an IconComponent, it's possible that some OTHER IconComponent,
and not the intended one, is removed.

J=SLAP-1231
TEST=manual

test that running repeated searches on no results, which currently
results in the FacetsComponent trying to remove a component that
was already removed, does not remove other unrelated components