### PR TITLE
addComponent no longer throws error, prints to console instead

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -15,7 +15,6 @@ import ErrorReporter from './core/errors/errorreporter';
 import ConsoleErrorReporter from './core/errors/consoleerrorreporter';
 import { AnalyticsReporter, NoopAnalyticsReporter } from './core';
 import Storage from './core/storage/storage';
-import { AnswersComponentError } from './core/errors/errors';
 import AnalyticsEvent from './core/analytics/analyticsevent';
 import StorageKeys from './core/storage/storagekeys';
 import QueryTriggers from './core/models/querytriggers';
@@ -433,7 +432,7 @@ class Answers {
     try {
       this.components.create(type, opts).mount();
     } catch (e) {
-      throw new AnswersComponentError('Failed to add component', type, e);
+      console.error('Failed to add component', type, e);
     }
     return this;
   }

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -432,7 +432,7 @@ class Answers {
     try {
       this.components.create(type, opts).mount();
     } catch (e) {
-      console.error('Failed to add component', type, e);
+      console.error('Failed to add component', type, '\n\n', e);
     }
     return this;
   }

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -22,7 +22,7 @@ const IconState = {
 export default class SearchComponent extends Component {
   constructor (config = {}, systemConfig = {}) {
     super(config, systemConfig);
-    throw new Error("error");
+
     /**
      * The optional vertical key for vertical search configuration
      * If not provided, auto-complete and search will be based on universal

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -22,7 +22,7 @@ const IconState = {
 export default class SearchComponent extends Component {
   constructor (config = {}, systemConfig = {}) {
     super(config, systemConfig);
-
+    throw new Error("error");
     /**
      * The optional vertical key for vertical search configuration
      * If not provided, auto-complete and search will be based on universal


### PR DESCRIPTION
If addComponent fails, we no longer throw an error, prints to console instead

TEST=manual
J=SLAP-1106

Threw an error in the component, and everything else loaded fine