### PR TITLE
Remove unused code from `AnswersSearchBar` entry point.

### DIFF
--- a/src/answers-search-bar.js
+++ b/src/answers-search-bar.js
@@ -209,32 +209,6 @@ class AnswersSearchBar {
 
     this.renderer.init(parsedConfig.templateBundle, this._getInitLocale());
     this._onReady();
-    this._searchOnLoad();
-  }
-
-  /**
-   * This guarantees that execution of the SearchBar's search on page load occurs only
-   * AFTER all components have been added to the page. Trying to do this with a regular
-   * onCreate relies on the SearchBar having some sort of async behavior to move the execution
-   * of the search to the end of the call stack. For instance, relying on promptForLocation
-   * being set to true, which adds additional Promises that will delay the exeuction.
-   *
-   * We need to guarantee that the searchOnLoad happens after the onReady, because certain
-   * components will update values in storage in their onMount/onCreate, which are then expected
-   * to be applied to this search on page load. For example, filter components can apply
-   * filters on page load, which must be applied before this search is made to affect it.
-   *
-   * If no special search components exist, we still want to search on load if a query has been set,
-   * either from a defaultInitialSearch or from a query in the URL.
-   */
-  _searchOnLoad () {
-    const searchComponents = this.components._activeComponents
-      .filter(c => c.constructor.type === SearchComponent.type);
-    if (searchComponents.length) {
-      searchComponents.forEach(c => c.searchAfterAnswersOnReady && c.searchAfterAnswersOnReady());
-    } else if (this.core.storage.has(StorageKeys.QUERY)) {
-      this.core.triggerSearch(this.core.storage.get(StorageKeys.QUERY_TRIGGER));
-    }
   }
 
   domReady (cb) {

--- a/src/answers-search-bar.js
+++ b/src/answers-search-bar.js
@@ -11,18 +11,15 @@ import ErrorReporter from './core/errors/errorreporter';
 import { AnalyticsReporter } from './core';
 import Storage from './core/storage/storage';
 import { AnswersComponentError } from './core/errors/errors';
-import AnalyticsEvent from './core/analytics/analyticsevent';
 import StorageKeys from './core/storage/storagekeys';
 import QueryTriggers from './core/models/querytriggers';
 import SearchConfig from './core/models/searchconfig';
 import ComponentManager from './ui/components/componentmanager';
-import VerticalPagesConfig from './core/models/verticalpagesconfig';
 import { SANDBOX, PRODUCTION, LOCALE, QUERY_SOURCE } from './core/constants';
 import { isValidContext } from './core/utils/apicontext';
 import { urlWithoutQueryParamsAndHash } from './core/utils/urlutils';
 import Filter from './core/models/filter';
 import SearchComponent from './ui/components/search/searchcomponent';
-import QueryUpdateListener from './core/statelisteners/queryupdatelistener';
 import { SEARCH_BAR_COMPONENTS_REGISTRY } from './ui/components/search-bar-only-registry';
 
 /** @typedef {import('./core/services/errorreporterservice').default} ErrorReporterService */
@@ -122,52 +119,12 @@ class AnswersSearchBar {
     this.validateConfig(parsedConfig);
 
     parsedConfig.search = new SearchConfig(parsedConfig.search);
-    parsedConfig.verticalPages = new VerticalPagesConfig(parsedConfig.verticalPages);
 
     const storage = new Storage({
-      updateListener: (data, url) => {
-        if (parsedConfig.onStateChange) {
-          parsedConfig.onStateChange(Object.fromEntries(data), url);
-        }
-      },
-      resetListener: data => {
-        let query = data.get(StorageKeys.QUERY);
-        const hasQuery = query || query === '';
-        this.core.storage.delete(StorageKeys.PERSISTED_LOCATION_RADIUS);
-        this.core.storage.delete(StorageKeys.PERSISTED_FILTER);
-        this.core.storage.delete(StorageKeys.PERSISTED_FACETS);
-        this.core.storage.delete(StorageKeys.SORT_BYS);
-        this.core.filterRegistry.clearAllFilterNodes();
-
-        if (!hasQuery) {
-          this.core.clearResults();
-        } else {
-          this.core.storage.set(StorageKeys.QUERY_TRIGGER, QueryTriggers.QUERY_PARAMETER);
-        }
-
-        if (!data.get(StorageKeys.SEARCH_OFFSET)) {
-          this.core.storage.set(StorageKeys.SEARCH_OFFSET, 0);
-        }
-
-        data.forEach((value, key) => {
-          if (key === StorageKeys.QUERY) {
-            return;
-          }
-          const parsedValue = this._parsePersistentStorageValue(key, value);
-          this.core.storage.set(key, parsedValue);
-        });
-
-        this.core.storage.set(StorageKeys.HISTORY_POP_STATE, data);
-
-        if (hasQuery) {
-          this.core.storage.set(StorageKeys.QUERY, query);
-        }
-      },
       persistedValueParser: this._parsePersistentStorageValue
     });
     storage.init(window.location.search);
     storage.set(StorageKeys.SEARCH_CONFIG, parsedConfig.search);
-    storage.set(StorageKeys.VERTICAL_PAGES_CONFIG, parsedConfig.verticalPages);
     storage.set(StorageKeys.LOCALE, parsedConfig.locale);
     storage.set(StorageKeys.QUERY_SOURCE, parsedConfig.querySource);
 
@@ -217,15 +174,7 @@ class AnswersSearchBar {
         parsedConfig.analyticsOptions,
         parsedConfig.environment);
 
-      // listen to query id updates
-      storage.registerListener({
-        eventType: 'update',
-        storageKey: StorageKeys.QUERY_ID,
-        callback: id => this._analyticsReporterService.setQueryId(id)
-      });
-
       this.components.setAnalyticsReporter(this._analyticsReporterService);
-      initScrollListener(this._analyticsReporterService);
     }
 
     this.core = new Core({
@@ -260,18 +209,7 @@ class AnswersSearchBar {
 
     this.renderer.init(parsedConfig.templateBundle, this._getInitLocale());
     this._onReady();
-    if (!this.components.getActiveComponent(SearchComponent.type)) {
-      this._initQueryUpdateListener(parsedConfig.search);
-    }
     this._searchOnLoad();
-  }
-
-  _initQueryUpdateListener ({ verticalKey, defaultInitialSearch }) {
-    const queryUpdateListener = new QueryUpdateListener(this.core, {
-      defaultInitialSearch,
-      verticalKey
-    });
-    this.core.setQueryUpdateListener(queryUpdateListener);
   }
 
   /**
@@ -368,15 +306,6 @@ class AnswersSearchBar {
       throw new AnswersComponentError('Failed to add component', type, e);
     }
     return this;
-  }
-
-  /**
-   * Conducts a search in the Answers experience
-   *
-   * @param {string} query
-   */
-  search (query) {
-    this.core.storage.setWithPersist(StorageKeys.QUERY, query);
   }
 
   /**
@@ -496,30 +425,6 @@ function getServices (config, storage) {
       },
       storage)
   };
-}
-
-/**
- * Initialize the scroll event listener to send analytics events
- * when the user scrolls to the bottom. Debounces scroll events so
- * they are processed after the user stops scrolling
- */
-function initScrollListener (reporter) {
-  const DEBOUNCE_TIME = 100;
-  let timeout = null;
-
-  const sendEvent = () => {
-    if ((window.innerHeight + window.pageYOffset) >= document.body.scrollHeight) {
-      const event = new AnalyticsEvent('SCROLL_TO_BOTTOM_OF_PAGE');
-      if (reporter.getQueryId()) {
-        reporter.report(event);
-      }
-    }
-  };
-
-  document.addEventListener('scroll', () => {
-    clearTimeout(timeout);
-    timeout = setTimeout(sendEvent, DEBOUNCE_TIME);
-  });
 }
 
 const ANSWERS_SEARCH_BAR = new AnswersSearchBar();

--- a/src/answers-search-bar.js
+++ b/src/answers-search-bar.js
@@ -19,7 +19,6 @@ import { SANDBOX, PRODUCTION, LOCALE, QUERY_SOURCE } from './core/constants';
 import { isValidContext } from './core/utils/apicontext';
 import { urlWithoutQueryParamsAndHash } from './core/utils/urlutils';
 import Filter from './core/models/filter';
-import SearchComponent from './ui/components/search/searchcomponent';
 import { SEARCH_BAR_COMPONENTS_REGISTRY } from './ui/components/search-bar-only-registry';
 
 /** @typedef {import('./core/services/errorreporterservice').default} ErrorReporterService */


### PR DESCRIPTION
This PR further optimizes the stand-alone `SearchBar` asset by removing unused
code from its entry point. Specifically, the following was removed:
- Any code related to `VerticalPagesConfig` as there is no navigation or
  no results in this integration.
- The `updateListener` and `resetListener` passed to `Storage`. This
  integration never persists any data in storage. Because of this, if there
  were a pop history event, any URL params would be unrelated to the
  `SearchBar`. This allows us to safely remove the listeners as they will
  never be invoked in this type of integration.
- The `QUERY_ID` storage listener was also removed. This integration doesn't
  actually perform a search, so there will never be a `QUERY_ID`. By the same
  reasoning, references to the `QueryUpdateListener` could also be removed.
- The `scrollListener` was also removed as that is not desired on a
  `SearchBar`-only page.
The other top-level methods, such as `setContext` and `setConversionsOptIn`
were left in, as requested by Product.

J=SLAP-1271
TEST=manual

Ensured the basic functionality of the integration still worked (autocomplete,
clear button, and redirects).