### PR TITLE
Allow progressive rendering of child components

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,8 +138,7 @@
       "test",
       "fixture",
       "CustomEvent",
-      "ANSWERS",
-      "requestAnimationFrame"
+      "ANSWERS"
     ],
     "ignore": [
       "docs/"

--- a/package.json
+++ b/package.json
@@ -138,7 +138,8 @@
       "test",
       "fixture",
       "CustomEvent",
-      "ANSWERS"
+      "ANSWERS",
+      "requestAnimationFrame"
     ],
     "ignore": [
       "docs/"

--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -378,7 +378,7 @@ export default class Component {
       this._children.forEach(child => {
         setTimeout(() => {
           child.mount();
-        }, 0);
+        });
       });
     } else {
       this._children.forEach(child => {

--- a/src/ui/sass/_base.scss
+++ b/src/ui/sass/_base.scss
@@ -12,3 +12,7 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+
+.yxt-Answers-component--unmounted {
+  display: none !important;
+}

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -51,7 +51,7 @@
 {{#*inline "results"}}
   <div class="yxt-Results-items js-yxt-Results-items{{#if numColumns}} yxt-Results-items--{{numColumns}}{{/if}}">
     {{#each results}}
-      <div class="yxt-Card{{#if ../_config.isUniversal}} yxt-Card--universal{{/if}}"
+      <div class="yxt-Answers-component--unmounted yxt-Card{{#if ../_config.isUniversal}} yxt-Card--universal{{/if}}"
         data-component="Card"
         data-opts='{ "_index": {{@index}} }'>
       </div>


### PR DESCRIPTION
Optimize main thread performance through progressive rendering and by avoiding unnecessary deep clones

By splitting up the rendering of child components with `setTimeout`, it allows the main thread to handle user input, which increases our minimum FPS if the rendering of the children takes a long time. This is is most useful for the mounting of the result cards which take a long time to render.

I added a .yxt-Answers-component--unmounted class to the vertical results which is removed on mount. This allows us to hide the component div until it is rendered which reduces layout shifts.

Finally, I updated the transformData logic so that it only runs when necessary.

J=SLAP-1240
TEST=manual

Enable progressive rendering on the vertial-full-page-map and observe the cards get rendered one-by-one. Also confirm that transform data still works.