### PR TITLE
refactor answers-umd storage init into _initStorage()

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -141,7 +141,7 @@ class Answers {
     return this.instance;
   }
 
-  _initStorage(parsedConfig) {
+  _initStorage (parsedConfig) {
     const storage = new Storage({
       updateListener: (data, url) => {
         if (parsedConfig.onStateChange) {

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -141,22 +141,7 @@ class Answers {
     return this.instance;
   }
 
-  /**
-   * Initializes the SDK with the provided configuration. Note that before onReady
-   * is ever called, a check to the relevant Answers Status page is made.
-   *
-   * @param {Object} config The Answers configuration.
-   * @param {Object} statusPage An override for the baseUrl and endpoint of the
-   *                            experience's Answers Status page.
-   */
-  init (config, statusPage) {
-    window.performance.mark('yext.answers.initStart');
-    const parsedConfig = this.parseConfig(config);
-    this.validateConfig(parsedConfig);
-
-    parsedConfig.search = new SearchConfig(parsedConfig.search);
-    parsedConfig.verticalPages = new VerticalPagesConfig(parsedConfig.verticalPages);
-
+  _initStorage(parsedConfig) {
     const storage = new Storage({
       updateListener: (data, url) => {
         if (parsedConfig.onStateChange) {
@@ -238,7 +223,26 @@ class Answers {
         urlWithoutQueryParamsAndHash(document.referrer)
       );
     }
+    return storage;
+  }
 
+  /**
+   * Initializes the SDK with the provided configuration. Note that before onReady
+   * is ever called, a check to the relevant Answers Status page is made.
+   *
+   * @param {Object} config The Answers configuration.
+   * @param {Object} statusPage An override for the baseUrl and endpoint of the
+   *                            experience's Answers Status page.
+   */
+  init (config, statusPage) {
+    window.performance.mark('yext.answers.initStart');
+    const parsedConfig = this.parseConfig(config);
+    this.validateConfig(parsedConfig);
+
+    parsedConfig.search = new SearchConfig(parsedConfig.search);
+    parsedConfig.verticalPages = new VerticalPagesConfig(parsedConfig.verticalPages);
+
+    const storage = this._initStorage(parsedConfig);
     this._masterSwitchApi = statusPage
       ? new MasterSwitchApi({ apiKey: parsedConfig.apiKey, ...statusPage }, storage)
       : MasterSwitchApi.from(parsedConfig.apiKey, parsedConfig.experienceKey, storage);


### PR DESCRIPTION
This commit refactors storage init into a single helper method.

J=SLAP-1258
TEST=manual

test that the page loads still and can run searches