### PR TITLE
Create IIFE template bundle for `SearchBar`-only integration.

### DIFF
--- a/conf/gulp-tasks/template/bundletemplatestaskfactory.js
+++ b/conf/gulp-tasks/template/bundletemplatestaskfactory.js
@@ -68,6 +68,7 @@ class BundleTemplatesTaskFactory {
       }
     };
     typeToConfig[TemplateType.SEARCH_BAR_UMD] = typeToConfig[TemplateType.UMD];
+    typeToConfig[TemplateType.SEARCH_BAR_IIFE] = typeToConfig[TemplateType.IIFE];
 
     return typeToConfig[templateType];
   }
@@ -82,7 +83,8 @@ class BundleTemplatesTaskFactory {
     const typeToTaskName = {
       [TemplateType.UMD]: 'bundleTemplatesUMD',
       [TemplateType.SEARCH_BAR_UMD]: 'bundleSearchTemplatesUMD',
-      [TemplateType.IIFE]: 'bundleTemplatesIIFE'
+      [TemplateType.IIFE]: 'bundleTemplatesIIFE',
+      [TemplateType.SEARCH_BAR_IIFE]: 'bundleSearchTemplatesIIFE'
     };
     const taskName = typeToTaskName[templateType];
     return addLocalePrefix(taskName, this._locale);

--- a/conf/gulp-tasks/template/filenameutils.js
+++ b/conf/gulp-tasks/template/filenameutils.js
@@ -3,7 +3,8 @@ const TemplateType = require('./templatetype');
 const fileNames = {
   [TemplateType.UMD]: 'answerstemplates.compiled.min.js',
   [TemplateType.IIFE]: 'answerstemplates-iife.compiled.min.js',
-  [TemplateType.SEARCH_BAR_UMD]: 'answers-search-bar-templates.compiled.min.js'
+  [TemplateType.SEARCH_BAR_UMD]: 'answers-search-bar-templates.compiled.min.js',
+  [TemplateType.SEARCH_BAR_IIFE]: 'answers-search-bar-templates-iife.compiled.min.js'
 };
 
 /**

--- a/conf/gulp-tasks/template/templatetype.js
+++ b/conf/gulp-tasks/template/templatetype.js
@@ -4,7 +4,8 @@
 const TemplateType = {
   UMD: 'templates-UMD',
   IIFE: 'templates-IIFE',
-  SEARCH_BAR_UMD: 'templates-search-bar-UMD'
+  SEARCH_BAR_UMD: 'templates-search-bar-UMD',
+  SEARCH_BAR_IIFE: 'templates-search-bar-IIFE'
 };
 
 module.exports = TemplateType;

--- a/conf/gulp-tasks/templates.gulpfile.js
+++ b/conf/gulp-tasks/templates.gulpfile.js
@@ -66,12 +66,16 @@ function createDefaultTask (locale, translator) {
   const bundleFactory = new BundleTemplatesTaskFactory(locale);
   const bundleTemplatesIIFE = bundleFactory.create(TemplateType.IIFE);
   const bundleTemplatesUMD = bundleFactory.create(TemplateType.UMD);
+  const bundleSearchTemplatesIIFE =
+    bundleFactory.create(TemplateType.SEARCH_BAR_IIFE);
   const bundleSearchTemplatesUMD =
     bundleFactory.create(TemplateType.SEARCH_BAR_UMD);
 
   const minifyFactory = new MinifyTemplatesTaskFactory(locale);
   const minifyTemplatesIIFE = minifyFactory.create(TemplateType.IIFE);
   const minifyTemplatesUMD = minifyFactory.create(TemplateType.UMD);
+  const minifyTemplatesSearchIIFE =
+    minifyFactory.create(TemplateType.SEARCH_BAR_IIFE);
   const minifyTemplatesSearchUMD =
     minifyFactory.create(TemplateType.SEARCH_BAR_UMD);
 
@@ -83,6 +87,7 @@ function createDefaultTask (locale, translator) {
     parallel(
       series(bundleTemplatesIIFE, minifyTemplatesIIFE),
       series(bundleTemplatesUMD, minifyTemplatesUMD),
+      series(bundleSearchTemplatesIIFE, minifyTemplatesSearchIIFE),
       series(bundleSearchTemplatesUMD, minifyTemplatesSearchUMD)
     ),
     cleanFiles


### PR DESCRIPTION
This PR ensures that an IIFE template bundle is generated for this integration.

TEST=manual

Used the new asset on an IE11 site and verified the integration worked as
expected. Verified that the file itself was in IIFE-style.