### PR TITLE
only send 'suggest' and 'initialize' query triggers to api

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -647,7 +647,7 @@ export default class Core {
    * @returns {QueryTriggers} query trigger if accepted by the search API, null o/w
    */
   getQueryTriggerForSearchApi (queryTrigger) {
-    if (queryTrigger === QueryTriggers.QUERY_PARAMETER) {
+    if (![QueryTriggers.INITIALIZE, QueryTriggers.SUGGEST].includes(queryTrigger)) {
       return null;
     }
     return queryTrigger;


### PR DESCRIPTION
This commit removes the sending of new query triggers added
in this release cycle (v1.8). While it could be nice to send
these query triggers to the api in the future, this feature
has not been fully tested/fleshed out, especially with regard
to the vertical-full-page-map in the answers-hitchhiker-theme.
Faulty analytics are arguably worse than no analytics at all.

J=none
TEST=manual

see that the 'search-bar' query trigger is no longer sent
on search bar searches, and the 'filter-component' trigger
is no longer sent when a filter is used to trigger a search.