### PR TITLE
add quarantine mode flag to testcafe tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       - setup-workspace
       - attach_workspace:
           at: ~/answers
-      - run: npx testcafe chrome:headless,firefox:headless tests/acceptance/acceptancesuites/*.js
+      - run: npx testcafe chrome:headless,firefox:headless tests/acceptance/acceptancesuites/*.js -q
   # run the browserstack testcafe acceptance tests
   browserstack_acceptance_test:
     docker:

--- a/.circleci/run_browserstack_acceptance.sh
+++ b/.circleci/run_browserstack_acceptance.sh
@@ -5,4 +5,4 @@ export BROWSERSTACK_BUILD_ID="${CIRCLE_BRANCH} - ${CIRCLE_BUILD_NUM}"
 COMMIT_MSG_TITLE=$(git log -n 1 --pretty=format:%s)
 export BROWSERSTACK_TEST_RUN_NAME=$COMMIT_MSG_TITLE
 
-npx testcafe "browserstack:ie@11.0,browserstack:safari" tests/acceptance/acceptancesuites/*.js
+npx testcafe "browserstack:ie@11.0,browserstack:safari" tests/acceptance/acceptancesuites/*.js -q


### PR DESCRIPTION
This commit adds the quarantine mode flag to our testcafe
tests. Quarantine mode will automatically rerun any tests
that failed until said tests have either passed or failed 3 times.
Tests have different results between test runs are marked as unstable.
However the build will still pass.

I think this could be a nice quality of life change, since our default
response to failing acceptance tests have been to first re run them a
few times. Quarantine mode will do this for us, with the main benefit
of only rerunning the tests that failed, instead of the entire suite.
The main downside is that tests may become unstable without us realizing it.

J=none
TEST=auto