### PR TITLE
remove extraneous DOM.create call

### DIFF
--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -428,12 +428,8 @@ export default class Component {
       }, data);
     }
 
-    // We create an HTML Document fragment with the rendered string
-    // So that we can query it for processing of sub components
-    let el = DOM.create(html);
-
     this.afterRender();
-    return el.innerHTML;
+    return html;
   }
 
   _createSubcomponent (domComponent, data) {

--- a/tests/ui/components/filters/sortoptionscomponent.js
+++ b/tests/ui/components/filters/sortoptionscomponent.js
@@ -182,7 +182,7 @@ describe('sort options component', () => {
     const isNoResults = true;
     component.handleVerticalResultsUpdate(isNoResults);
     const wrapper = mount(component);
-    expect(wrapper.text()).toEqual('');
+    expect(wrapper.find('.yxt-SortOptions-fieldSet')).toHaveLength(0);
   });
 
   it('uses the persisted sortBys on load', () => {


### PR DESCRIPTION
This commit removes a DOM.create call that is no longer needed.
Originally, this call we needed to perform DOM queries on the
updated component's HTML. see: https://github.com/yext/answers-search-ui/commit/1db8ba5564ad2a7da16743e7dfb21d9d5b290cd8
This is no longer the case. This changed shaved off ~13% of the render time when done for mercy
(original commit https://github.com/yext/answers-search-ui/pull/1313)

J=SLAP-1288
TEST=manual

test that the SDK still renders