### PR TITLE
pass jsLibVersion to all requests

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -304,7 +304,7 @@ MIT License
 
 The following NPM packages may be included in this product:
 
- - @yext/answers-core@1.1.0
+ - @yext/answers-core@1.2.0-alpha.0
 
 These packages each contain the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5318,9 +5318,9 @@
       }
     },
     "@yext/answers-core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.1.0.tgz",
-      "integrity": "sha512-H5ec+TE9pvGzcD7QZXUSLo9xXoSRJlrFQFVsGo2rlf3RC98rru+V2oEswjJAIf6Mfay4bFm2X//iQ0+LDEFjQg==",
+      "version": "1.2.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.2.0-alpha.0.tgz",
+      "integrity": "sha512-bQbFanG+OyRR3P4CmvenRZWEC8q5dAk0rIZIjakXU57xf3iOPVPHXns7Yv3ru+yAET/rAqn1UlEXiQK7ZeYCAQ==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.0.6"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@mapbox/mapbox-gl-language": "^0.10.1",
-    "@yext/answers-core": "^1.1.0",
+    "@yext/answers-core": "^1.2.0-alpha.0",
     "@yext/answers-storage": "^1.1.0",
     "@yext/rtf-converter": "^1.5.0",
     "cross-fetch": "^3.0.6",

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -17,7 +17,7 @@ import FilterRegistry from './filters/filterregistry';
 import DirectAnswer from './models/directanswer';
 import AutoCompleteResponseTransformer from './search/autocompleteresponsetransformer';
 
-import { PRODUCTION, ENDPOINTS } from './constants';
+import { PRODUCTION, ENDPOINTS, LIB_VERSION } from './constants';
 import { getCachedLiveApiUrl, getLiveApiUrl, getKnowledgeApiUrl } from './utils/urlutils';
 import { SearchParams } from '../ui';
 import SearchStates from './storage/searchstates';
@@ -133,7 +133,10 @@ export default class Core {
       experienceKey: this._experienceKey,
       locale: this._locale,
       experienceVersion: this._experienceVersion,
-      endpoints: this._getServiceUrls()
+      endpoints: this._getServiceUrls(),
+      additionalQueryParams: {
+        jsLibVersion: LIB_VERSION
+      }
     };
 
     this._coreLibrary = provideCore(params);


### PR DESCRIPTION
This commit fixes the SDK not passing jsLibVersion
as a query param to all requests, by using the new
additionalQueryParams functionality of answers-core.

J=SLAP-1324
TEST=manual

test that jsLibVersion is passed on vertical/universal
searches, autocomplete, and qa submission