### PR TITLE
Fix appearance of clear button on empty query in IE11

### DIFF
--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -416,8 +416,11 @@ export default class SearchComponent extends Component {
   initClearButton () {
     const button = this._getClearButton();
     this._showClearButton = this._showClearButton || this.query;
-    button.classList.toggle('yxt-SearchBar--hidden', !this._showClearButton);
-
+    if (this._showClearButton) {
+      button.classList.remove('yxt-SearchBar--hidden');
+    } else {
+      button.classList.add('yxt-SearchBar--hidden');
+    }
     DOM.on(button, 'click', () => {
       this.customHooks.onClearSearch();
       this.query = '';
@@ -523,17 +526,6 @@ export default class SearchComponent extends Component {
 
     inputEl.blur();
     DOM.query(this._container, '.js-yext-submit').blur();
-    // TODO: move this into initClearButton
-    if (this.clearButton) {
-      const button = DOM.query(this._container, '.js-yxt-SearchBar-clear');
-      if (this.query) {
-        this._showClearButton = true;
-        button.classList.remove('yxt-SearchBar--hidden');
-      } else {
-        this._showClearButton = false;
-        button.classList.add('yxt-SearchBar--hidden');
-      }
-    }
     if (this.isUsingYextAnimatedIcon) {
       this.animateIconToYext();
     }


### PR DESCRIPTION
update logic for adding/removing classname that hide the clear button since toggle() with second parameter is not supported in IE11

J=SLAP-1143
TEST=manual

Launched test site and confirmed visual changes of clear button on empty and nonempty query in search bar component in IE11, firefox, and chrome.