### PR TITLE
Upgrade the `@yext/rtf-converter` dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3841,11 +3841,11 @@
       "dev": true
     },
     "@yext/rtf-converter": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@yext/rtf-converter/-/rtf-converter-1.2.0.tgz",
-      "integrity": "sha512-uQAxTXN631sickvkSfxrdDGs2jZi1gvThqpce/IU0G2xRTcRlqOXKweDIgkckDaYdawv6FfdrkIGkczOt7SZiQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@yext/rtf-converter/-/rtf-converter-1.4.0.tgz",
+      "integrity": "sha512-Yd4lBm+ube058oNruJd50sHdK5V7GHW9yIdNQNDiXCshU8E+cpXNIZDogydMcQTnyNJrklbIK3S5M5NWiqULkg==",
       "requires": {
-        "markdown-it": "^10.0.0",
+        "markdown-it": "^12.0.0",
         "markdown-it-plugin-underline": "0.0.1"
       }
     },
@@ -4261,6 +4261,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -13947,6 +13948,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
       "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
       }
@@ -14379,21 +14381,34 @@
       "dev": true
     },
     "markdown-it": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.4.tgz",
+      "integrity": "sha512-34RwOXZT8kyuOJy25oJNJoulO8L0bTHYWXcdZBYZqFnjIy3NgjeoM3FmPXIOFQ26/lSHYMr8oc62B6adxXcb3Q==",
       "requires": {
-        "argparse": "^1.0.7",
-        "entities": "~2.0.0",
-        "linkify-it": "^2.0.0",
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
       },
       "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
         "entities": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+        },
+        "linkify-it": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.2.tgz",
+          "integrity": "sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==",
+          "requires": {
+            "uc.micro": "^1.0.1"
+          }
         }
       }
     },
@@ -18981,7 +18996,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@mapbox/mapbox-gl-language": "^0.10.1",
-    "@yext/rtf-converter": "^1.2.0",
+    "@yext/rtf-converter": "^1.4.0",
     "css-vars-ponyfill": "^2.3.1",
     "gulp-sourcemaps": "^2.6.5",
     "handlebars": "^4.7.2",


### PR DESCRIPTION
This PR updates the SDK to use v1.4 of the rtf-converter library. This new library version supports the
strike-through syntax of Yext Markdown.

J=SLAP-1236
TEST=manual

Passed strike-through syntax to `ANSWERS.formatRichText` and saw it properly converted to HTML.