### PR TITLE
Add self-contained styling for the `SearchBar` only integration.

### DIFF
--- a/src/ui/sass/answers-search-bar.scss
+++ b/src/ui/sass/answers-search-bar.scss
@@ -1,0 +1,14 @@
+// Variables and mixins
+@import "util";
+@import "colors";
+@import "fonts";
+@import "layout";
+@import "mixins";
+
+// General styling
+@import "base";
+
+// Component Styling
+@import "modules/SearchBar";
+@import "modules/Icon";
+@import "modules/AutoComplete";


### PR DESCRIPTION
This PR adds a new CSS asset, `answers-search-bar.css`, that contains just the
styling needed for the `SearchBar` integration. Specifically, this bundle
contains some common SDK styling and styles for the `SearchBar`, `AutoComplete`,
and `Icon` components.

J=SLAP-1254
TEST=manual

Built a `SearchBar`-only page locally with this new CSS asset. Saw the correct
styling applied and verified that the page score on Mobile was still 100.