### PR TITLE
Add acceptance tests for the `SearchBar`-only integration.

### DIFF
--- a/tests/acceptance/acceptancesuites/searchbaronlysuite.js
+++ b/tests/acceptance/acceptancesuites/searchbaronlysuite.js
@@ -1,0 +1,34 @@
+import { ClientFunction } from 'testcafe';
+import SearchBarOnlyPage from '../pageobjects/searchbaronlypage';
+import {
+  setupServer,
+  shutdownServer,
+  SEARCH_BAR_ONLY_PAGE
+} from '../server';
+
+/**
+ * This file contains acceptance tests for a SearchBar-only page.
+ * Note that before any tests are run, a local HTTP server is spun
+ * up to serve the page and the dist directory of Answers. This server
+ * is closed once all tests have completed.
+ */
+fixture`SearchBar-only page works as expected`
+  .before(setupServer)
+  .after(shutdownServer)
+  .page`${SEARCH_BAR_ONLY_PAGE}`;
+
+test('Basic search and redirect flow', async t => {
+  const searchComponent = SearchBarOnlyPage.getSearchComponent();
+
+  await searchComponent.enterQuery('Tom');
+  await searchComponent.clearQuery();
+
+  await searchComponent.enterQuery('ama');
+  await searchComponent.getAutoComplete().selectOption('amani farooque phone number');
+
+  const getUrl = ClientFunction(() => window.location.href);
+  const clientUrl = await getUrl();
+  const expectedUrl = 
+    'http://localhost:9999/tests/acceptance/fixtures/html/universal?query=amani+farooque+phone+number';
+  await t.expect(clientUrl).eql(expectedUrl);
+});

--- a/tests/acceptance/acceptancesuites/searchbaronlysuite.js
+++ b/tests/acceptance/acceptancesuites/searchbaronlysuite.js
@@ -28,7 +28,7 @@ test('Basic search and redirect flow', async t => {
 
   const getUrl = ClientFunction(() => window.location.href);
   const clientUrl = await getUrl();
-  const expectedUrl = 
+  const expectedUrl =
     'http://localhost:9999/tests/acceptance/fixtures/html/universal?query=amani+farooque+phone+number';
   await t.expect(clientUrl).eql(expectedUrl);
 });

--- a/tests/acceptance/fixtures/html/searchbaronly.html
+++ b/tests/acceptance/fixtures/html/searchbaronly.html
@@ -1,0 +1,31 @@
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="http://localhost:9999/dist/answers-search-bar-templates.compiled.min.js"></script>
+    <script src="http://localhost:9999/dist/answers-search-bar.js"></script>
+    <link rel="stylesheet" type="text/css" href="http://localhost:9999/dist/answers-search-bar.css">
+  </head>
+  <body>
+    <div class="answers-container">
+      <div class="search-bar-container"></div>
+      <div class="navigation-container"></div>
+      <div class="results-container"></div>
+    </div>
+    <script>
+      ANSWERS.init({
+        apiKey: '2d8c550071a64ea23e263118a2b0680b',
+        experienceKey: 'slanswers',
+        businessId: '3350634',
+        experienceVersion: 'PRODUCTION',
+        templateBundle: TemplateBundle.default,
+        onReady: function() {
+          this.addComponent('SearchBar', {
+            container: '.search-bar-container',
+            clearButton: true,
+            redirectUrl: './universal'
+          });
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/tests/acceptance/pageobjects/searchbaronlypage.js
+++ b/tests/acceptance/pageobjects/searchbaronlypage.js
@@ -1,0 +1,20 @@
+import SearchComponentBlock from '../blocks/searchcomponent';
+
+/**
+ * A model of a SearchBar-only page, containing block representations
+ * of the various {@link Component}s a user would interact with.
+ */
+class SearchBarOnlyPage {
+  constructor () {
+    this._searchComponent = new SearchComponentBlock();
+  }
+
+  /**
+   * Returns the {@link SearchComponentBlock} on the page.
+   */
+  getSearchComponent () {
+    return this._searchComponent;
+  }
+}
+
+export default new SearchBarOnlyPage();

--- a/tests/acceptance/server.js
+++ b/tests/acceptance/server.js
@@ -26,3 +26,4 @@ export const VERTICAL_PAGE = 'http://localhost:9999/tests/acceptance/fixtures/ht
 export const FACETS_PAGE = 'http://localhost:9999/tests/acceptance/fixtures/html/facets';
 export const FILTERBOX_PAGE = 'http://localhost:9999/tests/acceptance/fixtures/html/filterbox';
 export const UNIVERSAL_INITIAL_SEARCH_PAGE = 'http://localhost:9999/tests/acceptance/fixtures/html/universalinitialsearch';
+export const SEARCH_BAR_ONLY_PAGE = 'http://localhost:9999/tests/acceptance/fixtures/html/searchbaronly';


### PR DESCRIPTION
The tests verify a simple flow: a user interacts with the search bar, then selects an autocomplete option, and is redirected to the proper URL.

J=SLAP-1364
TEST=auto

Ensured the new tests passed.