### PR TITLE
Add IE-11 compliant versions of the `SearchBar` assets.

### DIFF
--- a/conf/gulp-tasks/bundle/bundle.js
+++ b/conf/gulp-tasks/bundle/bundle.js
@@ -53,12 +53,12 @@ exports.modernBundle = function (
 };
 
 /**
- * The Gulp task for producing either variant of the legacy SDK bundle.
+ * The Gulp task for producing any variant of a legacy SDK asset.
  *
  * @param {Function} callback
+ * @param {string} entryPoint The entry point for the asset.
  * @param {Object<string, ?>} outputConfig Any variant-specific configuration
  *                                         for the legacy bundle.
- * @param {string} entryPoint The entry point for the asset.
  * @param {string} bundleName The name of the created bundle.
  * @param {string} locale The current locale
  * @param {string} libVersion The current JS library version

--- a/conf/gulp-tasks/bundle/bundle.js
+++ b/conf/gulp-tasks/bundle/bundle.js
@@ -58,6 +58,7 @@ exports.modernBundle = function (
  * @param {Function} callback
  * @param {Object<string, ?>} outputConfig Any variant-specific configuration
  *                                         for the legacy bundle.
+ * @param {string} entryPoint The entry point for the asset.
  * @param {string} bundleName The name of the created bundle.
  * @param {string} locale The current locale
  * @param {string} libVersion The current JS library version
@@ -65,9 +66,17 @@ exports.modernBundle = function (
  * @returns {stream.Writable} A {@link Writable} stream containing the legacy
  *                            SDK bundle.
  */
-exports.legacyBundle = function (callback, outputConfig, bundleName, locale, libVersion, translationResolver) {
+exports.legacyBundle = function (
+  callback,
+  entryPoint,
+  outputConfig, 
+  bundleName, 
+  locale, 
+  libVersion,
+  translationResolver) 
+{
   const rollupConfig = {
-    input: './src/answers-umd.js',
+    input: entryPoint,
     output: outputConfig,
     plugins: [
       resolve({ browser: true }),

--- a/conf/gulp-tasks/bundle/bundletaskfactory.js
+++ b/conf/gulp-tasks/bundle/bundletaskfactory.js
@@ -98,7 +98,7 @@ class BundleTaskFactory {
   }
 
   /**
-   * The Gulp task for producing the legacy, IIFE-style SDK bundle.
+   * The Gulp task for producing a legacy, IIFE-style bundle of an SDK asset.
    *
    * @param {function} callback function that will run after the Gulp task
    * @param {BundleType} bundleType The type of SDK asset to generate the bundle for.
@@ -131,7 +131,7 @@ class BundleTaskFactory {
   }
 
   /**
-   * The Gulp task for producing the legacy, UMD-style SDK bundle.
+   * The Gulp task for producing the legacy, UMD-style bundle of an SDK asset.
    *
    * @param {function} callback function that will run after the Gulp task
    * @param {BundleType} bundleType The type of SDK asset to generate the bundle for.

--- a/conf/gulp-tasks/bundle/bundletaskfactory.js
+++ b/conf/gulp-tasks/bundle/bundletaskfactory.js
@@ -37,25 +37,21 @@ class BundleTaskFactory {
    */
   create (bundleType) {
     let bundleFunction;
-    switch (bundleType) {
-      case BundleType.SEARCH_BAR_MODERN:
-        // fall through
-      case BundleType.MODERN:
-        bundleFunction = (callback) => this._modernBundle(callback, bundleType);
-        break;
-      case BundleType.SEARCH_BAR_LEGACY_IIFE:
-        // fall through
-      case BundleType.LEGACY_IIFE:
-        bundleFunction = (callback) => this._legacyBundleIIFE(callback, bundleType);
-        break;
-      case BundleType.SEARCH_BAR_LEGACY_UMD:
-        // fall through
-      case BundleType.LEGACY_UMD:
-        bundleFunction = (callback) => this._legacyBundleUMD(callback, bundleType);
-        break;
-      default:
-        throw new Error('Unrecognized BundleType');
+
+    const modernBundleTypes = [BundleType.MODERN, BundleType.SEARCH_BAR_MODERN];
+    const iifeBundleTypes = [BundleType.LEGACY_IIFE, BundleType.SEARCH_BAR_LEGACY_IIFE];
+    const umdBundleTypes = [BundleType.LEGACY_UMD, BundleType.SEARCH_BAR_LEGACY_UMD];
+
+    if (modernBundleTypes.includes(bundleType)) {
+      bundleFunction = (callback) => this._modernBundle(callback, bundleType);
+    } else if (iifeBundleTypes.includes(bundleType)) {
+      bundleFunction = (callback) => this._legacyBundleIIFE(callback, bundleType);
+    } else if (umdBundleTypes.includes(bundleType)) {
+      bundleFunction = (callback) => this._legacyBundleUMD(callback, bundleType);
+    } else {
+      throw new Error('Unrecognized BundleType');
     }
+
     Object.defineProperty(bundleFunction, 'name', {
       value: `bundle ${getBundleName(bundleType, this._locale)}`
     });

--- a/conf/gulp-tasks/bundle/bundletaskfactory.js
+++ b/conf/gulp-tasks/bundle/bundletaskfactory.js
@@ -146,7 +146,7 @@ class BundleTaskFactory {
       namespace = BundleNamespaces.ANSWERS_SEARCH_BAR;
       entryPoint = './src/answers-search-bar.js';
     }
-    
+
     const legacyBundleConfig = {
       format: 'umd',
       name: namespace,

--- a/conf/gulp-tasks/bundle/bundletaskfactory.js
+++ b/conf/gulp-tasks/bundle/bundletaskfactory.js
@@ -13,7 +13,9 @@ const BundleType = {
   MODERN: 'answers-modern',
   LEGACY_IIFE: 'answers',
   LEGACY_UMD: 'answers-umd',
-  SEARCH_BAR_MODERN: 'answers-search-bar-modern'
+  SEARCH_BAR_MODERN: 'answers-search-bar-modern',
+  SEARCH_BAR_LEGACY_IIFE: 'answers-search-bar',
+  SEARCH_BAR_LEGACY_UMD: 'answers-search-bar-umd'
 };
 Object.freeze(BundleType);
 
@@ -41,11 +43,15 @@ class BundleTaskFactory {
       case BundleType.MODERN:
         bundleFunction = (callback) => this._modernBundle(callback, bundleType);
         break;
+      case BundleType.SEARCH_BAR_LEGACY_IIFE:
+        // fall through
       case BundleType.LEGACY_IIFE:
-        bundleFunction = (callback) => this._legacyBundleIIFE(callback);
+        bundleFunction = (callback) => this._legacyBundleIIFE(callback, bundleType);
         break;
+      case BundleType.SEARCH_BAR_LEGACY_UMD:
+        // fall through
       case BundleType.LEGACY_UMD:
-        bundleFunction = (callback) => this._legacyBundleUMD(callback);
+        bundleFunction = (callback) => this._legacyBundleUMD(callback, bundleType);
         break;
       default:
         throw new Error('Unrecognized BundleType');
@@ -95,19 +101,29 @@ class BundleTaskFactory {
    * The Gulp task for producing the legacy, IIFE-style SDK bundle.
    *
    * @param {function} callback function that will run after the Gulp task
+   * @param {BundleType} bundleType The type of SDK asset to generate the bundle for.
    * @returns {stream.Writable} A {@link Writable} stream containing the legacy,
    *                            IIFE-style SDK bundle.
    */
-  _legacyBundleIIFE (callback) {
+  _legacyBundleIIFE (callback, bundleType) {
+    let namespace = BundleNamespaces.ANSWERS;
+    let entryPoint = './src/answers-umd.js';
+
+    if (bundleType === BundleType.SEARCH_BAR_LEGACY_IIFE) {
+      namespace = BundleNamespaces.ANSWERS_SEARCH_BAR;
+      entryPoint = './src/answers-search-bar.js';
+    }
+
     const legacyBundleConfig = {
       format: 'iife',
-      name: BundleNamespaces.ANSWERS,
+      name: namespace,
       sourcemap: true
     };
     return legacyBundle(
       callback,
+      entryPoint,
       legacyBundleConfig,
-      getBundleName(BundleType.LEGACY_IIFE, this._locale),
+      getBundleName(bundleType, this._locale),
       this._locale,
       this._libVersion,
       this._translationResolver
@@ -118,20 +134,30 @@ class BundleTaskFactory {
    * The Gulp task for producing the legacy, UMD-style SDK bundle.
    *
    * @param {function} callback function that will run after the Gulp task
+   * @param {BundleType} bundleType The type of SDK asset to generate the bundle for.
    * @returns {stream.Writable} A {@link Writable} stream containing the legacy,
    *                            UMD-style SDK bundle.
    */
-  _legacyBundleUMD (callback) {
+  _legacyBundleUMD (callback, bundleType) {
+    let namespace = BundleNamespaces.ANSWERS;
+    let entryPoint = './src/answers-umd.js';
+
+    if (bundleType === BundleType.SEARCH_BAR_LEGACY_UMD) {
+      namespace = BundleNamespaces.ANSWERS_SEARCH_BAR;
+      entryPoint = './src/answers-search-bar.js';
+    }
+    
     const legacyBundleConfig = {
       format: 'umd',
-      name: BundleNamespaces.ANSWERS,
+      name: namespace,
       export: 'default',
       sourcemap: true
     };
     return legacyBundle(
       callback,
+      entryPoint,
       legacyBundleConfig,
-      getBundleName(BundleType.LEGACY_UMD, this._locale),
+      getBundleName(bundleType, this._locale),
       this._locale,
       this._libVersion,
       this._translationResolver

--- a/conf/gulp-tasks/library.gulpfile.js
+++ b/conf/gulp-tasks/library.gulpfile.js
@@ -60,6 +60,10 @@ exports.buildLocales = function allLocaleJSBundles () {
     'answers.min.js',
     'answers-modern.js',
     'answers-modern.min.js',
+    'answers-search-bar.js',
+    'answers-search-bar.min.js',
+    'answers-search-bar-umd.js',
+    'answers-search-bar-umd.min.js',
     'answers-search-bar-modern.js',
     'answers-search-bar-modern.min.js',
     'answers-umd.js',
@@ -93,6 +97,14 @@ function createBundles (bundleTaskFactory, minifyTaskFactory) {
     series(
       bundleTaskFactory.create(BundleType.SEARCH_BAR_MODERN),
       minifyTaskFactory.minify(BundleType.SEARCH_BAR_MODERN)
+    ),
+    series(
+      bundleTaskFactory.create(BundleType.SEARCH_BAR_LEGACY_IIFE),
+      minifyTaskFactory.minify(BundleType.SEARCH_BAR_LEGACY_IIFE)
+    ),
+    series(
+      bundleTaskFactory.create(BundleType.SEARCH_BAR_LEGACY_UMD),
+      minifyTaskFactory.minify(BundleType.SEARCH_BAR_LEGACY_UMD)
     )
   );
 }

--- a/src/answers-search-bar.js
+++ b/src/answers-search-bar.js
@@ -1,6 +1,7 @@
 /** @module */
 
 import Core from './core/core';
+import cssVars from 'css-vars-ponyfill';
 
 import {
   Renderers,
@@ -207,7 +208,8 @@ class AnswersSearchBar {
     this._onReady = parsedConfig.onReady || function () {};
 
     this.renderer.init(parsedConfig.templateBundle, this._getInitLocale());
-    this._onReady();
+    this._handlePonyfillCssVariables(parsedConfig.disableCssVariablesPonyfill)
+      .finally(() => this._onReady());    
   }
 
   domReady (cb) {
@@ -354,6 +356,55 @@ class AnswersSearchBar {
    */
   _getInitLocale () {
     return this.core.storage.get(StorageKeys.LOCALE);
+  }
+
+  /**
+   * A promise that resolves when ponyfillCssVariables resolves,
+   * or resolves immediately if ponyfill is disabled
+   * @param {boolean} option to opt out of the css variables ponyfill
+   * @return {Promise} resolves after ponyfillCssVariables, or immediately if disabled
+   */
+   _handlePonyfillCssVariables (ponyfillDisabled) {
+    if (ponyfillDisabled) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve, reject) => {
+      this.ponyfillCssVariables({
+        onFinally: () => {
+          resolve();
+        }
+      });
+    });
+  }
+
+  /*
+   * Updates the css styles with new current variables. This is useful when the css
+   * variables are updated dynamically (e.g. through js) or if the css variables are
+   * added after the ANSWERS.init
+   *
+   * To solve issues with non-zero max-age cache controls for link/script assets in IE11,
+   * we add a cache busting parameter so that XMLHttpRequests succeed.
+   *
+   * @param {Object} config Additional config to pass to the ponyfill
+   */
+  ponyfillCssVariables (config = {}) {
+    cssVars({
+      onlyLegacy: true,
+      onError: config.onError || function () {},
+      onSuccess: config.onSuccess || function () {},
+      onFinally: config.onFinally || function () {},
+      onBeforeSend: (xhr, node, url) => {
+        try {
+          const uriWithCacheBust = new URL(url);
+          const params = new SearchParams(uriWithCacheBust.search);
+          params.set('_', new Date().getTime());
+          uriWithCacheBust.search = params.toString();
+          xhr.open('GET', uriWithCacheBust.toString());
+        } catch (e) {
+          // Catch the error and continue if the URL provided in the asset is not a valid URL
+        }
+      }
+    });
   }
 
   /**

--- a/src/answers-search-bar.js
+++ b/src/answers-search-bar.js
@@ -5,7 +5,8 @@ import cssVars from 'css-vars-ponyfill';
 
 import {
   Renderers,
-  DOM
+  DOM,
+  SearchParams
 } from './ui/index';
 
 import ErrorReporter from './core/errors/errorreporter';
@@ -209,7 +210,7 @@ class AnswersSearchBar {
 
     this.renderer.init(parsedConfig.templateBundle, this._getInitLocale());
     this._handlePonyfillCssVariables(parsedConfig.disableCssVariablesPonyfill)
-      .finally(() => this._onReady());    
+      .finally(() => this._onReady());
   }
 
   domReady (cb) {
@@ -364,7 +365,7 @@ class AnswersSearchBar {
    * @param {boolean} option to opt out of the css variables ponyfill
    * @return {Promise} resolves after ponyfillCssVariables, or immediately if disabled
    */
-   _handlePonyfillCssVariables (ponyfillDisabled) {
+  _handlePonyfillCssVariables (ponyfillDisabled) {
     if (ponyfillDisabled) {
       return Promise.resolve();
     }


### PR DESCRIPTION
This PR adds IIFE and UMD bundles of the `SearchBar` that support IE11. As part
of this, I had to add CSS Variable Ponyfills back to the integration's entry
point. Technically, we could create styling for this integration that does not
use CSS variables. But, that would be rather onerous to create and maintain.

J=SLAP-1253
TEST=manual

Created a `SearchBar` site using the IIFE and UMD assets. Verified that the site
looked and worked as expected in IE11.