### PR TITLE
replace history for searches on load/back nav

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -343,7 +343,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The following NPM packages may be included in this product:
 
  - @yext/answers-search-ui@1.8.0
- - @yext/answers-storage@1.0.0-beta.0
+ - @yext/answers-storage@1.1.0
 
 These packages each contain the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5327,9 +5327,9 @@
       }
     },
     "@yext/answers-storage": {
-      "version": "1.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@yext/answers-storage/-/answers-storage-1.0.0-beta.0.tgz",
-      "integrity": "sha512-WdNPXN5nwvZEa97EgtagW3Ub7doFZeV0XokoyMLWKdwooWe51nwSXSSzto6u4gb3c4JK7ufAKWH/dwnHHEqc8Q=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yext/answers-storage/-/answers-storage-1.1.0.tgz",
+      "integrity": "sha512-qrRhuDQpqTB/qC5lACTvw9CfxFERt8+lizW4SieP0kb325GEFyElAXcdDfeId+4W1H2A5ClY5HaBElvqDwlZ/A=="
     },
     "@yext/rtf-converter": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@mapbox/mapbox-gl-language": "^0.10.1",
     "@yext/answers-core": "^1.1.0",
-    "@yext/answers-storage": "^1.0.0-beta.0",
+    "@yext/answers-storage": "^1.1.0",
     "@yext/rtf-converter": "^1.5.0",
     "cross-fetch": "^3.0.6",
     "css-vars-ponyfill": "^2.4.3",

--- a/src/core/storage/storage.js
+++ b/src/core/storage/storage.js
@@ -123,6 +123,18 @@ export default class Storage {
   }
 
   /**
+   * Adds all entries of the persistent storage to the URL,
+   * replacing the current history state.
+   */
+  replaceHistoryWithState () {
+    this.persistentStorage.replaceHistoryWithState();
+    this.persistedStateListeners.update(
+      this.persistentStorage.getAll(),
+      this.getCurrentStateUrlMerged()
+    );
+  }
+
+  /**
    * Adds all entries of the persistent storage to the URL.
    */
   pushStateToHistory () {

--- a/tests/acceptance/acceptancesuites/universalinitialsearch.js
+++ b/tests/acceptance/acceptancesuites/universalinitialsearch.js
@@ -17,7 +17,7 @@ test(`blank defaultInitialSearch will fire on universal if allowEmptySearch is t
   await t.expect(Selector('.yxt-Results').exists).ok();
 });
 
-test.only(`referrerPageUrl is added to the URL on default initial searches`, async t => {
+test(`referrerPageUrl is added to the URL on default initial searches`, async t => {
   await Selector('.yxt-Results').with({ visibilityCheck: true })();
   const currentSearchParams = await getCurrentUrlParams();
   const referrerPageUrl = currentSearchParams.has(StorageKeys.REFERRER_PAGE_URL);

--- a/tests/acceptance/acceptancesuites/verticalinitialsearch.js
+++ b/tests/acceptance/acceptancesuites/verticalinitialsearch.js
@@ -1,23 +1,18 @@
 import {
   setupServer,
   shutdownServer,
-  UNIVERSAL_INITIAL_SEARCH_PAGE
+  FILTERBOX_PAGE
 } from '../server';
 import { Selector } from 'testcafe';
 import { getCurrentUrlParams } from '../utils';
 import StorageKeys from '../../../src/core/storage/storagekeys';
 
-fixture`Universal page with default initial search`
+fixture`Vertical page with default initial search`
   .before(setupServer)
   .after(shutdownServer)
-  .page`${UNIVERSAL_INITIAL_SEARCH_PAGE}`;
+  .page`${FILTERBOX_PAGE}`;
 
-test(`blank defaultInitialSearch will fire on universal if allowEmptySearch is true`, async t => {
-  await Selector('.yxt-Results').with({ visibilityCheck: true })();
-  await t.expect(Selector('.yxt-Results').exists).ok();
-});
-
-test.only(`referrerPageUrl is added to the URL on default initial searches`, async t => {
+test(`referrerPageUrl is added to the URL on default initial searches`, async t => {
   await Selector('.yxt-Results').with({ visibilityCheck: true })();
   const currentSearchParams = await getCurrentUrlParams();
   const referrerPageUrl = currentSearchParams.has(StorageKeys.REFERRER_PAGE_URL);

--- a/tests/acceptance/utils.js
+++ b/tests/acceptance/utils.js
@@ -18,6 +18,11 @@ export async function browserForwardButton () {
   return t.wait(2500);
 }
 
+export async function getCurrentUrlParams () {
+  const urlParams = await ClientFunction(() => window.location.search)();
+  return new URLSearchParams(urlParams);
+}
+
 /**
  * Register the Ie11NoCacheHook, if the current browser is IE11.
  *


### PR DESCRIPTION
Searches run on page load/back navigation were not updating
the URL at all. Prior to the storage rework, we would do
history.replaceState calls for certain storage keys, most
notably REFERRER_PAGE_URL, which is behavior we need to replicate.

J=SLAP-1258
TEST=manual,auto

test that a default initial search will have a referrerPageUrl
put onto the URL.
test that a page with no defaultInitialSearch does not get
referrerPageUrl put onto the URL.