### PR TITLE
Fix doubly stringified context

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -237,7 +237,7 @@ export default class Core {
         sortBys: this.storage.get(StorageKeys.SORT_BYS),
         /** In the SDK a locationRadius of 0 means "unset my locationRadius" */
         locationRadius: locationRadius === 0 ? undefined : locationRadius,
-        context: JSON.parse(context),
+        context: context && JSON.parse(context),
         referrerPageUrl: referrerPageUrl,
         querySource: this.storage.get(StorageKeys.QUERY_SOURCE)
       })
@@ -343,7 +343,7 @@ export default class Core {
         skipSpellCheck: this.storage.get(StorageKeys.SKIP_SPELL_CHECK),
         queryTrigger: queryTriggerForApi,
         sessionTrackingEnabled: this.storage.get(StorageKeys.SESSIONS_OPT_IN).value,
-        context: JSON.parse(context),
+        context: context && JSON.parse(context),
         referrerPageUrl: referrerPageUrl,
         querySource: this.storage.get(StorageKeys.QUERY_SOURCE)
       })

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -237,7 +237,7 @@ export default class Core {
         sortBys: this.storage.get(StorageKeys.SORT_BYS),
         /** In the SDK a locationRadius of 0 means "unset my locationRadius" */
         locationRadius: locationRadius === 0 ? undefined : locationRadius,
-        context: context,
+        context: JSON.parse(context),
         referrerPageUrl: referrerPageUrl,
         querySource: this.storage.get(StorageKeys.QUERY_SOURCE)
       })
@@ -343,7 +343,7 @@ export default class Core {
         skipSpellCheck: this.storage.get(StorageKeys.SKIP_SPELL_CHECK),
         queryTrigger: queryTriggerForApi,
         sessionTrackingEnabled: this.storage.get(StorageKeys.SESSIONS_OPT_IN).value,
-        context: context,
+        context: JSON.parse(context),
         referrerPageUrl: referrerPageUrl,
         querySource: this.storage.get(StorageKeys.QUERY_SOURCE)
       })

--- a/tests/core/core.js
+++ b/tests/core/core.js
@@ -3,19 +3,19 @@ import Storage from '../../src/core/storage/storage';
 import StorageKeys from '../../src/core/storage/storagekeys';
 
 describe('Search requests are created properly', () => {
-    window.performance.mark = jest.fn();
-    const mockCore = getMockCore();
-    const context = {
-      str: 'string',
-      num: 123,
-      bool: true
-    };
+  window.performance.mark = jest.fn();
+  const mockCore = getMockCore();
+  const context = {
+    str: 'string',
+    num: 123,
+    bool: true
+  };
 
   it('context is passed as an object for universal search', () => {
     mockCore.storage.set(StorageKeys.API_CONTEXT, JSON.stringify(context));
     mockCore.search('test');
     expect(mockCore._coreLibrary.universalSearch).toHaveBeenCalledWith(
-      expect.objectContaining({ context }),
+      expect.objectContaining({ context })
     );
   });
 
@@ -23,7 +23,7 @@ describe('Search requests are created properly', () => {
     mockCore.storage.set(StorageKeys.API_CONTEXT, JSON.stringify(context));
     mockCore.verticalSearch('verticalKey', 'test');
     expect(mockCore._coreLibrary.verticalSearch).toHaveBeenCalledWith(
-      expect.objectContaining({ context }),
+      expect.objectContaining({ context })
     );
   });
 });

--- a/tests/core/core.js
+++ b/tests/core/core.js
@@ -1,0 +1,41 @@
+import Core from '../../src/core/core';
+import Storage from '../../src/core/storage/storage';
+import StorageKeys from '../../src/core/storage/storagekeys';
+
+describe('Search requests are created properly', () => {
+    window.performance.mark = jest.fn();
+    const mockCore = getMockCore();
+    const context = {
+      str: 'string',
+      num: 123,
+      bool: true
+    };
+
+  it('context is passed as an object for universal search', () => {
+    mockCore.storage.set(StorageKeys.API_CONTEXT, JSON.stringify(context));
+    mockCore.search('test');
+    expect(mockCore._coreLibrary.universalSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ context }),
+    );
+  });
+
+  it('context is passed as an object for vertical search', () => {
+    mockCore.storage.set(StorageKeys.API_CONTEXT, JSON.stringify(context));
+    mockCore.verticalSearch('verticalKey', 'test');
+    expect(mockCore._coreLibrary.verticalSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ context }),
+    );
+  });
+});
+
+function getMockCore () {
+  const core = new Core({
+    storage: new Storage().init()
+  });
+  core.init();
+  core._coreLibrary.universalSearch = jest.fn(() => Promise.resolve());
+  core._coreLibrary.verticalSearch = jest.fn(() => Promise.resolve());
+  core._getUrls = jest.fn();
+  core.storage.set(StorageKeys.SESSIONS_OPT_IN, { value: false });
+  return core;
+}


### PR DESCRIPTION
Fix context which is currently being sent to the API in an overly stringified form

When context is sent to the API, it should look like `{"key":"value"}`. Currently it looks like: `"{\"key\":\"value\"}"` since it is stringified twice. This bug occurred because the core libarary expects context as an object and not as a string.

Z=401576
TEST=manual, auto

Test that on both universal and vertical searches, context is sent correctly in the API request. Test that when no context is set, the API doesn't send context in requests.