### PR TITLE
Direct Answers: Fix IE11 console error

### DIFF
--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -188,8 +188,8 @@ export default class AutoCompleteComponent extends Component {
   }
 
   isQueryInputFocused () {
-    return document.activeElement &&
-      document.activeElement.className.includes(this._inputEl.substring(1));
+    return document.activeElement && document.activeElement.getAttribute('class') &&
+      document.activeElement.getAttribute('class').includes(this._inputEl.substring(1));
   }
 
   /**


### PR DESCRIPTION
resolved issue of getting property of undefined/null references in
direct answer component by using Element.getAttribute for SVG elements
in place of className

J=SLAP-556
T=manual

Launched test site in IE11 and confirmed that error
is gone when click on feedback button