### PR TITLE
Change semistandard to eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,17 +2,17 @@
    "extends": ["semistandard"],
    "ignorePatterns": ["dist", "docs"],
    "globals": {
-      "beforeEach" : true,
-      "beforeAll" : true,
-      "describe" : true,
-      "it" : true,
-      "expect" : true,
-      "jest" : true,
-      "DOMParser" : true,
-      "ytag" : true,
-      "test" : true,
-      "fixture" : true,
-      "CustomEvent" : true,
-      "ANSWERS" : true
+      "beforeEach": true,
+      "beforeAll": true,
+      "describe": true,
+      "it": true,
+      "expect": true,
+      "jest": true,
+      "DOMParser": true,
+      "ytag": true,
+      "test": true,
+      "fixture": true,
+      "CustomEvent": true,
+      "ANSWERS": true
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+   "extends": ["semistandard"],
+   "ignorePatterns": ["dist", "docs"],
+   "globals": {
+      "beforeEach" : true,
+      "beforeAll" : true,
+      "describe" : true,
+      "it" : true,
+      "expect" : true,
+      "jest" : true,
+      "DOMParser" : true,
+      "ytag" : true,
+      "test" : true,
+      "fixture" : true,
+      "CustomEvent" : true,
+      "ANSWERS" : true
+    }
+}

--- a/conf/gulp-tasks/template/bundletemplatestaskfactory.js
+++ b/conf/gulp-tasks/template/bundletemplatestaskfactory.js
@@ -111,7 +111,7 @@ class BundleTemplatesTaskFactory {
           plugins: [
             '@babel/syntax-dynamic-import',
             ['@babel/plugin-transform-runtime', {
-              'corejs': 3
+              corejs: 3
             }],
             '@babel/plugin-transform-arrow-functions',
             '@babel/plugin-proposal-object-rest-spread',

--- a/conf/gulp-tasks/template/createcleanfiles.js
+++ b/conf/gulp-tasks/template/createcleanfiles.js
@@ -27,7 +27,7 @@ function createCleanFilesTask (locale) {
  */
 function _cleanFiles (callback, locale) {
   const precompiledFile = getPrecompiledFileName(locale);
-  del.sync([ `./dist/${precompiledFile}` ]);
+  del.sync([`./dist/${precompiledFile}`]);
   callback();
 }
 

--- a/conf/gulp-tasks/template/createprecompiletemplates.js
+++ b/conf/gulp-tasks/template/createprecompiletemplates.js
@@ -54,7 +54,7 @@ function precompileTemplates (callback, outputFile, processAST) {
         processPartialName: function (fileName, a, b, c) {
           // Strip the extension and the underscore
           // Escape the output with JSON.stringify
-          let name = fileName.split('.')[0];
+          const name = fileName.split('.')[0];
           if (name.charAt(0) === '_') {
             return JSON.stringify(name.substr(1));
           } else {
@@ -64,8 +64,8 @@ function precompileTemplates (callback, outputFile, processAST) {
         // TBH, this isn't really needed anymore since we don't name files like so 'foo.bar.js', but this is here to
         // support that use case.
         customContext: function (fileName) {
-          let name = fileName.split('.')[0];
-          let keys = name.split('.');
+          const name = fileName.split('.')[0];
+          const keys = name.split('.');
           let context = 'context';
           for (let i = 0; i < keys.length; i++) {
             context = context += '["' + keys[i] + '"]';
@@ -78,7 +78,7 @@ function precompileTemplates (callback, outputFile, processAST) {
       root: 'context',
       noRedeclare: true,
       processName: function (filePath) {
-        let path = filePath.replace('src/ui/templates', '');
+        const path = filePath.replace('src/ui/templates', '');
         return declare.processNameByPath(path, '').replace('.', '/');
       }
     }))

--- a/conf/i18n/constants.js
+++ b/conf/i18n/constants.js
@@ -3,7 +3,7 @@ exports.TRANSLATION_FLAGGER_REGEX = /TranslationFlagger.flag\((\s)*\{[^;]+?\}(\s
 exports.DEFAULT_LOCALE = 'en';
 
 const LANGUAGES_TO_LOCALES = {
-  'en': [
+  en: [
     'en_AE',
     'en_AI',
     'en_AS',
@@ -65,7 +65,7 @@ const LANGUAGES_TO_LOCALES = {
     'en_US',
     'en_ZA'
   ],
-  'es': [
+  es: [
     'es_BO',
     'es_CO',
     'es_CU',
@@ -77,7 +77,7 @@ const LANGUAGES_TO_LOCALES = {
     'es_NI',
     'es_US'
   ],
-  'fr': [
+  fr: [
     'fr_BE',
     'fr_BL',
     'fr_CA',
@@ -89,18 +89,18 @@ const LANGUAGES_TO_LOCALES = {
     'fr_MC',
     'fr_RE'
   ],
-  'it': [
+  it: [
     'it_CH',
     'it_IT'
   ],
-  'de': [
+  de: [
     'de_AT',
     'de_CH',
     'de_DE',
     'de_EU',
     'de_LU'
   ],
-  'ja': [
+  ja: [
     'ja_JP'
   ]
 };

--- a/conf/i18n/runtimecallgeneratorutils.js
+++ b/conf/i18n/runtimecallgeneratorutils.js
@@ -52,6 +52,6 @@ function formatPluralForms (translatorResult) {
  * @returns {string}
  */
 function escapeSingleQuotes (str) {
-  const regex = new RegExp('\'', 'g');
+  const regex = /'/g;
   return str.replace(regex, '\\\'');
 }

--- a/conf/i18n/translatehelpervisitor.js
+++ b/conf/i18n/translatehelpervisitor.js
@@ -107,7 +107,7 @@ class TranslateHelperVisitor {
       ...statement,
       path: {
         ...statement.path,
-        parts: [ this._processTranslationHelper ],
+        parts: [this._processTranslationHelper],
         original: this._processTranslationHelper
       }
     };

--- a/conf/i18n/translator.js
+++ b/conf/i18n/translator.js
@@ -164,7 +164,7 @@ class Translator {
     const placeholders = {};
     let placeholderMatch;
 
-    const placeholderRegex = new RegExp(/\[\[([a-zA-Z0-9]+)\]\]/, 'g');
+    const placeholderRegex = /\[\[([a-zA-Z0-9]+)\]\]/g;
     while ((placeholderMatch = placeholderRegex.exec(phrase)) != null) {
       if (placeholderMatch.length >= 2) {
         placeholders[placeholderMatch[1]] = placeholderMatch[0];

--- a/package-lock.json
+++ b/package-lock.json
@@ -3767,6 +3767,72 @@
         "kuler": "^2.0.0"
       }
     },
+    "@eslint/eslintrc": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
+      "integrity": "sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
+        "import-fresh": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
     "@gulp-sourcemaps/identity-map": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz",
@@ -5214,6 +5280,12 @@
         "jest-diff": "^24.3.0"
       }
     },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
     "@types/lodash": {
       "version": "4.14.168",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
@@ -5480,12 +5552,6 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
-    },
-    "ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
     },
     "align-text": {
       "version": "1.0.2",
@@ -5970,16 +6036,127 @@
       "dev": true
     },
     "array-includes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.2.tgz",
-      "integrity": "sha512-w2GspexNQpx+PutG3QpT437/BenZBj0M/MZGn5mzv/MofYqo0xmRHzn4lFsoDlWJ+THYsGJmFlW68WlDFx7VRw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
+      "integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
-        "get-intrinsic": "^1.0.1",
+        "es-abstract": "^1.18.0-next.2",
+        "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.5"
+      },
+      "dependencies": {
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
+        "es-abstract": {
+          "version": "1.18.3",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+          "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.3",
+            "is-string": "^1.0.6",
+            "object-inspect": "^1.10.3",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.1"
+          },
+          "dependencies": {
+            "has-symbols": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+              "dev": true
+            },
+            "is-string": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+              "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
+              "dev": true
+            }
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+          "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-symbols": "^1.0.2"
+          },
+          "dependencies": {
+            "has-symbols": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+              "dev": true
+            }
+          }
+        },
+        "object-inspect": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+          "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+          "dev": true
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        }
       }
     },
     "array-initial": {
@@ -6075,6 +6252,18 @@
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
         "es-abstract": "^1.18.0-next.1"
+      }
+    },
+    "array.prototype.flatmap": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz",
+      "integrity": "sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "function-bind": "^1.1.1"
       }
     },
     "arrify": {
@@ -6301,65 +6490,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
-      }
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
@@ -7288,12 +7418,6 @@
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
       "dev": true
     },
-    "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-      "dev": true
-    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -7539,12 +7663,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-      "dev": true
-    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -7590,15 +7708,6 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
-    },
-    "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "^2.0.0"
-      }
     },
     "cli-spinners": {
       "version": "2.5.0",
@@ -7686,12 +7795,6 @@
           "dev": true
         }
       }
-    },
-    "cli-width": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
-      "dev": true
     },
     "clipboardy": {
       "version": "1.2.3",
@@ -8747,12 +8850,6 @@
         "object-assign": "4.X"
       }
     },
-    "debug-log": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-      "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
-      "dev": true
-    },
     "debuglog": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
@@ -8912,20 +9009,6 @@
         }
       }
     },
-    "deglob": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/deglob/-/deglob-3.1.0.tgz",
-      "integrity": "sha512-al10l5QAYaM/PeuXkAr1Y9AQz0LCtWsnJG23pIgh44hDxHFOj36l6qvhfjnIWBYwZOqM1fXUFV9tkjL7JPdGvw==",
-      "dev": true,
-      "requires": {
-        "find-root": "^1.0.0",
-        "glob": "^7.0.5",
-        "ignore": "^5.0.0",
-        "pkg-config": "^1.1.0",
-        "run-parallel": "^1.1.2",
-        "uniq": "^1.0.1"
-      }
-    },
     "del": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
@@ -9065,9 +9148,9 @@
       "dev": true
     },
     "doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -9523,69 +9606,107 @@
       }
     },
     "eslint": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.4.0.tgz",
-      "integrity": "sha512-UIpL91XGex3qtL6qwyCQJar2j3osKxK9e3ano3OcGEIRM4oWIpCkDg9x95AXEC2wMs7PnxzOkPZ2gq+tsMS9yg==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.12.1.tgz",
+      "integrity": "sha512-HlMTEdr/LicJfN08LB3nM1rRYliDXOmfoO4vj39xN6BLpFzF00hbwBoqHk8UcJ2M/3nlARZWy/mslvGEuZFvsg==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.0",
-        "babel-code-frame": "^6.26.0",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
-        "debug": "^3.1.0",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^4.0.0",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^4.0.0",
-        "esquery": "^1.0.1",
+        "@babel/code-frame": "^7.0.0",
+        "@eslint/eslintrc": "^0.2.1",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.0",
+        "esquery": "^1.2.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
+        "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.7.0",
-        "ignore": "^4.0.2",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^5.2.0",
-        "is-resolvable": "^1.1.0",
-        "js-yaml": "^3.11.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.5",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
+        "optionator": "^0.9.1",
         "progress": "^2.0.0",
-        "regexpp": "^2.0.0",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.5.0",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
-        "table": "^4.0.3",
-        "text-table": "^0.2.0"
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "color-convert": "^2.0.1"
           }
+        },
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "ignore": {
           "version": "4.0.6",
@@ -9593,48 +9714,103 @@
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+        "import-fresh": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
           }
         },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+        "levn": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+          "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1",
+            "type-check": "~0.4.0"
+          }
+        },
+        "optionator": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+          "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+          "dev": true,
+          "requires": {
+            "deep-is": "^0.1.3",
+            "fast-levenshtein": "^2.0.6",
+            "levn": "^0.4.1",
+            "prelude-ls": "^1.2.1",
+            "type-check": "^0.4.0",
+            "word-wrap": "^1.2.3"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+          "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
           "dev": true
         },
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "lru-cache": "^6.0.0"
           }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-check": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+          "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
         }
       }
     },
     "eslint-config-semistandard": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-semistandard/-/eslint-config-semistandard-13.0.0.tgz",
-      "integrity": "sha512-ZuImKnf/9LeZjr6dtRJ0zEdQbjBwXu0PJR3wXJXoQeMooICMrYPyD70O1tIA9Ng+wutgLjB7UXvZOKYPvzHg+w==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-semistandard/-/eslint-config-semistandard-15.0.1.tgz",
+      "integrity": "sha512-sfV+qNBWKOmF0kZJll1VH5XqOAdTmLlhbOl9WKI11d2eMEe+Kicxnpm24PQWHOqAfk5pAWU2An0LjNCXKa4Usg==",
       "dev": true
     },
     "eslint-config-standard": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
-      "integrity": "sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.0.tgz",
+      "integrity": "sha512-kMCehB9yXIG+LNsu9uXfm06o6Pt63TFAOzn9tUOzw4r/hFIxHhNR1Xomxy+B5zMrXhqyfHVEcmanzttEjGei9w==",
       "dev": true
     },
     "eslint-config-standard-jsx": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-6.0.2.tgz",
-      "integrity": "sha512-D+YWAoXw+2GIdbMBRAzWwr1ZtvnSf4n4yL0gKGg7ShUOGXkSOLerI17K4F6LdQMJPNMoWYqepzQD/fKY+tXNSg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-10.0.0.tgz",
+      "integrity": "sha512-hLeA2f5e06W1xyr/93/QJulN/rLbUVUmqTlexv9PRKHFwEC9ffJcH2LvJhMoEqYQBEYafedgGZXH2W8NUpt5lA==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -9665,24 +9841,15 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
+      "integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.9",
+        "debug": "^3.2.7",
         "pkg-dir": "^2.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -9701,12 +9868,6 @@
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         },
         "p-limit": {
           "version": "1.3.0",
@@ -9750,31 +9911,34 @@
       }
     },
     "eslint-plugin-es": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.1.tgz",
-      "integrity": "sha512-5fa/gR2yR3NxQf+UXkeLeP8FBBl6tSgdrAz1+cF84v1FMM4twGwQoqTnn+QxFLcPOrF4pdKEJKDB/q9GoyJrCA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
       "dev": true,
       "requires": {
-        "eslint-utils": "^1.4.2",
-        "regexpp": "^2.0.1"
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
       }
     },
     "eslint-plugin-import": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
-      "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+      "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
       "dev": true,
       "requires": {
+        "array-includes": "^3.1.1",
+        "array.prototype.flat": "^1.2.3",
         "contains-path": "^0.1.0",
-        "debug": "^2.6.8",
+        "debug": "^2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.1",
-        "eslint-module-utils": "^2.2.0",
-        "has": "^1.0.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.3",
+        "eslint-import-resolver-node": "^0.3.4",
+        "eslint-module-utils": "^2.6.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.1",
         "read-pkg-up": "^2.0.0",
-        "resolve": "^1.6.0"
+        "resolve": "^1.17.0",
+        "tsconfig-paths": "^3.9.0"
       },
       "dependencies": {
         "debug": {
@@ -9911,44 +10075,61 @@
       }
     },
     "eslint-plugin-node": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz",
-      "integrity": "sha512-lfVw3TEqThwq0j2Ba/Ckn2ABdwmL5dkOgAux1rvOk6CO7A6yGyPI2+zIxN6FyNkp1X1X/BSvKOceD6mBWSj4Yw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
+      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
       "dev": true,
       "requires": {
-        "eslint-plugin-es": "^1.3.1",
-        "eslint-utils": "^1.3.1",
-        "ignore": "^4.0.2",
+        "eslint-plugin-es": "^3.0.0",
+        "eslint-utils": "^2.0.0",
+        "ignore": "^5.1.1",
         "minimatch": "^3.0.4",
-        "resolve": "^1.8.1",
-        "semver": "^5.5.0"
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
       },
       "dependencies": {
-        "ignore": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
     },
     "eslint-plugin-promise": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
-      "integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
       "dev": true
     },
     "eslint-plugin-react": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
-      "integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz",
+      "integrity": "sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.0.3",
+        "array-includes": "^3.1.1",
+        "array.prototype.flatmap": "^1.2.3",
         "doctrine": "^2.1.0",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.0.1",
-        "prop-types": "^15.6.2"
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "object.entries": "^1.1.2",
+        "object.fromentries": "^2.0.2",
+        "object.values": "^1.1.1",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.18.1",
+        "string.prototype.matchall": "^4.0.2"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        }
       }
     },
     "eslint-plugin-standard": {
@@ -9958,28 +10139,36 @@
       "dev": true
     },
     "eslint-scope": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
+        "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
       }
     },
     "eslint-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true
     },
     "esm": {
@@ -10006,20 +10195,26 @@
       }
     },
     "espree": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
-      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
       "dev": true,
       "requires": {
-        "acorn": "^6.0.2",
-        "acorn-jsx": "^5.0.0",
-        "eslint-visitor-keys": "^1.0.0"
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
           "dev": true
         }
       }
@@ -10031,9 +10226,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
@@ -10373,17 +10568,6 @@
         }
       }
     },
-    "external-editor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-      "dev": true,
-      "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
-      }
-    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -10590,23 +10774,13 @@
       "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg==",
       "dev": true
     },
-    "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "^1.0.5"
-      }
-    },
     "file-entry-cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "^2.0.1"
       }
     },
     "file-type": {
@@ -10686,12 +10860,6 @@
           "dev": true
         }
       }
-    },
-    "find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-      "dev": true
     },
     "find-up": {
       "version": "4.1.0",
@@ -10881,17 +11049,22 @@
       "dev": true
     },
     "flat-cache": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
-      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "graceful-fs": "^4.1.2",
-        "rimraf": "~2.6.2",
-        "write": "^0.2.1"
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
       },
       "dependencies": {
+        "flatted": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+          "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+          "dev": true
+        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -12221,6 +12394,12 @@
         }
       }
     },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -12823,56 +13002,26 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
-    "inquirer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
-      "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+    "internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.1.0",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^5.5.2",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
           }
         }
       }
@@ -12972,6 +13121,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-bigint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+      "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
       "dev": true
     },
     "is-binary-path": {
@@ -14840,13 +14995,13 @@
       "dev": true
     },
     "jsx-ast-utils": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
-      "integrity": "sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
+      "integrity": "sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.1",
-        "object.assign": "^4.1.0"
+        "array-includes": "^3.1.2",
+        "object.assign": "^4.1.2"
       }
     },
     "just-debounce": {
@@ -16222,12 +16377,6 @@
       "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
       "dev": true
     },
-    "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
-    },
     "nan": {
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
@@ -16800,6 +16949,129 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.18.0-next.1",
         "has": "^1.0.3"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.4.tgz",
+      "integrity": "sha512-EsFBshs5RUUpQEY1D4q/m59kMfz4YJvxuNCJcv/jWwOJr34EaVnG11ZrZa0UHB3wnzV1wx8m58T4hQL8IuNXlQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.2",
+        "has": "^1.0.3"
+      },
+      "dependencies": {
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
+        "es-abstract": {
+          "version": "1.18.3",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+          "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.3",
+            "is-string": "^1.0.6",
+            "object-inspect": "^1.10.3",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.1"
+          },
+          "dependencies": {
+            "has-symbols": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+              "dev": true
+            }
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+          "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-symbols": "^1.0.2"
+          },
+          "dependencies": {
+            "has-symbols": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+              "dev": true
+            }
+          }
+        },
+        "is-string": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+          "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
+          "dev": true
+        },
+        "object-inspect": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+          "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+          "dev": true
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -17501,69 +17773,55 @@
       }
     },
     "pkg-conf": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
-      "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "load-json-file": "^4.0.0"
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
       },
       "dependencies": {
         "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+          "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
+            "graceful-fs": "^4.1.15",
             "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "pify": "^4.0.1",
+            "strip-bom": "^3.0.0",
+            "type-fest": "^0.3.0"
           }
         },
         "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "^2.0.0",
+            "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
           }
         },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
         "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "^2.0.0"
           }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
@@ -17572,9 +17830,9 @@
           "dev": true
         },
         "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         },
         "strip-bom": {
@@ -17582,18 +17840,13 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
+        },
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+          "dev": true
         }
-      }
-    },
-    "pkg-config": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
-      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
-      "dev": true,
-      "requires": {
-        "debug-log": "^1.0.0",
-        "find-root": "^1.0.0",
-        "xtend": "^4.0.1"
       }
     },
     "pkg-dir": {
@@ -17706,12 +17959,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/plural-forms/-/plural-forms-0.5.2.tgz",
       "integrity": "sha512-Tcne7cxK2behLyvEj7iqdfJjr4ji9s9OBxrD/Q/GUHrSP3o2UbwKI0fldQ+Hd7DP6+6RWhKkbpQps5DWvkij/Q=="
-    },
-    "pluralize": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-      "dev": true
     },
     "pn": {
       "version": "1.1.0",
@@ -19691,10 +19938,43 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regexp.prototype.flags": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "dependencies": {
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        }
+      }
+    },
     "regexpp": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true
     },
     "regexpu-core": {
@@ -19960,39 +20240,6 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
-      },
-      "dependencies": {
-        "caller-path": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-          "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-          "dev": true,
-          "requires": {
-            "callsites": "^0.2.0"
-          }
-        },
-        "callsites": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-          "dev": true
-        }
-      }
-    },
     "requizzle": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
@@ -20056,16 +20303,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-    },
-    "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
-      "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
-      }
     },
     "ret": {
       "version": "0.1.15",
@@ -20250,15 +20487,6 @@
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
       "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
       "dev": true
-    },
-    "rxjs": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-      "dev": true,
-      "requires": {
-        "symbol-observable": "1.0.1"
-      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -20679,21 +20907,21 @@
       }
     },
     "semistandard": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/semistandard/-/semistandard-13.0.1.tgz",
-      "integrity": "sha512-2GkuX4BsoMEYoufJYRz8/ERbYDfgOO3yP29IBaoXtxl202azlkV1MsFyoSFiM6GBUfL7MSUxSy38KfM9oDAE2g==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/semistandard/-/semistandard-16.0.0.tgz",
+      "integrity": "sha512-pLETGjFyl0ETMDAEZxkC1OJBmNmPIMpMkayStGTgHMMh/5FM7Rbk5NWc1t7yfQ4PrRURQH8MUg3ZxvojJJifcw==",
       "dev": true,
       "requires": {
-        "eslint": "~5.4.0",
-        "eslint-config-semistandard": "13.0.0",
-        "eslint-config-standard": "12.0.0",
-        "eslint-config-standard-jsx": "6.0.2",
-        "eslint-plugin-import": "~2.14.0",
-        "eslint-plugin-node": "~7.0.1",
-        "eslint-plugin-promise": "~4.0.0",
-        "eslint-plugin-react": "~7.11.1",
-        "eslint-plugin-standard": "~4.0.0",
-        "standard-engine": "~10.0.0"
+        "eslint": "~7.12.1",
+        "eslint-config-semistandard": "15.0.1",
+        "eslint-config-standard": "16.0.0",
+        "eslint-config-standard-jsx": "10.0.0",
+        "eslint-plugin-import": "~2.22.1",
+        "eslint-plugin-node": "~11.1.0",
+        "eslint-plugin-promise": "~4.2.1",
+        "eslint-plugin-react": "~7.21.5",
+        "eslint-plugin-standard": "~4.0.2",
+        "standard-engine": "^14.0.0"
       }
     },
     "semver": {
@@ -20940,6 +21168,30 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "dependencies": {
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        }
+      }
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -21120,11 +21372,13 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "dev": true,
       "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
       },
       "dependencies": {
@@ -21457,21 +21711,21 @@
       "dev": true
     },
     "standard-engine": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-10.0.0.tgz",
-      "integrity": "sha512-91BjmzIRZbFmyOY73R6vaDd/7nw5qDWsfpJW5/N+BCXFgmvreyfrRg7oBSu4ihL0gFGXfnwCImJm6j+sZDQQyw==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-14.0.1.tgz",
+      "integrity": "sha512-7FEzDwmHDOGva7r9ifOzD3BGdTbA7ujJ50afLVdW/tK14zQEptJjbFuUfn50irqdHDcTbNh0DTIoMPynMCXb0Q==",
       "dev": true,
       "requires": {
-        "deglob": "^3.0.0",
-        "get-stdin": "^6.0.0",
-        "minimist": "^1.1.0",
-        "pkg-conf": "^2.0.0"
+        "get-stdin": "^8.0.0",
+        "minimist": "^1.2.5",
+        "pkg-conf": "^3.1.0",
+        "xdg-basedir": "^4.0.0"
       },
       "dependencies": {
         "get-stdin": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+          "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
           "dev": true
         }
       }
@@ -21581,6 +21835,123 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.0"
+      }
+    },
+    "string.prototype.matchall": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.5.tgz",
+      "integrity": "sha512-Z5ZaXO0svs0M2xd/6By3qpeKpLKd9mO4v4q3oMEQrk8Ck4xOD5d5XeBOOjGrmVZZ/AHB1S0CgG4N5r1G9N3E2Q==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.2",
+        "get-intrinsic": "^1.1.1",
+        "has-symbols": "^1.0.2",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.3.1",
+        "side-channel": "^1.0.4"
+      },
+      "dependencies": {
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
+        "es-abstract": {
+          "version": "1.18.3",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+          "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.3",
+            "is-string": "^1.0.6",
+            "object-inspect": "^1.10.3",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.1"
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        },
+        "is-callable": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+          "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-symbols": "^1.0.2"
+          }
+        },
+        "is-string": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+          "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
+          "dev": true
+        },
+        "object-inspect": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+          "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+          "dev": true
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        }
       }
     },
     "string.prototype.trim": {
@@ -22355,12 +22726,6 @@
         "util.promisify": "~1.0.0"
       }
     },
-    "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-      "dev": true
-    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -22368,23 +22733,27 @@
       "dev": true
     },
     "table": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
-      "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "dev": true,
       "requires": {
-        "ajv": "^6.0.1",
-        "ajv-keywords": "^3.0.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
-        "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -22394,22 +22763,23 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
+            "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -23904,6 +24274,35 @@
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
     },
+    "tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
     "tslib": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
@@ -23995,6 +24394,26 @@
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
+    },
+    "unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        }
+      }
     },
     "unbzip2-stream": {
       "version": "1.4.3",
@@ -24724,6 +25143,19 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
     "which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
@@ -24945,9 +25377,9 @@
       "dev": true
     },
     "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
@@ -24968,6 +25400,12 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
       "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==",
+      "dev": true
+    },
+    "xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
     },
     "xhr": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3768,19 +3768,18 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
-      "integrity": "sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
+      "integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
         "espree": "^7.3.0",
-        "globals": "^12.1.0",
+        "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -3795,12 +3794,12 @@
           }
         },
         "globals": {
-          "version": "12.4.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "version": "13.9.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
+          "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
           "dev": true,
           "requires": {
-            "type-fest": "^0.8.1"
+            "type-fest": "^0.20.2"
           }
         },
         "ignore": {
@@ -3826,9 +3825,9 @@
           "dev": true
         },
         "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
       }
@@ -6254,18 +6253,6 @@
         "es-abstract": "^1.18.0-next.1"
       }
     },
-    "array.prototype.flatmap": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz",
-      "integrity": "sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
-        "function-bind": "^1.1.1"
-      }
-    },
     "arrify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
@@ -8222,12 +8209,6 @@
         "bluebird": "^3.1.1"
       }
     },
-    "contains-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
-      "dev": true
-    },
     "content-disposition": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
@@ -9606,29 +9587,31 @@
       }
     },
     "eslint": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.12.1.tgz",
-      "integrity": "sha512-HlMTEdr/LicJfN08LB3nM1rRYliDXOmfoO4vj39xN6BLpFzF00hbwBoqHk8UcJ2M/3nlARZWy/mslvGEuZFvsg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.28.0.tgz",
+      "integrity": "sha512-UMfH0VSjP0G4p3EWirscJEQ/cHqnT/iuH6oNZOB94nBjWbMnhGEPxsZm1eyIW0C/9jLI0Fow4W5DXLjEI7mn1g==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@eslint/eslintrc": "^0.2.1",
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.4.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^2.0.0",
-        "espree": "^7.3.0",
-        "esquery": "^1.2.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^5.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
+        "glob-parent": "^5.1.2",
+        "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -9636,7 +9619,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.19",
+        "lodash.merge": "^4.6.2",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -9645,11 +9628,20 @@
         "semver": "^7.2.1",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
-        "table": "^5.2.3",
+        "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -9693,13 +9685,28 @@
             "ms": "2.1.2"
           }
         },
-        "globals": {
-          "version": "12.4.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "dev": true,
           "requires": {
-            "type-fest": "^0.8.1"
+            "is-glob": "^4.0.1"
+          }
+        },
+        "globals": {
+          "version": "13.9.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
+          "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
           }
         },
         "has-flag": {
@@ -9788,9 +9795,9 @@
           }
         },
         "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
       }
@@ -9802,15 +9809,9 @@
       "dev": true
     },
     "eslint-config-standard": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.0.tgz",
-      "integrity": "sha512-kMCehB9yXIG+LNsu9uXfm06o6Pt63TFAOzn9tUOzw4r/hFIxHhNR1Xomxy+B5zMrXhqyfHVEcmanzttEjGei9w==",
-      "dev": true
-    },
-    "eslint-config-standard-jsx": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-10.0.0.tgz",
-      "integrity": "sha512-hLeA2f5e06W1xyr/93/QJulN/rLbUVUmqTlexv9PRKHFwEC9ffJcH2LvJhMoEqYQBEYafedgGZXH2W8NUpt5lA==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
+      "integrity": "sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -9921,26 +9922,38 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
-      "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+      "version": "2.23.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
+      "integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.1",
-        "array.prototype.flat": "^1.2.3",
-        "contains-path": "^0.1.0",
+        "array-includes": "^3.1.3",
+        "array.prototype.flat": "^1.2.4",
         "debug": "^2.6.9",
-        "doctrine": "1.5.0",
+        "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.4",
-        "eslint-module-utils": "^2.6.0",
+        "eslint-module-utils": "^2.6.1",
+        "find-up": "^2.0.0",
         "has": "^1.0.3",
+        "is-core-module": "^2.4.0",
         "minimatch": "^3.0.4",
-        "object.values": "^1.1.1",
-        "read-pkg-up": "^2.0.0",
-        "resolve": "^1.17.0",
+        "object.values": "^1.1.3",
+        "pkg-up": "^2.0.0",
+        "read-pkg-up": "^3.0.0",
+        "resolve": "^1.20.0",
         "tsconfig-paths": "^3.9.0"
       },
       "dependencies": {
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -9951,13 +9964,44 @@
           }
         },
         "doctrine": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
+            "esutils": "^2.0.2"
+          }
+        },
+        "es-abstract": {
+          "version": "1.18.3",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+          "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.3",
+            "is-string": "^1.0.6",
+            "object-inspect": "^1.10.3",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.1"
+          },
+          "dependencies": {
+            "has-symbols": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+              "dev": true
+            }
           }
         },
         "find-up": {
@@ -9969,15 +10013,65 @@
             "locate-path": "^2.0.0"
           }
         },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+          "dev": true
+        },
+        "is-core-module": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+          "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+          "dev": true,
+          "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "is-regex": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+          "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-symbols": "^1.0.2"
+          },
+          "dependencies": {
+            "has-symbols": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+              "dev": true
+            }
+          }
+        },
+        "is-string": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+          "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
+          "dev": true
+        },
         "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
             "strip-bom": "^3.0.0"
           }
         },
@@ -9996,6 +10090,23 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        },
+        "object-inspect": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+          "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+          "dev": true
+        },
+        "object.values": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+          "integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.18.2"
+          }
         },
         "p-limit": {
           "version": "1.3.0",
@@ -10021,15 +10132,6 @@
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -10037,33 +10139,78 @@
           "dev": true
         },
         "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^2.0.0"
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+          "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.1.0"
           }
         },
         "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^2.0.0",
+            "load-json-file": "^4.0.0",
             "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
             "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
           }
         },
         "strip-bom": {
@@ -10097,45 +10244,9 @@
       }
     },
     "eslint-plugin-promise": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
-      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
-      "dev": true
-    },
-    "eslint-plugin-react": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz",
-      "integrity": "sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.1.1",
-        "array.prototype.flatmap": "^1.2.3",
-        "doctrine": "^2.1.0",
-        "has": "^1.0.3",
-        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "object.entries": "^1.1.2",
-        "object.fromentries": "^2.0.2",
-        "object.values": "^1.1.1",
-        "prop-types": "^15.7.2",
-        "resolve": "^1.18.1",
-        "string.prototype.matchall": "^4.0.2"
-      },
-      "dependencies": {
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        }
-      }
-    },
-    "eslint-plugin-standard": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.2.tgz",
-      "integrity": "sha512-nKptN8l7jksXkwFk++PhJB3cCDTcXOEyhISIN86Ue2feJ1LFyY3PrY3/xT2keXlJSY5bpmbiTG0f885/YKAvTA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.1.0.tgz",
+      "integrity": "sha512-NGmI6BH5L12pl7ScQHbg7tvtk4wPxxj8yPHH47NvSmMtFneC077PSeY3huFj06ZWZvtbfxSPt3RuOQD5XcR4ng==",
       "dev": true
     },
     "eslint-scope": {
@@ -10775,12 +10886,12 @@
       "dev": true
     },
     "file-entry-cache": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "requires": {
-        "flat-cache": "^2.0.1"
+        "flat-cache": "^3.0.4"
       }
     },
     "file-type": {
@@ -11049,31 +11160,13 @@
       "dev": true
     },
     "flat-cache": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
       "dev": true,
       "requires": {
-        "flatted": "^2.0.0",
-        "rimraf": "2.6.3",
-        "write": "1.0.3"
-      },
-      "dependencies": {
-        "flatted": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-          "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
       }
     },
     "flatted": {
@@ -13001,30 +13094,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
-    },
-    "internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.1.0",
-        "has": "^1.0.3",
-        "side-channel": "^1.0.4"
-      },
-      "dependencies": {
-        "get-intrinsic": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1"
-          }
-        }
-      }
     },
     "interpret": {
       "version": "1.4.0",
@@ -14994,16 +15063,6 @@
       "integrity": "sha512-/jsi/9C0S70zfkT/4UlKQa5E1xKurDnXcQizcww9JSR/Fv+uIbWM2btG+bFcL3iNoK9jIGS0ls9HWLr1iw0kFg==",
       "dev": true
     },
-    "jsx-ast-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
-      "integrity": "sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.1.2",
-        "object.assign": "^4.1.2"
-      }
-    },
     "just-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
@@ -15531,6 +15590,12 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -15555,6 +15620,12 @@
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+      "dev": true
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -16951,129 +17022,6 @@
         "has": "^1.0.3"
       }
     },
-    "object.fromentries": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.4.tgz",
-      "integrity": "sha512-EsFBshs5RUUpQEY1D4q/m59kMfz4YJvxuNCJcv/jWwOJr34EaVnG11ZrZa0UHB3wnzV1wx8m58T4hQL8IuNXlQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2",
-        "has": "^1.0.3"
-      },
-      "dependencies": {
-        "call-bind": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1",
-            "get-intrinsic": "^1.0.2"
-          }
-        },
-        "es-abstract": {
-          "version": "1.18.3",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
-          "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "get-intrinsic": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.2",
-            "is-callable": "^1.2.3",
-            "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
-            "object-inspect": "^1.10.3",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.2",
-            "string.prototype.trimend": "^1.0.4",
-            "string.prototype.trimstart": "^1.0.4",
-            "unbox-primitive": "^1.0.1"
-          },
-          "dependencies": {
-            "has-symbols": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-              "dev": true
-            }
-          }
-        },
-        "get-intrinsic": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1"
-          }
-        },
-        "is-callable": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-          "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "has-symbols": "^1.0.2"
-          },
-          "dependencies": {
-            "has-symbols": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-              "dev": true
-            }
-          }
-        },
-        "is-string": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-          "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
-          "dev": true
-        },
-        "object-inspect": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-          "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
-          "dev": true
-        },
-        "string.prototype.trimend": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
-          }
-        },
-        "string.prototype.trimstart": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
-          }
-        }
-      }
-    },
     "object.getownpropertydescriptors": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz",
@@ -17770,83 +17718,6 @@
       "dev": true,
       "requires": {
         "pngjs": "^3.0.0"
-      }
-    },
-    "pkg-conf": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
-      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
-      "dev": true,
-      "requires": {
-        "find-up": "^3.0.0",
-        "load-json-file": "^5.2.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
-          "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.15",
-            "parse-json": "^4.0.0",
-            "pify": "^4.0.1",
-            "strip-bom": "^3.0.0",
-            "type-fest": "^0.3.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        },
-        "type-fest": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
-          "dev": true
-        }
       }
     },
     "pkg-dir": {
@@ -19351,17 +19222,6 @@
         "sisteransi": "^1.0.5"
       }
     },
-    "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -19938,39 +19798,6 @@
         "safe-regex": "^1.1.0"
       }
     },
-    "regexp.prototype.flags": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      },
-      "dependencies": {
-        "call-bind": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1",
-            "get-intrinsic": "^1.0.2"
-          }
-        },
-        "get-intrinsic": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1"
-          }
-        }
-      }
-    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
@@ -20232,6 +20059,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "require-main-filename": {
@@ -20906,24 +20739,6 @@
         }
       }
     },
-    "semistandard": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/semistandard/-/semistandard-16.0.0.tgz",
-      "integrity": "sha512-pLETGjFyl0ETMDAEZxkC1OJBmNmPIMpMkayStGTgHMMh/5FM7Rbk5NWc1t7yfQ4PrRURQH8MUg3ZxvojJJifcw==",
-      "dev": true,
-      "requires": {
-        "eslint": "~7.12.1",
-        "eslint-config-semistandard": "15.0.1",
-        "eslint-config-standard": "16.0.0",
-        "eslint-config-standard-jsx": "10.0.0",
-        "eslint-plugin-import": "~2.22.1",
-        "eslint-plugin-node": "~11.1.0",
-        "eslint-plugin-promise": "~4.2.1",
-        "eslint-plugin-react": "~7.21.5",
-        "eslint-plugin-standard": "~4.0.2",
-        "standard-engine": "^14.0.0"
-      }
-    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -21168,30 +20983,6 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
-    "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      },
-      "dependencies": {
-        "get-intrinsic": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1"
-          }
-        }
-      }
-    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -21372,20 +21163,44 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "astral-regex": "^1.0.0",
-        "is-fullwidth-code-point": "^2.0.0"
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
       },
       "dependencies": {
-        "is-fullwidth-code-point": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "astral-regex": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         }
       }
@@ -21710,26 +21525,6 @@
       "integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=",
       "dev": true
     },
-    "standard-engine": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-14.0.1.tgz",
-      "integrity": "sha512-7FEzDwmHDOGva7r9ifOzD3BGdTbA7ujJ50afLVdW/tK14zQEptJjbFuUfn50irqdHDcTbNh0DTIoMPynMCXb0Q==",
-      "dev": true,
-      "requires": {
-        "get-stdin": "^8.0.0",
-        "minimist": "^1.2.5",
-        "pkg-conf": "^3.1.0",
-        "xdg-basedir": "^4.0.0"
-      },
-      "dependencies": {
-        "get-stdin": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
-          "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
-          "dev": true
-        }
-      }
-    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -21835,123 +21630,6 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.0"
-      }
-    },
-    "string.prototype.matchall": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.5.tgz",
-      "integrity": "sha512-Z5ZaXO0svs0M2xd/6By3qpeKpLKd9mO4v4q3oMEQrk8Ck4xOD5d5XeBOOjGrmVZZ/AHB1S0CgG4N5r1G9N3E2Q==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.2",
-        "get-intrinsic": "^1.1.1",
-        "has-symbols": "^1.0.2",
-        "internal-slot": "^1.0.3",
-        "regexp.prototype.flags": "^1.3.1",
-        "side-channel": "^1.0.4"
-      },
-      "dependencies": {
-        "call-bind": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1",
-            "get-intrinsic": "^1.0.2"
-          }
-        },
-        "es-abstract": {
-          "version": "1.18.3",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
-          "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "get-intrinsic": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.2",
-            "is-callable": "^1.2.3",
-            "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
-            "object-inspect": "^1.10.3",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.2",
-            "string.prototype.trimend": "^1.0.4",
-            "string.prototype.trimstart": "^1.0.4",
-            "unbox-primitive": "^1.0.1"
-          }
-        },
-        "get-intrinsic": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-          "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "has-symbols": "^1.0.2"
-          }
-        },
-        "is-string": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-          "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
-          "dev": true
-        },
-        "object-inspect": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-          "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
-          "dev": true
-        },
-        "string.prototype.trimend": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
-          }
-        },
-        "string.prototype.trimstart": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
-          }
-        }
       }
     },
     "string.prototype.trim": {
@@ -22733,54 +22411,36 @@
       "dev": true
     },
     "table": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
+      "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
       "dev": true,
       "requires": {
-        "ajv": "^6.10.2",
-        "lodash": "^4.17.14",
-        "slice-ansi": "^2.1.0",
-        "string-width": "^3.0.0"
+        "ajv": "^8.0.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+        "ajv": {
+          "version": "8.6.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
+          "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
           }
         },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
         }
       }
     },
@@ -25376,15 +25036,6 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "write": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
-      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-      "dev": true,
-      "requires": {
-        "mkdirp": "^0.5.1"
-      }
-    },
     "write-file-atomic": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
@@ -25400,12 +25051,6 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
       "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==",
-      "dev": true
-    },
-    "xdg-basedir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
     },
     "xhr": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-resolve": "^4.0.1",
     "sass": "^1.34.0",
-    "semistandard": "^13.0.1",
+    "semistandard": "^16.0.0",
     "serve": "^11.3.0",
     "size-limit": "^4.9.0",
     "stylelint": "^13.7.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,12 @@
     "cssnano": "^4.1.10",
     "del": "^5.1.0",
     "enzyme": "^3.11.0",
+    "eslint": "^7.28.0",
+    "eslint-config-semistandard": "^15.0.1",
+    "eslint-config-standard": "^16.0.3",
+    "eslint-plugin-import": "^2.23.4",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^5.1.0",
     "fs-extra": "^9.0.1",
     "generate-license-file": "^1.1.0",
     "gettext-extractor": "^3.5.2",
@@ -81,7 +87,6 @@
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-resolve": "^4.0.1",
     "sass": "^1.34.0",
-    "semistandard": "^16.0.0",
     "serve": "^11.3.0",
     "size-limit": "^4.9.0",
     "stylelint": "^13.7.1",
@@ -96,11 +101,11 @@
     "build-locales": "gulp buildLocales && size-limit",
     "dev": "gulp dev",
     "docs": "jsdoc -R README.md -d docs/ -r src/",
-    "lint": "semistandard",
-    "test": "semistandard && stylelint src/**/*.scss && jest",
+    "lint": "eslint .",
+    "test": "eslint . && stylelint src/**/*.scss && jest",
     "acceptance": "testcafe safari,chrome tests/acceptance/acceptancesuites/*.js",
     "size": "size-limit",
-    "fix": "semistandard --fix",
+    "fix": "eslint . --fix",
     "extract-translations": "gulp extractTranslations",
     "prepublishOnly": "./conf/npm/prepublishOnly.sh",
     "postpublish": "./conf/npm/postpublish.sh",
@@ -127,25 +132,6 @@
       "**/tests/core/**/*.js",
       "**/tests/ui/**/*.js",
       "**/tests/conf/**/*.js"
-    ]
-  },
-  "semistandard": {
-    "globals": [
-      "beforeEach",
-      "beforeAll",
-      "describe",
-      "it",
-      "expect",
-      "jest",
-      "DOMParser",
-      "ytag",
-      "test",
-      "fixture",
-      "CustomEvent",
-      "ANSWERS"
-    ],
-    "ignore": [
-      "docs/"
     ]
   },
   "percy": {

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -142,7 +142,7 @@ class Answers {
         }
       },
       resetListener: data => {
-        let query = data.get(StorageKeys.QUERY);
+        const query = data.get(StorageKeys.QUERY);
         const hasQuery = query || query === '';
         this.core.storage.delete(StorageKeys.PERSISTED_LOCATION_RADIUS);
         this.core.storage.delete(StorageKeys.PERSISTED_FILTER);

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -724,17 +724,17 @@ export default class Core {
    * to use StorageKeys.VERTICAL_PAGES_CONFIG
    */
   _getUrls (query) {
-    let nav = this._componentManager.getActiveComponent('Navigation');
+    const nav = this._componentManager.getActiveComponent('Navigation');
     if (!nav) {
       return undefined;
     }
 
-    let tabs = nav.getState('tabs');
-    let urls = {};
+    const tabs = nav.getState('tabs');
+    const urls = {};
 
     if (tabs && Array.isArray(tabs)) {
       for (let i = 0; i < tabs.length; i++) {
-        let params = new SearchParams(tabs[i].url.split('?')[1]);
+        const params = new SearchParams(tabs[i].url.split('?')[1]);
         params.set('query', query);
 
         let url = tabs[i].baseUrl;

--- a/src/core/errors/errorreporter.js
+++ b/src/core/errors/errorreporter.js
@@ -90,10 +90,10 @@ export default class ErrorReporter {
         version: 20190301,
         environment: this.environment,
         params: {
-          'libVersion': LIB_VERSION,
-          'experienceVersion': this.experienceVersion,
-          'experienceKey': this.experienceKey,
-          'error': err.toJson()
+          libVersion: LIB_VERSION,
+          experienceVersion: this.experienceVersion,
+          experienceKey: this.experienceKey,
+          error: err.toJson()
         }
       };
       const request = new ApiRequest(requestConfig, this.storage);

--- a/src/core/errors/errors.js
+++ b/src/core/errors/errors.js
@@ -12,7 +12,7 @@
  * 4XX errors: Core errors
  */
 export class AnswersBaseError extends Error {
-  constructor (errorCode, message, boundary = 'unknown', causedBy) {
+  constructor (errorCode, message, boundary = 'unknown', causedBy = undefined) {
     super(message);
     this.errorCode = errorCode;
     this.errorMessage = message;

--- a/src/core/eventemitter/eventemitter.js
+++ b/src/core/eventemitter/eventemitter.js
@@ -65,13 +65,13 @@ export default class EventEmitter {
    * @param {Object} data the data to send along to the subscribers
    */
   emit (evt, data) {
-    let listeners = this._listeners[evt];
+    const listeners = this._listeners[evt];
     if (listeners === undefined) {
       return;
     }
 
     // Invoke each of all the listener handlers and remove the ones that should fire only once.
-    let keep = [];
+    const keep = [];
     for (let i = 0; i < listeners.length; i++) {
       listeners[i].cb(data);
       if (listeners[i].once === true) {

--- a/src/core/filters/filterregistry.js
+++ b/src/core/filters/filterregistry.js
@@ -115,9 +115,9 @@ export default class FilterRegistry {
     return filters.length === 1
       ? filters[0]
       : {
-        filters: filters,
-        combinator: combinator
-      };
+          filters: filters,
+          combinator: combinator
+        };
   }
 
   /**

--- a/src/core/filters/simplefilternode.js
+++ b/src/core/filters/simplefilternode.js
@@ -95,7 +95,7 @@ export default class SimpleFilterNode extends FilterNode {
       return false;
     }
     return thisMatchers.every(m =>
-      otherMatchersToValues.hasOwnProperty(m) &&
+      m in otherMatchersToValues &&
       otherMatchersToValues[m] === thisMatchersToValues[m]
     );
   }

--- a/src/core/http/apirequest.js
+++ b/src/core/http/apirequest.js
@@ -14,7 +14,7 @@ import { getLiveApiUrl } from '../utils/urlutils';
 export default class ApiRequest {
   // TODO (tmeyer): Create an ApiService interface and pass an implementation to the current
   // consumers of ApiRequest as a dependency.
-  constructor (opts = {}, storage) {
+  constructor (opts = {}, storage = undefined) {
     /**
      * An abstraction used for making network request and handling errors
      * @type {HttpRequester}

--- a/src/core/http/apirequest.js
+++ b/src/core/http/apirequest.js
@@ -105,15 +105,15 @@ export default class ApiRequest {
    * @private
    */
   baseParams () {
-    let baseParams = {
-      'v': this._version,
-      'api_key': this._apiKey,
-      'jsLibVersion': LIB_VERSION,
-      'sessionTrackingEnabled': this._storage.get(StorageKeys.SESSIONS_OPT_IN).value
+    const baseParams = {
+      v: this._version,
+      api_key: this._apiKey,
+      jsLibVersion: LIB_VERSION,
+      sessionTrackingEnabled: this._storage.get(StorageKeys.SESSIONS_OPT_IN).value
     };
     const urlParams = new SearchParams(this._storage.getCurrentStateUrlMerged());
     if (urlParams.has('beta')) {
-      baseParams['beta'] = urlParams.get('beta');
+      baseParams.beta = urlParams.get('beta');
     }
 
     return baseParams;

--- a/src/core/http/httprequester.js
+++ b/src/core/http/httprequester.js
@@ -50,8 +50,8 @@ export default class HttpRequester {
 
   request (method, url, opts) {
     const reqArgs = Object.assign({}, {
-      'method': method,
-      'credentials': 'include'
+      method: method,
+      credentials: 'include'
     }, opts);
 
     return this._fetch(url, reqArgs);
@@ -89,9 +89,9 @@ export default class HttpRequester {
       return window.navigator.sendBeacon(url, data);
     }
 
-    var event = window.event && window.event.type;
-    var sync = event === 'unload' || event === 'beforeunload';
-    var xhr = ('XMLHttpRequest' in window) ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
+    const event = window.event && window.event.type;
+    const sync = event === 'unload' || event === 'beforeunload';
+    const xhr = ('XMLHttpRequest' in window) ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
     xhr.open('POST', url, !sync);
     xhr.setRequestHeader('Accept', '*/*');
     if (typeof data === 'string') {
@@ -113,7 +113,7 @@ export default class HttpRequester {
     let hasParam = url.indexOf('?') > -1;
 
     let searchQuery = '';
-    for (let key in params) {
+    for (const key in params) {
       if (!hasParam) {
         hasParam = true;
         searchQuery += '?';

--- a/src/core/models/facet.js
+++ b/src/core/models/facet.js
@@ -46,15 +46,15 @@ export default class Facet {
    */
   static fromCore (coreFacets = []) {
     const facets = coreFacets.map(f => ({
-      label: f['displayName'],
-      fieldId: f['fieldId'],
+      label: f.displayName,
+      fieldId: f.fieldId,
       options: f.options.map(o => ({
-        label: o['displayName'],
-        countLabel: o['count'],
-        selected: o['selected'],
+        label: o.displayName,
+        countLabel: o.count,
+        selected: o.selected,
         filter: {
-          [f['fieldId']]: {
-            [o['matcher']]: o['value']
+          [f.fieldId]: {
+            [o.matcher]: o.value
           }
         }
       }))

--- a/src/core/models/filter.js
+++ b/src/core/models/filter.js
@@ -94,7 +94,7 @@ export default class Filter {
    */
   static or (...filters) {
     return new Filter({
-      [ FilterCombinators.OR ]: filters
+      [FilterCombinators.OR]: filters
     });
   }
 
@@ -105,7 +105,7 @@ export default class Filter {
    */
   static and (...filters) {
     return new Filter({
-      [ FilterCombinators.AND ]: filters
+      [FilterCombinators.AND]: filters
     });
   }
 

--- a/src/core/models/highlightedvalue.js
+++ b/src/core/models/highlightedvalue.js
@@ -115,8 +115,8 @@ export default class HighlightedValue {
     }
 
     for (let j = 0; j < highlightedSubstrings.length; j++) {
-      let start = Number(highlightedSubstrings[j].offset);
-      let end = start + highlightedSubstrings[j].length;
+      const start = Number(highlightedSubstrings[j].offset);
+      const end = start + highlightedSubstrings[j].length;
 
       highlightedValue += [
         transformFunction(val.slice(nextStart, start)),

--- a/src/core/models/navigation.js
+++ b/src/core/models/navigation.js
@@ -7,7 +7,7 @@ export default class Navigation {
   }
 
   static from (modules) {
-    let nav = [];
+    const nav = [];
     if (!modules || !Array.isArray(modules)) {
       return nav;
     }

--- a/src/core/models/questionsubmission.js
+++ b/src/core/models/questionsubmission.js
@@ -5,7 +5,7 @@
  * to power the QuestionSubmission component
  */
 export default class QuestionSubmission {
-  constructor (question = {}, errors) {
+  constructor (question = {}, errors = null) {
     /**
      * The author of the question
      * @type {string}

--- a/src/core/models/section.js
+++ b/src/core/models/section.js
@@ -3,7 +3,7 @@
 import SearchStates from '../storage/searchstates';
 
 export default class Section {
-  constructor (data = {}, url, resultsContext) {
+  constructor (data = {}, url = null, resultsContext = undefined) {
     this.searchState = SearchStates.SEARCH_COMPLETE;
     this.verticalConfigId = data.verticalConfigId || null;
     this.resultsCount = data.resultsCount || 0;

--- a/src/core/models/section.js
+++ b/src/core/models/section.js
@@ -21,12 +21,12 @@ export default class Section {
       return {};
     }
 
-    let mapMarkers = [];
+    const mapMarkers = [];
 
     let centerCoordinates = {};
 
     for (let j = 0; j < results.length; j++) {
-      let result = results[j]._raw;
+      const result = results[j]._raw;
       if (result && result.yextDisplayCoordinate) {
         if (!centerCoordinates.latitude) {
           centerCoordinates = {
@@ -44,8 +44,8 @@ export default class Section {
     }
 
     return {
-      'mapCenter': centerCoordinates,
-      'mapMarkers': mapMarkers
+      mapCenter: centerCoordinates,
+      mapMarkers: mapMarkers
     };
   }
 }

--- a/src/core/models/verticalresults.js
+++ b/src/core/models/verticalresults.js
@@ -46,7 +46,7 @@ export default class VerticalResults {
    * @param {string} verticalKeyFromRequest
    * @returns {@link Section}
    */
-  static fromCore (verticalResults, urls = {}, formatters, resultsContext = ResultsContext.NORMAL, verticalKeyFromRequest) {
+  static fromCore (verticalResults, urls = {}, formatters = undefined, resultsContext = ResultsContext.NORMAL, verticalKeyFromRequest = undefined) {
     if (!verticalResults) {
       return new Section();
     }

--- a/src/core/search/searchdatatransformer.js
+++ b/src/core/search/searchdatatransformer.js
@@ -17,7 +17,7 @@ import ResultsContext from '../storage/resultscontext';
  * component library and core storage understand.
  */
 export default class SearchDataTransformer {
-  static transformUniversal (data, urls = {}, formatters) {
+  static transformUniversal (data, urls = {}, formatters = undefined) {
     return {
       [StorageKeys.QUERY_ID]: data.queryId,
       [StorageKeys.NAVIGATION]: Navigation.fromCore(data.verticalResults),

--- a/src/core/services/errorreporterservice.js
+++ b/src/core/services/errorreporterservice.js
@@ -11,5 +11,5 @@ export default class ErrorReporterService {
    * Reports an error to backend servers for logging
    * @param {AnswersBaseError} err The error to be reported
    */
-  report (err) {} // eslint-disable-line handle-callback-err
+  report (err) {} // eslint-disable-line
 }

--- a/src/core/utils/arrayutils.js
+++ b/src/core/utils/arrayutils.js
@@ -16,7 +16,7 @@ export function groupArray (arr, keyFunc, valueFunc, initial) {
     const key = keyFunc(element, idx);
     const value = valueFunc(element, idx);
     if (!groups[key]) {
-      groups[key] = [ value ];
+      groups[key] = [value];
     } else {
       groups[key].push(value);
     }

--- a/src/core/utils/configutils.js
+++ b/src/core/utils/configutils.js
@@ -12,11 +12,11 @@
  * @param {any} defaultValue
  */
 export function defaultConfigOption (config, synonyms, defaultValue) {
-  for (let name of synonyms) {
+  for (const name of synonyms) {
     const accessors = name.split('.');
     let parentConfig = config;
     let skip = false;
-    for (let childConfigAccessor of accessors.slice(0, -1)) {
+    for (const childConfigAccessor of accessors.slice(0, -1)) {
       if (!(childConfigAccessor in parentConfig)) {
         skip = true;
         break;

--- a/src/ui/components/cards/accordioncardcomponent.js
+++ b/src/ui/components/cards/accordioncardcomponent.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-self-assign */
 /** @module AccordionCardComponent */
 
 import Component from '../component';

--- a/src/ui/components/cards/consts.js
+++ b/src/ui/components/cards/consts.js
@@ -1,11 +1,11 @@
 export const cardTemplates = {
-  'Standard': 'cards/standard',
-  'Accordion': 'cards/accordion',
-  'Legacy': 'cards/legacy'
+  Standard: 'cards/standard',
+  Accordion: 'cards/accordion',
+  Legacy: 'cards/legacy'
 };
 
 export const cardTypes = {
-  'Standard': 'StandardCard',
-  'Accordion': 'AccordionCard',
-  'Legacy': 'LegacyCard'
+  Standard: 'StandardCard',
+  Accordion: 'AccordionCard',
+  Legacy: 'LegacyCard'
 };

--- a/src/ui/components/cards/legacycardcomponent.js
+++ b/src/ui/components/cards/legacycardcomponent.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-self-assign */
 /** @module LegacyCardComponent */
 
 import Component from '../component';

--- a/src/ui/components/cards/standardcardcomponent.js
+++ b/src/ui/components/cards/standardcardcomponent.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-self-assign */
 /** @module StandardCardComponent */
 
 import Component from '../component';

--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -285,7 +285,7 @@ export default class Component {
   }
 
   addChild (data, type, opts) {
-    let childComponent = this.componentManager.create(
+    const childComponent = this.componentManager.create(
       type,
       Object.assign({
         name: data.name,
@@ -388,7 +388,7 @@ export default class Component {
 
     // Attach analytics hooks as necessary
     if (this.analyticsReporter) {
-      let domHooks = DOM.queryAll(this._container, '[data-eventtype]:not([data-is-analytics-attached])');
+      const domHooks = DOM.queryAll(this._container, '[data-eventtype]:not([data-is-analytics-attached])');
       domHooks.forEach(this._createAnalyticsHook.bind(this));
     }
 
@@ -439,7 +439,7 @@ export default class Component {
     const prop = dataset.prop;
     let opts = dataset.opts ? JSON.parse(dataset.opts) : {};
 
-    let childData = data[prop] || {};
+    const childData = data[prop] || {};
 
     opts = {
       ...opts,

--- a/src/ui/components/componentmanager.js
+++ b/src/ui/components/componentmanager.js
@@ -117,7 +117,7 @@ export default class ComponentManager {
     // Every component needs local access to the component manager
     // because sometimes components have subcomponents that need to be
     // constructed during creation
-    let systemOpts = {
+    const systemOpts = {
       core: this._core,
       renderer: this._renderer,
       analyticsReporter: this._analyticsReporter,
@@ -126,7 +126,7 @@ export default class ComponentManager {
     };
     this._componentIdCounter++;
 
-    let componentClass = COMPONENT_REGISTRY[componentType];
+    const componentClass = COMPONENT_REGISTRY[componentType];
     if (!componentClass) {
       throw new AnswersComponentError(
         `Component type ${componentType} is not recognized as a valid component.` +
@@ -148,7 +148,7 @@ export default class ComponentManager {
     };
 
     // Instantiate our new component and keep track of it
-    let component =
+    const component =
       new COMPONENT_REGISTRY[componentType](config, systemOpts)
         .init(config);
 

--- a/src/ui/components/ctas/ctacollectioncomponent.js
+++ b/src/ui/components/ctas/ctacollectioncomponent.js
@@ -76,7 +76,7 @@ export default class CTACollectionComponent extends Component {
         parsedCTAs = parsedCTAs.concat(ctaMapping(result));
       } else if (typeof ctaMapping === 'object') {
         const ctaObject = { ...ctaMapping };
-        for (let [ctaAttribute, attributeMapping] of Object.entries(ctaMapping)) {
+        for (const [ctaAttribute, attributeMapping] of Object.entries(ctaMapping)) {
           if (typeof attributeMapping === 'function') {
             ctaObject[ctaAttribute] = attributeMapping(result);
           }

--- a/src/ui/components/ctas/ctacollectioncomponent.js
+++ b/src/ui/components/ctas/ctacollectioncomponent.js
@@ -71,7 +71,7 @@ export default class CTACollectionComponent extends Component {
    */
   static resolveCTAMapping (result, ...ctas) {
     let parsedCTAs = [];
-    ctas.map(ctaMapping => {
+    ctas.forEach(ctaMapping => {
       if (typeof ctaMapping === 'function') {
         parsedCTAs = parsedCTAs.concat(ctaMapping(result));
       } else if (typeof ctaMapping === 'object') {

--- a/src/ui/components/ctas/ctacomponent.js
+++ b/src/ui/components/ctas/ctacomponent.js
@@ -80,7 +80,7 @@ export default class CTAComponent extends Component {
   }
 
   onMount () {
-    const el = DOM.query(this._container, `.js-yxt-CTA`);
+    const el = DOM.query(this._container, '.js-yxt-CTA');
     if (el && this._config.eventOptions) {
       DOM.on(el, 'mousedown', e => {
         if (e.button === 0 || e.button === 1) {

--- a/src/ui/components/ctas/ctacomponent.js
+++ b/src/ui/components/ctas/ctacomponent.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-self-assign */
 /** @module CTAComponent */
 
 import Component from '../component';

--- a/src/ui/components/filters/daterangefiltercomponent.js
+++ b/src/ui/components/filters/daterangefiltercomponent.js
@@ -226,12 +226,12 @@ export default class DateRangeFilterComponent extends Component {
     if (!max) {
       displayValue = this._isExclusive
         ? TranslationFlagger.flag({
-          phrase: 'After [[date]]',
-          context: 'After a date. Example: After [August 15th]',
-          interpolationValues: {
-            date: min
-          }
-        })
+            phrase: 'After [[date]]',
+            context: 'After a date. Example: After [August 15th]',
+            interpolationValues: {
+              date: min
+            }
+          })
         : TranslationFlagger.flag({
           phrase: '[[date]] or later',
           context: 'Beginning at a date (with no end date). Example: [August 15th] or later',
@@ -242,12 +242,12 @@ export default class DateRangeFilterComponent extends Component {
     } else if (!min) {
       displayValue = this._isExclusive
         ? TranslationFlagger.flag({
-          phrase: 'Before [[date]]',
-          context: 'Before a date. Example: Before [August 15th]',
-          interpolationValues: {
-            date: max
-          }
-        })
+            phrase: 'Before [[date]]',
+            context: 'Before a date. Example: Before [August 15th]',
+            interpolationValues: {
+              date: max
+            }
+          })
         : TranslationFlagger.flag({
           phrase: '[[date]] and earlier',
           context: 'Ending at a date with (no start date). Example: [August 15th] or earlier',

--- a/src/ui/components/filters/daterangefiltercomponent.js
+++ b/src/ui/components/filters/daterangefiltercomponent.js
@@ -226,12 +226,12 @@ export default class DateRangeFilterComponent extends Component {
     if (!max) {
       displayValue = this._isExclusive
         ? TranslationFlagger.flag({
-            phrase: 'After [[date]]',
-            context: 'After a date. Example: After [August 15th]',
-            interpolationValues: {
-              date: min
-            }
-          })
+          phrase: 'After [[date]]',
+          context: 'After a date. Example: After [August 15th]',
+          interpolationValues: {
+            date: min
+          }
+        })
         : TranslationFlagger.flag({
           phrase: '[[date]] or later',
           context: 'Beginning at a date (with no end date). Example: [August 15th] or later',
@@ -242,12 +242,12 @@ export default class DateRangeFilterComponent extends Component {
     } else if (!min) {
       displayValue = this._isExclusive
         ? TranslationFlagger.flag({
-            phrase: 'Before [[date]]',
-            context: 'Before a date. Example: Before [August 15th]',
-            interpolationValues: {
-              date: max
-            }
-          })
+          phrase: 'Before [[date]]',
+          context: 'Before a date. Example: Before [August 15th]',
+          interpolationValues: {
+            date: max
+          }
+        })
         : TranslationFlagger.flag({
           phrase: '[[date]] and earlier',
           context: 'Ending at a date with (no start date). Example: [August 15th] or earlier',

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -234,7 +234,7 @@ export default class FacetsComponent extends Component {
   }
 
   setState (data) {
-    let facets = data['filters'] || [];
+    let facets = data.filters || [];
 
     if (this._transformFacets) {
       const facetsCopy = cloneDeep(facets);
@@ -266,7 +266,7 @@ export default class FacetsComponent extends Component {
       // passed to FilterOptionsConfig. Even after deletion here, the filter options will still
       // exist in the 'filters' field of the facets component state, and therefore any
       // modifications which occur to options inside transformFacets will still take effect.
-      filterOptions['options'] && delete filterOptions['options'];
+      filterOptions.options && delete filterOptions.options;
       acc[currentFacet.fieldId] = filterOptions;
       return acc;
     }, {});
@@ -281,7 +281,7 @@ export default class FacetsComponent extends Component {
   _applyDefaultFormatting (facet) {
     const isBooleanFacet = facet => {
       const firstOption = (facet.options && facet.options[0]) || {};
-      return firstOption['value'] === true || firstOption['value'] === false;
+      return firstOption.value === true || firstOption.value === false;
     };
 
     if (isBooleanFacet(facet)) {

--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -176,7 +176,7 @@ export default class FilterBoxComponent extends Component {
     this._filterNodes = [];
 
     this.config.filterConfigs.forEach(config => {
-      let hideCount = config.showCount === undefined ? !this.config.showCount : !config.showCount;
+      const hideCount = config.showCount === undefined ? !this.config.showCount : !config.showCount;
 
       if (hideCount) {
         config.options.forEach(option => {
@@ -252,7 +252,7 @@ export default class FilterBoxComponent extends Component {
     }
 
     // Initialize reset button
-    let resetEl = DOM.query(this._container, '.js-yxt-FilterBox-reset');
+    const resetEl = DOM.query(this._container, '.js-yxt-FilterBox-reset');
 
     if (resetEl) {
       DOM.on(resetEl, 'click', this.resetFilters.bind(this));

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -365,11 +365,11 @@ export default class FilterOptionsComponent extends Component {
 
   onMount () {
     DOM.delegate(
-      DOM.query(this._container, `.yxt-FilterOptions-options`),
+      DOM.query(this._container, '.yxt-FilterOptions-options'),
       this.config.optionSelector,
       'click',
       event => {
-        let selectedCountEl = DOM.query(this._container, '.js-yxt-FilterOptions-selectedCount');
+        const selectedCountEl = DOM.query(this._container, '.js-yxt-FilterOptions-selectedCount');
         if (selectedCountEl) {
           selectedCountEl.innerText = this._getSelectedCount();
         }
@@ -394,7 +394,7 @@ export default class FilterOptionsComponent extends Component {
           this.showMoreState = true;
           showLessEl.classList.add('hidden');
           showMoreEl.classList.remove('hidden');
-          for (let optionEl of optionsOverLimitEls) {
+          for (const optionEl of optionsOverLimitEls) {
             optionEl.classList.add('hidden');
           }
         });
@@ -405,7 +405,7 @@ export default class FilterOptionsComponent extends Component {
           this.showMoreState = false;
           showLessEl.classList.remove('hidden');
           showMoreEl.classList.add('hidden');
-          for (let optionEl of optionsOverLimitEls) {
+          for (const optionEl of optionsOverLimitEls) {
             optionEl.classList.remove('hidden');
           }
         });
@@ -441,7 +441,7 @@ export default class FilterOptionsComponent extends Component {
             clearSearchEl.classList.remove('js-hidden');
           }
 
-          for (let filterOption of filterOptionEls) {
+          for (const filterOption of filterOptionEls) {
             const labelEl = DOM.query(filterOption, '.js-yxt-FilterOptions-optionLabel--name');
             let labelText = labelEl.textContent || labelEl.innerText || '';
             labelText = labelText.trim();
@@ -450,7 +450,7 @@ export default class FilterOptionsComponent extends Component {
               filterOption.classList.remove('displaySearch');
               labelEl.innerHTML = labelText;
             } else {
-              let matchedSubstring = this._getMatchedSubstring(labelText.toLowerCase(), filter.toLowerCase());
+              const matchedSubstring = this._getMatchedSubstring(labelText.toLowerCase(), filter.toLowerCase());
               if (matchedSubstring) {
                 filterOption.classList.add('displaySearch');
                 filterOption.classList.remove('hiddenSearch');
@@ -550,7 +550,7 @@ export default class FilterOptionsComponent extends Component {
     const maxLevenshteinDistance = 1;
     if (filter.length > minFilterSizeForLevenshtein) {
       // Break option into X filter.length size substrings
-      let substrings = [];
+      const substrings = [];
       for (let start = 0; start <= (option.length - filter.length); start++) {
         substrings.push(option.substr(start, filter.length));
       }
@@ -558,8 +558,8 @@ export default class FilterOptionsComponent extends Component {
       // Find the substring that is the closest in levenshtein distance to filter
       let minLevDist = filter.length;
       let minLevSubstring = filter;
-      for (let substring of substrings) {
-        let levDist = this._calcLevenshteinDistance(substring, filter);
+      for (const substring of substrings) {
+        const levDist = this._calcLevenshteinDistance(substring, filter);
         if (levDist < minLevDist) {
           minLevDist = levDist;
           minLevSubstring = substring;

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -347,7 +347,7 @@ export default class FilterOptionsComponent extends Component {
    * @override
    */
   static defaultTemplateName (config) {
-    return `controls/filteroptions`;
+    return 'controls/filteroptions';
   }
 
   setState (data) {

--- a/src/ui/components/map/mapcomponent.js
+++ b/src/ui/components/map/mapcomponent.js
@@ -9,8 +9,8 @@ import StorageKeys from '../../../core/storage/storagekeys';
 import ResultsContext from '../../../core/storage/resultscontext';
 
 const ProviderTypes = {
-  'google': GoogleMapProvider,
-  'mapbox': MapBoxMapProvider
+  google: GoogleMapProvider,
+  mapbox: MapBoxMapProvider
 };
 
 export default class MapComponent extends Component {

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -108,7 +108,7 @@ export default class GoogleMapProvider extends MapProvider {
     // NOTE(billy) This timeout is a hack for dealing with async nature.
     // Only here for demo purposes, so we'll fix later.
     setTimeout(() => {
-      let container = DOM.query(el);
+      const container = DOM.query(el);
       this.map = new google.maps.Map(container, {
         zoom: this._zoom,
         center: this.getCenterMarker(mapData)
@@ -119,14 +119,14 @@ export default class GoogleMapProvider extends MapProvider {
         const collapsedMarkers = this._collapsePins
           ? this._collapseMarkers(mapData.mapMarkers)
           : mapData.mapMarkers;
-        let googleMapMarkerConfigs = GoogleMapMarkerConfig.from(
+        const googleMapMarkerConfigs = GoogleMapMarkerConfig.from(
           collapsedMarkers,
           this._pinConfig,
           this.map);
 
-        let bounds = new google.maps.LatLngBounds();
+        const bounds = new google.maps.LatLngBounds();
         for (let i = 0; i < googleMapMarkerConfigs.length; i++) {
-          let marker = new google.maps.Marker(googleMapMarkerConfigs[i]);
+          const marker = new google.maps.Marker(googleMapMarkerConfigs[i]);
           if (this._onPinClick) {
             marker.addListener('click', () => this._onPinClick(collapsedMarkers[i].item));
           }
@@ -196,7 +196,7 @@ export class GoogleMapMarkerConfig {
    * @returns {string[]}
    */
   static serialize (googleMapMarkerConfigs) {
-    let serializedMarkers = [];
+    const serializedMarkers = [];
     googleMapMarkerConfigs.forEach((marker) => {
       serializedMarkers.push(`markers=label:${marker.label}|${marker.position.lat},${marker.position.lng}`);
     });
@@ -211,7 +211,7 @@ export class GoogleMapMarkerConfig {
    * @returns {GoogleMapMarkerConfig[]}
    */
   static from (markers, pinConfig, map) {
-    let googleMapMarkerConfigs = [];
+    const googleMapMarkerConfigs = [];
     if (!Array.isArray(markers)) {
       markers = [markers];
     }

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -28,7 +28,7 @@ export default class MapBoxMapProvider extends MapProvider {
    * @param {function} onLoad An optional callback to invoke once the JS is loaded.
    */
   loadJS (onLoad) {
-    let script = DOM.createEl('script', {
+    const script = DOM.createEl('script', {
       id: 'yext-map-js',
       onload: () => {
         this._isLoaded = true;
@@ -46,7 +46,7 @@ export default class MapBoxMapProvider extends MapProvider {
       src: 'https://api.mapbox.com/mapbox-gl-js/v0.44.1/mapbox-gl.js'
     });
 
-    let css = DOM.createEl('link', {
+    const css = DOM.createEl('link', {
       id: 'yext-map-css',
       rel: 'stylesheet',
       href: 'https://api.mapbox.com/mapbox-gl-js/v0.44.1/mapbox-gl.css'
@@ -62,7 +62,7 @@ export default class MapBoxMapProvider extends MapProvider {
       return this;
     }
 
-    let container = DOM.query(el);
+    const container = DOM.query(el);
     this._map = new mapboxgl.Map({
       container: container,
       zoom: this._zoom,
@@ -85,11 +85,11 @@ export default class MapBoxMapProvider extends MapProvider {
 
       const bounds = new mapboxgl.LngLatBounds();
       for (let i = 0; i < mapboxMapMarkerConfigs.length; i++) {
-        let wrapper = mapboxMapMarkerConfigs[i].wrapper;
-        let coords = new mapboxgl.LngLat(
+        const wrapper = mapboxMapMarkerConfigs[i].wrapper;
+        const coords = new mapboxgl.LngLat(
           mapboxMapMarkerConfigs[i].position.longitude,
           mapboxMapMarkerConfigs[i].position.latitude);
-        let marker = new mapboxgl.Marker(wrapper).setLngLat(coords);
+        const marker = new mapboxgl.Marker(wrapper).setLngLat(coords);
         bounds.extend(marker.getLngLat());
         marker.addTo(this._map);
         if (this._onPinClick) {
@@ -159,7 +159,7 @@ export class MapBoxMarkerConfig {
    * @returns {string[]}
    */
   static serialize (mapboxMapMarkerConfigs) {
-    let serializedMarkers = [];
+    const serializedMarkers = [];
     mapboxMapMarkerConfigs.forEach((marker) => {
       if (marker.staticMapPin) {
         serializedMarkers.push(`url-${marker.staticMapPin}(${marker.position.longitude},${marker.position.latitude})`);
@@ -178,7 +178,7 @@ export class MapBoxMarkerConfig {
    * @returns {MapBoxMarkerConfig[]}
    */
   static from (markers, pinConfig, map) {
-    let mapboxMapMarkerConfigs = [];
+    const mapboxMapMarkerConfigs = [];
     if (!Array.isArray(markers)) {
       markers = [markers];
     }

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -173,7 +173,7 @@ export default class MapProvider {
     });
 
     const collapsedMarkers = [];
-    for (let [, markers] of Object.entries(locationToItem)) {
+    for (const [, markers] of Object.entries(locationToItem)) {
       if (markers.length > 1) {
         const collapsedMarker = {
           item: markers.map(m => m.item),

--- a/src/ui/components/navigation/navigationcomponent.js
+++ b/src/ui/components/navigation/navigationcomponent.js
@@ -392,7 +392,7 @@ export default class NavigationComponent extends Component {
   // ParentNode.prepend polyfill
   // https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/prepend#Polyfill
   _prepend (collapsedLinks, lastLink) {
-    if (!collapsedLinks.hasOwnProperty('prepend')) {
+    if (!collapsedLinks.hasOwnProperty('prepend')) { // eslint-disable-line no-prototype-builtins
       const docFrag = document.createDocumentFragment();
       const isNode = lastLink instanceof Node;
       docFrag.appendChild(isNode ? lastLink : document.createTextNode(String(lastLink)));
@@ -408,7 +408,7 @@ export default class NavigationComponent extends Component {
   // Adapted from Element.closest polyfill
   // https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill
   _closest (el, closestElSelector) {
-    if (!el.hasOwnProperty('closest')) {
+    if (!el.hasOwnProperty('closest')) { // eslint-disable-line no-prototype-builtins
       do {
         if (DOM.matches(el, closestElSelector)) return el;
         el = el.parentElement || el.parentNode;
@@ -422,10 +422,11 @@ export default class NavigationComponent extends Component {
     switch (this._mobileOverflowBehavior) {
       case MOBILE_OVERFLOW_BEHAVIOR_OPTION.COLLAPSE:
         return true;
-      case MOBILE_OVERFLOW_BEHAVIOR_OPTION.INNERSCROLL:
+      case MOBILE_OVERFLOW_BEHAVIOR_OPTION.INNERSCROLL: {
         const container = DOM.query(this._container, '.yxt-Nav-container') || this._container;
         const navWidth = container.offsetWidth;
         return navWidth > MOBILE_BREAKPOINT;
+      }
     }
   }
 }

--- a/src/ui/components/questions/questionsubmissioncomponent.js
+++ b/src/ui/components/questions/questionsubmissioncomponent.js
@@ -19,19 +19,19 @@ const DEFAULT_CONFIG = {
    * This is typically an organization object
    * @type {number}
    */
-  'entityId': null,
+  entityId: null,
 
   /**
    * The main CSS selector used to reference the form for the component.
    * @type {string} CSS selector
    */
-  'formSelector': 'form',
+  formSelector: 'form',
 
   /**
    * An optional label to use for the e-mail address input
    * @type {string}
    */
-  'emailLabel': TranslationFlagger.flag({
+  emailLabel: TranslationFlagger.flag({
     phrase: 'Email',
     context: 'Labels the email value provided as an argument'
   }),
@@ -40,7 +40,7 @@ const DEFAULT_CONFIG = {
    * An optional label to use for the name input
    * @type {string}
    */
-  'nameLabel': TranslationFlagger.flag({
+  nameLabel: TranslationFlagger.flag({
     phrase: 'Name',
     context: 'Labels the name value provided as an argument'
   }),
@@ -49,7 +49,7 @@ const DEFAULT_CONFIG = {
    * An optional label to use for the question
    * @type {string}
    */
-  'questionLabel': TranslationFlagger.flag({
+  questionLabel: TranslationFlagger.flag({
     phrase: 'Question',
     context: 'Labels the question value provided as an argument'
   }),
@@ -58,7 +58,7 @@ const DEFAULT_CONFIG = {
    * An optional label to use for the Privacy Policy
    * @type {string}
    */
-  'privacyPolicyText': TranslationFlagger.flag({
+  privacyPolicyText: TranslationFlagger.flag({
     phrase: 'By submitting my email address, I consent to being contacted via email at the address provided.'
   }),
 
@@ -66,7 +66,7 @@ const DEFAULT_CONFIG = {
    * The label to use for the Submit button
    * @type {string}
    */
-  'buttonLabel': TranslationFlagger.flag({
+  buttonLabel: TranslationFlagger.flag({
     phrase: 'Submit',
     context: 'Button label'
   }),
@@ -75,7 +75,7 @@ const DEFAULT_CONFIG = {
    * The title to display in the title bar
    * @type {string}
    */
-  'sectionTitle': TranslationFlagger.flag({
+  sectionTitle: TranslationFlagger.flag({
     phrase: 'Ask a Question',
     context: 'Title of section'
   }),
@@ -84,7 +84,7 @@ const DEFAULT_CONFIG = {
    * The description to display in the title bar
    * @type {string}
    */
-  'teaser': TranslationFlagger.flag({
+  teaser: TranslationFlagger.flag({
     phrase: 'Can’t find what you\'re looking for? Ask a question below.'
   }),
 
@@ -92,13 +92,13 @@ const DEFAULT_CONFIG = {
    * The name of the icon to use in the title bar
    * @type {string}
    */
-  'sectionTitleIconName': 'support',
+  sectionTitleIconName: 'support',
 
   /**
    * The text to display in the feedback form ahead of the Question input
    * @type {string}
    */
-  'description': TranslationFlagger.flag({
+  description: TranslationFlagger.flag({
     phrase: 'Enter your question and contact information, and we\'ll get back to you with a response shortly.'
   }),
 
@@ -106,7 +106,7 @@ const DEFAULT_CONFIG = {
    * The placeholder text for required inputs
    * @type {string}
    */
-  'requiredInputPlaceholder': TranslationFlagger.flag({
+  requiredInputPlaceholder: TranslationFlagger.flag({
     phrase: '(required)',
     context: 'Indicates that entering input is mandatory'
   }),
@@ -115,7 +115,7 @@ const DEFAULT_CONFIG = {
    * The placeholder text for the question text area
    * @type {string}
    */
-  'questionInputPlaceholder': TranslationFlagger.flag({
+  questionInputPlaceholder: TranslationFlagger.flag({
     phrase: 'Enter your question here',
     context: 'Placeholder text for input field'
   }),
@@ -124,7 +124,7 @@ const DEFAULT_CONFIG = {
    * The confirmation text to display after successfully submitting feedback
    * @type {string}
    */
-  'questionSubmissionConfirmationText': TranslationFlagger.flag({
+  questionSubmissionConfirmationText: TranslationFlagger.flag({
     phrase: 'Thank you for your question!'
   }),
 
@@ -132,7 +132,7 @@ const DEFAULT_CONFIG = {
    * The default privacy policy url label
    * @type {string}
   */
-  'privacyPolicyUrlLabel': TranslationFlagger.flag({
+  privacyPolicyUrlLabel: TranslationFlagger.flag({
     phrase: 'Learn more here.',
     context: 'Labels a link'
   }),
@@ -141,13 +141,13 @@ const DEFAULT_CONFIG = {
    * The default privacy policy url
    * @type {string}
    */
-  'privacyPolicyUrl': '',
+  privacyPolicyUrl: '',
 
   /**
    * The default privacy policy error text, shown when the user does not agree
    * @type {string}
    */
-  'privacyPolicyErrorText': TranslationFlagger.flag({
+  privacyPolicyErrorText: TranslationFlagger.flag({
     phrase: '* You must agree to the privacy policy to submit a question.'
   }),
 
@@ -155,7 +155,7 @@ const DEFAULT_CONFIG = {
    * The default email format error text, shown when the user submits an invalid email
    * @type {string}
    */
-  'emailFormatErrorText': TranslationFlagger.flag({
+  emailFormatErrorText: TranslationFlagger.flag({
     phrase: '* Please enter a valid email address.'
   }),
 
@@ -164,7 +164,7 @@ const DEFAULT_CONFIG = {
    * request.
    * @type {string}
    */
-  'networkErrorText': TranslationFlagger.flag({
+  networkErrorText: TranslationFlagger.flag({
     phrase: 'We\'re sorry, an error occurred.'
   }),
 
@@ -172,7 +172,7 @@ const DEFAULT_CONFIG = {
    * Whether or not this component is expanded by default.
    * @type {boolean}
    */
-  'expanded': true
+  expanded: true
 };
 
 /**
@@ -268,12 +268,12 @@ export default class QuestionSubmissionComponent extends Component {
   }
 
   onMount () {
-    let triggerEl = DOM.query(this._container, '.js-content-visibility-toggle');
+    const triggerEl = DOM.query(this._container, '.js-content-visibility-toggle');
     if (triggerEl !== null) {
       this.bindFormToggle(triggerEl);
     }
 
-    let formEl = DOM.query(this._container, this._config.formSelector);
+    const formEl = DOM.query(this._container, this._config.formSelector);
     if (formEl === null) {
       return;
     }
@@ -315,17 +315,17 @@ export default class QuestionSubmissionComponent extends Component {
       }
 
       this.core.submitQuestion({
-        'entityId': this._config.entityId,
-        'site': 'FIRSTPARTY',
-        'name': formData.name,
-        'email': formData.email,
-        'questionText': formData.questionText,
-        'questionDescription': formData.questionDescription
+        entityId: this._config.entityId,
+        site: 'FIRSTPARTY',
+        name: formData.name,
+        email: formData.email,
+        questionText: formData.questionText,
+        questionDescription: formData.questionDescription
       })
         .catch(error => {
           this.setState(
             new QuestionSubmission(formData, {
-              'network': 'We\'re sorry, an error occurred.'
+              network: 'We\'re sorry, an error occurred.'
             })
           );
           throw error;
@@ -343,8 +343,9 @@ export default class QuestionSubmissionComponent extends Component {
       this.setState(
         new QuestionSubmission({
           ...formData,
-          'expanded': !formData.questionExpanded,
-          'submitted': formData.questionSubmitted },
+          expanded: !formData.questionExpanded,
+          submitted: formData.questionSubmitted
+        },
         formData.errors));
     });
   }
@@ -361,7 +362,7 @@ export default class QuestionSubmissionComponent extends Component {
       return {};
     }
 
-    let obj = {};
+    const obj = {};
     for (let i = 0; i < inputFields.length; i++) {
       let val = inputFields[i].value;
       if (inputFields[i].type === 'checkbox') {
@@ -379,7 +380,7 @@ export default class QuestionSubmissionComponent extends Component {
    * @returns {Object} errors object if any errors found
    */
   validate (formEl) {
-    let errors = {};
+    const errors = {};
     const fields = DOM.queryAll(formEl, '.js-question-field');
     for (let i = 0; i < fields.length; i++) {
       if (!fields[i].checkValidity()) {
@@ -389,20 +390,20 @@ export default class QuestionSubmissionComponent extends Component {
         }
         switch (fields[i].name) {
           case 'email':
-            errors['emailError'] = true;
+            errors.emailError = true;
             if (!fields[i].validity.valueMissing) {
-              errors['emailErrorText'] = this._config.emailFormatErrorText;
+              errors.emailErrorText = this._config.emailFormatErrorText;
             }
             break;
           case 'name':
-            errors['nameError'] = true;
+            errors.nameError = true;
             break;
           case 'privacyPolicy':
-            errors['privacyPolicyErrorText'] = this._config.privacyPolicyErrorText;
-            errors['privacyPolicyError'] = true;
+            errors.privacyPolicyErrorText = this._config.privacyPolicyErrorText;
+            errors.privacyPolicyError = true;
             break;
           case 'questionText':
-            errors['questionTextError'] = true;
+            errors.questionTextError = true;
             break;
         }
       }

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -135,7 +135,7 @@ export default class AlternativeVerticalsComponent extends Component {
    * @param {object} verticalsConfig the configuration to use
    */
   _buildVerticalSuggestions (alternativeVerticals, verticalsConfig, context, referrerPageUrl) {
-    let verticals = [];
+    const verticals = [];
 
     const params = new SearchParams(this.core.storage.getCurrentStateUrlMerged());
     if (context) {

--- a/src/ui/components/results/directanswercomponent.js
+++ b/src/ui/components/results/directanswercomponent.js
@@ -151,7 +151,7 @@ export default class DirectAnswerComponent extends Component {
 
       this.reportQuality(checkedValue);
       this.updateState({
-        'feedbackSubmitted': true
+        feedbackSubmitted: true
       });
     });
 
@@ -299,7 +299,7 @@ export default class DirectAnswerComponent extends Component {
       fieldName: directAnswer.answer.fieldName,
       fieldType: directAnswer.answer.fieldType
     };
-    for (let [propertyToMatch, propertyValue] of Object.entries(override)) {
+    for (const [propertyToMatch, propertyValue] of Object.entries(override)) {
       if (propertyToMatch === 'cardType') {
         continue;
       }
@@ -349,7 +349,7 @@ export default class DirectAnswerComponent extends Component {
     const eventType = isGood === true ? EventTypes.THUMBS_UP : EventTypes.THUMBS_DOWN;
     const event = new AnalyticsEvent(eventType)
       .addOptions({
-        'directAnswer': true
+        directAnswer: true
       });
 
     this.analyticsReporter.report(event);

--- a/src/ui/components/results/paginationcomponent.js
+++ b/src/ui/components/results/paginationcomponent.js
@@ -227,9 +227,9 @@ export default class PaginationComponent extends Component {
    * @returns {Array<number>} the backLimit and frontLimit, respectively
    */
   _allocate (pageNumber, maxPage, limit) {
-    var backLimit = pageNumber;
-    var frontLimit = pageNumber;
-    for (var i = 0; i < limit; i++) {
+    let backLimit = pageNumber;
+    let frontLimit = pageNumber;
+    for (let i = 0; i < limit; i++) {
       if (i % 2 === 0) {
         if (backLimit > 0) {
           backLimit--;
@@ -258,7 +258,7 @@ export default class PaginationComponent extends Component {
     const [mobileBackLimit, mobileFrontLimit] = this._allocate(pageNumber, maxPage, this._maxVisiblePagesMobile);
     const [desktopBackLimit, desktopFrontLimit] = this._allocate(pageNumber, maxPage, this._maxVisiblePagesDesktop);
     const pageNumberViews = [];
-    for (var i = 1; i <= maxPage; i++) {
+    for (let i = 1; i <= maxPage; i++) {
       const num = { number: i };
       if (i === pageNumber) {
         num.active = true;

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -78,7 +78,7 @@ export default class UniversalResultsComponent extends Component {
     }, val));
   }
 
-  addChild (data = {}, type, opts) {
+  addChild (data = {}, type = undefined, opts = undefined) {
     const verticals = this._config.verticals || this._config.config || {};
     const verticalKey = data.verticalConfigId;
     const childOpts = {

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -348,7 +348,7 @@ export default class VerticalResultsComponent extends Component {
     this.addContainerClass(getContainerClass(searchState));
   }
 
-  setState (data = {}, val) {
+  setState (data = {}, val = undefined) {
     /**
      * @type {Array<Result>}
      */

--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -205,7 +205,7 @@ export default class AutoCompleteComponent extends Component {
    */
   onCreate () {
     // Use the context of the parent component to find the input node.
-    let queryInput = DOM.query(this._parentContainer, this._inputEl);
+    const queryInput = DOM.query(this._parentContainer, this._inputEl);
     if (!queryInput) {
       throw new Error('Could not initialize AutoComplete. Can not find {HTMLElement} `', this._inputEl, '`.');
     }
@@ -248,8 +248,8 @@ export default class AutoCompleteComponent extends Component {
 
     // Allow the user to select a result with the mouse
     DOM.delegate(this._container, '.js-yext-autocomplete-option', 'click', (evt, target) => {
-      let data = target.dataset;
-      let val = data.short;
+      const data = target.dataset;
+      const val = data.short;
 
       this.updateQuery(val);
       this._onSubmit(val, data.filter);
@@ -290,18 +290,18 @@ export default class AutoCompleteComponent extends Component {
     // If one is provided, great.
     // Otherwise, lets try to find it from the current selection in the results.
     if (optValue === undefined) {
-      let sections = this._state.get('sections');
+      const sections = this._state.get('sections');
 
-      let results = sections[this._sectionIndex].results;
+      const results = sections[this._sectionIndex].results;
       optValue = results[this._resultIndex].shortValue;
     }
 
-    let queryEl = DOM.query(this._parentContainer, this._inputEl);
+    const queryEl = DOM.query(this._parentContainer, this._inputEl);
     queryEl.value = optValue;
   }
 
   handleTyping (key, value, e) {
-    let ignoredKeys = [
+    const ignoredKeys = [
       Keys.DOWN,
       Keys.UP,
       Keys.CTRL,
@@ -356,7 +356,7 @@ export default class AutoCompleteComponent extends Component {
     if (!data) {
       return false;
     }
-    let sections = data['sections'];
+    const sections = data.sections;
     if (!sections) {
       return false;
     }
@@ -380,7 +380,7 @@ export default class AutoCompleteComponent extends Component {
   }
 
   handleNavigateResults (key, e) {
-    let sections = this._state.get('sections');
+    const sections = this._state.get('sections');
     if (sections === undefined || sections.length <= 0) {
       return;
     }
@@ -391,7 +391,7 @@ export default class AutoCompleteComponent extends Component {
       return;
     }
 
-    let results = sections[this._sectionIndex].results;
+    const results = sections[this._sectionIndex].results;
     if (key === Keys.UP) {
       e.preventDefault();
       if (this._resultIndex <= 0) {
@@ -433,7 +433,7 @@ export default class AutoCompleteComponent extends Component {
   }
 
   handleSubmitResult (key, value, e) {
-    let sections = this._state.get('sections');
+    const sections = this._state.get('sections');
     if (sections === undefined || sections.length <= 0) {
       if (this.isFilterSearch) {
         this.autoComplete(value);

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -626,9 +626,9 @@ export default class SearchComponent extends Component {
     if (!autocompleteData) {
       const autocompleteRequest = this._verticalKey
         ? this.core.autoCompleteVertical(
-            query,
-            this._autoCompleteName,
-            this._verticalKey)
+          query,
+          this._autoCompleteName,
+          this._verticalKey)
         : this.core.autoCompleteUniversal(query, this._autoCompleteName);
       return autocompleteRequest.then(data => data.inputIntents);
     } else {

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -9,8 +9,8 @@ import QueryUpdateListener from '../../../core/statelisteners/queryupdatelistene
 import QueryTriggers from '../../../core/models/querytriggers';
 
 const IconState = {
-  'YEXT': 0,
-  'MAGNIFYING_GLASS': 1
+  YEXT: 0,
+  MAGNIFYING_GLASS: 1
 };
 
 /**
@@ -459,7 +459,7 @@ export default class SearchComponent extends Component {
     this._container.classList.add('yxt-SearchBar-wrapper');
 
     if (this._useForm) {
-      let form = DOM.query(this._container, formSelector);
+      const form = DOM.query(this._container, formSelector);
       if (!form) {
         throw new Error(
           'Could not initialize SearchBar; Can not find {HTMLElement} `',
@@ -626,9 +626,9 @@ export default class SearchComponent extends Component {
     if (!autocompleteData) {
       const autocompleteRequest = this._verticalKey
         ? this.core.autoCompleteVertical(
-          query,
-          this._autoCompleteName,
-          this._verticalKey)
+            query,
+            this._autoCompleteName,
+            this._verticalKey)
         : this.core.autoCompleteUniversal(query, this._autoCompleteName);
       return autocompleteRequest.then(data => data.inputIntents);
     } else {

--- a/src/ui/components/search/spellcheckcomponent.js
+++ b/src/ui/components/search/spellcheckcomponent.js
@@ -45,7 +45,7 @@ export default class SpellCheckComponent extends Component {
     if (query === undefined) {
       return '';
     }
-    let params = new SearchParams(this.core.storage.getCurrentStateUrlMerged());
+    const params = new SearchParams(this.core.storage.getCurrentStateUrlMerged());
     params.set(StorageKeys.QUERY, query.value);
     params.set(StorageKeys.SKIP_SPELL_CHECK, true);
     params.set(StorageKeys.QUERY_TRIGGER, type.toLowerCase());

--- a/src/ui/dom/dom.js
+++ b/src/ui/dom/dom.js
@@ -98,8 +98,8 @@ export default class DOM {
    * @param {Object} opts_data Optional attributes to apply to the new HTMLElement
    */
   static createEl (el, opts_data = {}) {
-    let node = document.createElement(el);
-    let props = Object.keys(opts_data);
+    const node = document.createElement(el);
+    const props = Object.keys(opts_data);
 
     for (let i = 0; i < props.length; i++) {
       if (props[i] === 'class') {
@@ -136,8 +136,8 @@ export default class DOM {
       return;
     }
 
-    let classes = className.split(',');
-    let len = classes.length;
+    const classes = className.split(',');
+    const len = classes.length;
 
     for (let i = 0; i < len; i++) {
       node.classList.add(classes[i]);
@@ -162,9 +162,9 @@ export default class DOM {
   }
 
   static css (selector, styles) {
-    let node = DOM.query(selector);
+    const node = DOM.query(selector);
 
-    for (let prop in styles) {
+    for (const prop in styles) {
       node.style[prop] = styles[prop];
     }
   }
@@ -179,7 +179,7 @@ export default class DOM {
   }
 
   static trigger (selector, event, settings) {
-    let e = DOM._customEvent(event, settings);
+    const e = DOM._customEvent(event, settings);
     DOM.query(selector).dispatchEvent(e);
   }
 
@@ -210,7 +210,7 @@ export default class DOM {
   }
 
   static delegate (ctxt, selector, evt, handler) {
-    let el = DOM.query(ctxt);
+    const el = DOM.query(ctxt);
     el.addEventListener(evt, function (event) {
       let target = event.target;
       while (!target.isEqualNode(el)) {

--- a/src/ui/dom/searchparams.js
+++ b/src/ui/dom/searchparams.js
@@ -34,7 +34,7 @@ export default class SearchParams {
    * @returns {Object} mapping from query param -> value where value is '' if no value is provided
    */
   parse (url) {
-    let params = {};
+    const params = {};
     let search = url;
 
     if (!search) {
@@ -102,16 +102,16 @@ export default class SearchParams {
    * @return {string}
    */
   toString () {
-    let string = [];
-    for (let key in this._params) {
+    const string = [];
+    for (const key in this._params) {
       string.push(`${key}=${SearchParams.encode(this._params[key])}`);
     }
     return string.join('&');
   }
 
   entries () {
-    let entries = [];
-    for (let key in this._params) {
+    const entries = [];
+    for (const key in this._params) {
       entries.push([key, this._params[key]]);
     }
     return entries;
@@ -132,7 +132,7 @@ export default class SearchParams {
    * @return {string}
    */
   static encode (string) {
-    let replace = {
+    const replace = {
       '!': '%21',
       "'": '%27',
       '(': '%28',

--- a/src/ui/icons/chevron.js
+++ b/src/ui/icons/chevron.js
@@ -2,5 +2,5 @@ import SVGIcon from './icon.js';
 export default new SVGIcon({
   name: 'chevron',
   viewBox: '0 0 7 9',
-  complexContents: `<g fill-rule="evenodd" transform="translate(-1 -8)"><path d="m2.6417004 8-1.1417004 1.0575 3.70850202 3.4425-3.70850202 3.4425 1.1417004 1.0575 4.8582996-4.5z"/></g>`
+  complexContents: '<g fill-rule="evenodd" transform="translate(-1 -8)"><path d="m2.6417004 8-1.1417004 1.0575 3.70850202 3.4425-3.70850202 3.4425 1.1417004 1.0575 4.8582996-4.5z"/></g>'
 });

--- a/src/ui/icons/kabob.js
+++ b/src/ui/icons/kabob.js
@@ -2,5 +2,5 @@ import SVGIcon from './icon.js';
 export default new SVGIcon({
   name: 'kabob',
   viewBox: '0 0 3 11',
-  complexContents: `<circle cx="1.5" cy="1.5" r="1.5"/><circle cx="1.5" cy="5.5" r="1.5"/><circle cx="1.5" cy="9.5" r="1.5"/>`
+  complexContents: '<circle cx="1.5" cy="1.5" r="1.5"/><circle cx="1.5" cy="5.5" r="1.5"/><circle cx="1.5" cy="9.5" r="1.5"/>'
 });

--- a/src/ui/rendering/defaulttemplatesloader.js
+++ b/src/ui/rendering/defaulttemplatesloader.js
@@ -31,7 +31,7 @@ export default class DefaultTemplatesLoader {
 
   fetchTemplates () {
     // If template have already been loaded, do nothing
-    let node = DOM.query('#yext-answers-templates');
+    const node = DOM.query('#yext-answers-templates');
     if (node) {
       return Promise.resolve();
     }
@@ -39,7 +39,7 @@ export default class DefaultTemplatesLoader {
     // Inject a script to fetch the compiled templates,
     // wrapping it a Promise for cleanliness
     return new Promise((resolve, reject) => {
-      let script = DOM.createEl('script', {
+      const script = DOM.createEl('script', {
         id: 'yext-answers-templates',
         onload: resolve,
         onerror: reject,

--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -164,17 +164,17 @@ export default class HandlebarsRenderer extends Renderer {
     });
 
     this.registerHelper('formatPhoneNumber', function (phoneNumberString) {
-      var cleaned = ('' + phoneNumberString).replace(/\D/g, '');
-      var match = cleaned.match(/^(1|)?(\d{3})(\d{3})(\d{4})$/);
+      const cleaned = ('' + phoneNumberString).replace(/\D/g, '');
+      const match = cleaned.match(/^(1|)?(\d{3})(\d{3})(\d{4})$/);
       if (match) {
-        var intlCode = (match[1] ? '+1 ' : '');
+        const intlCode = (match[1] ? '+1 ' : '');
         return [intlCode, '(', match[2], ') ', match[3], '-', match[4]].join('');
       }
       return null;
     });
 
     this.registerHelper('assign', function (name, value, options) {
-      let args = arguments;
+      const args = arguments;
       options = args[args.length - 1];
 
       if (!options.data.root) {
@@ -201,7 +201,7 @@ export default class HandlebarsRenderer extends Renderer {
         : pluralText;
     });
 
-    let self = this;
+    const self = this;
 
     this.registerHelper('processTranslation', function (options) {
       const pluralizationInfo = {};

--- a/src/ui/tools/filterutils.js
+++ b/src/ui/tools/filterutils.js
@@ -37,7 +37,7 @@ export function findSimpleFiltersWithFieldId (persistedFilter, fieldId) {
       childFilter => findSimpleFiltersWithFieldId(Filter.from(childFilter), fieldId));
   }
   if (Filter.from(persistedFilter).getFilterKey() === fieldId) {
-    return [ persistedFilter ];
+    return [persistedFilter];
   }
   return [];
 }

--- a/src/ui/tools/searchparamsparser.js
+++ b/src/ui/tools/searchparamsparser.js
@@ -1,7 +1,7 @@
 /** @module SearchParamsParser */
 
 export default function buildSearchParameters (searchParameterConfigs) {
-  let searchParameters = {
+  const searchParameters = {
     sectioned: false,
     fields: []
   };

--- a/tests/acceptance/acceptancesuites/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuites/acceptancesuite.js
@@ -128,7 +128,7 @@ fixture`Facets page`
   .after(shutdownServer)
   .page`${FACETS_PAGE}`;
 
-test(`Facets load on the page, and can affect the search`, async t => {
+test('Facets load on the page, and can affect the search', async t => {
   const searchComponent = FacetsPage.getSearchComponent();
   await searchComponent.submitQuery();
 
@@ -183,7 +183,7 @@ test(`Facets load on the page, and can affect the search`, async t => {
   await t.expect(actualResultsCount).eql(initialResultsCount);
 });
 
-test(`selecting a sort option and refreshing maintains that sort selection`, async t => {
+test('selecting a sort option and refreshing maintains that sort selection', async t => {
   const searchComponent = FacetsPage.getSearchComponent();
   await searchComponent.submitQuery();
 

--- a/tests/acceptance/acceptancesuites/facetsonload.js
+++ b/tests/acceptance/acceptancesuites/facetsonload.js
@@ -17,7 +17,7 @@ fixture`Facets page`
   .after(shutdownServer)
   .page`${FACETS_PAGE}`;
 
-test(`Facets work with back/forward navigation and page refresh`, async t => {
+test('Facets work with back/forward navigation and page refresh', async t => {
   const logger = RequestLogger({
     url: /v2\/accounts\/me\/answers\/vertical\/query/
   });
@@ -45,10 +45,10 @@ test(`Facets work with back/forward navigation and page refresh`, async t => {
   await filterBox.applyFilters();
   currentFacets = await getFacetsFromRequest();
   const state1 = {
-    'c_puppyPreference': [],
-    'c_employeeDepartment': [{ 'c_employeeDepartment': { '$eq': 'Client Delivery [SO]' } }],
-    'languages': [],
-    'specialities': []
+    c_puppyPreference: [],
+    c_employeeDepartment: [{ c_employeeDepartment: { $eq: 'Client Delivery [SO]' } }],
+    languages: [],
+    specialities: []
   };
   await t.expect(currentFacets).eql(state1);
   logger.clear();
@@ -58,9 +58,9 @@ test(`Facets work with back/forward navigation and page refresh`, async t => {
   await filterBox.applyFilters();
   currentFacets = await getFacetsFromRequest();
   const state2 = {
-    'c_employeeDepartment': [
-      { 'c_employeeDepartment': { '$eq': 'Client Delivery [SO]' } },
-      { 'c_employeeDepartment': { '$eq': 'Technology' } }
+    c_employeeDepartment: [
+      { c_employeeDepartment: { $eq: 'Client Delivery [SO]' } },
+      { c_employeeDepartment: { $eq: 'Technology' } }
     ]
   };
   await t.expect(currentFacets).eql(state2);
@@ -71,13 +71,13 @@ test(`Facets work with back/forward navigation and page refresh`, async t => {
   await filterBox.applyFilters();
   currentFacets = await getFacetsFromRequest();
   const state3 = {
-    'c_puppyPreference': [{ 'c_puppyPreference': { '$eq': 'Frodo' } }],
-    'c_employeeDepartment': [
-      { 'c_employeeDepartment': { '$eq': 'Client Delivery [SO]' } },
-      { 'c_employeeDepartment': { '$eq': 'Technology' } }
+    c_puppyPreference: [{ c_puppyPreference: { $eq: 'Frodo' } }],
+    c_employeeDepartment: [
+      { c_employeeDepartment: { $eq: 'Client Delivery [SO]' } },
+      { c_employeeDepartment: { $eq: 'Technology' } }
     ],
-    'languages': [],
-    'specialities': []
+    languages: [],
+    specialities: []
   };
   await t.expect(currentFacets).eql(state3);
   logger.clear();

--- a/tests/acceptance/acceptancesuites/filterboxsuite.js
+++ b/tests/acceptance/acceptancesuites/filterboxsuite.js
@@ -22,7 +22,7 @@ fixture`FilterBox page`
   .after(shutdownServer)
   .page`${FILTERBOX_PAGE}`;
 
-test(`single option filterbox works with back/forward navigation and page refresh`, async t => {
+test('single option filterbox works with back/forward navigation and page refresh', async t => {
   const radiusFilterLogger = RequestLogger({
     url: /v2\/accounts\/me\/answers\/vertical\/query/
   });
@@ -60,7 +60,7 @@ test(`single option filterbox works with back/forward navigation and page refres
   await expectRequestLocationRadiusToEql(radiusFilterLogger, 40233.6);
 });
 
-test(`multioption filterbox works with back/forward navigation and page refresh`, async t => {
+test('multioption filterbox works with back/forward navigation and page refresh', async t => {
   const filterBoxLogger = RequestLogger({
     url: /v2\/accounts\/me\/answers\/vertical\/query/
   });
@@ -130,7 +130,7 @@ test(`multioption filterbox works with back/forward navigation and page refresh`
   });
 });
 
-test(`locationRadius of 0 is persisted`, async t => {
+test('locationRadius of 0 is persisted', async t => {
   const filterBox = FacetsPage.getStaticFilterBox();
   const radiusFilter = await filterBox.getFilterOptions('DISTANCE');
   await radiusFilter.toggleOption('0 miles');

--- a/tests/acceptance/acceptancesuites/filtersearchsuite.js
+++ b/tests/acceptance/acceptancesuites/filtersearchsuite.js
@@ -16,7 +16,7 @@ fixture`Facets page`
   .after(shutdownServer)
   .page`${FACETS_PAGE}`;
 
-test(`filtersearch works with back/forward navigation and page refresh`, async t => {
+test('filtersearch works with back/forward navigation and page refresh', async t => {
   const expectOnlyFilterTagToEql = async expectedText => {
     await t.expect(filterTags.count).eql(1);
     const filterTagText = await filterTags.nth(0).find(
@@ -56,7 +56,7 @@ test(`filtersearch works with back/forward navigation and page refresh`, async t
   await expectOnlyFilterTagToEql('New York City, New York, United States');
 });
 
-test(`pagination works with page navigation after selecting a filtersearch filter`, async t => {
+test('pagination works with page navigation after selecting a filtersearch filter', async t => {
   const expectFilterTagIsNewYork = async () => {
     await t.expect(filterTags.count).eql(1);
     const filterTagText = await filterTags.nth(0).find(

--- a/tests/acceptance/acceptancesuites/universalinitialsearch.js
+++ b/tests/acceptance/acceptancesuites/universalinitialsearch.js
@@ -12,12 +12,12 @@ fixture`Universal page with default initial search`
   .after(shutdownServer)
   .page`${UNIVERSAL_INITIAL_SEARCH_PAGE}`;
 
-test(`blank defaultInitialSearch will fire on universal if allowEmptySearch is true`, async t => {
+test('blank defaultInitialSearch will fire on universal if allowEmptySearch is true', async t => {
   await Selector('.yxt-Results').with({ visibilityCheck: true })();
   await t.expect(Selector('.yxt-Results').exists).ok();
 });
 
-test(`referrerPageUrl is added to the URL on default initial searches`, async t => {
+test('referrerPageUrl is added to the URL on default initial searches', async t => {
   await Selector('.yxt-Results').with({ visibilityCheck: true })();
   const currentSearchParams = await getCurrentUrlParams();
   const referrerPageUrl = currentSearchParams.has(StorageKeys.REFERRER_PAGE_URL);

--- a/tests/acceptance/acceptancesuites/verticalinitialsearch.js
+++ b/tests/acceptance/acceptancesuites/verticalinitialsearch.js
@@ -12,7 +12,7 @@ fixture`Vertical page with default initial search`
   .after(shutdownServer)
   .page`${FILTERBOX_PAGE}`;
 
-test(`referrerPageUrl is added to the URL on default initial searches`, async t => {
+test('referrerPageUrl is added to the URL on default initial searches', async t => {
   await Selector('.yxt-Results').with({ visibilityCheck: true })();
   const currentSearchParams = await getCurrentUrlParams();
   const referrerPageUrl = currentSearchParams.has(StorageKeys.REFERRER_PAGE_URL);

--- a/tests/acceptance/acceptancesuites/xss.js
+++ b/tests/acceptance/acceptancesuites/xss.js
@@ -13,9 +13,9 @@ fixture`Universal page`
   .after(shutdownServer)
   .page`${UNIVERSAL_PAGE}`;
 
-test(`a universal page's search bar is protected against xss`, async t => {
+test('a universal page\'s search bar is protected against xss', async t => {
   const searchComponent = UniversalPage.getSearchComponent();
-  const xssCode = `window.xssFingerprint = 'gottem!!!'`;
+  const xssCode = 'window.xssFingerprint = \'gottem!!!\'';
   const xssAttackQuery = `"<span><img src=sdf onerror="${xssCode}"`;
   await searchComponent.enterQuery(xssAttackQuery);
   await searchComponent.submitQuery();
@@ -28,9 +28,9 @@ fixture`Vertical page`
   .after(shutdownServer)
   .page`${VERTICAL_PAGE}`;
 
-test(`a vertical page's search bar is protected against xss`, async t => {
+test('a vertical page\'s search bar is protected against xss', async t => {
   const searchComponent = VerticalPage.getSearchComponent();
-  const xssCode = `window.xssFingerprint = 'gottem!!!'`;
+  const xssCode = 'window.xssFingerprint = \'gottem!!!\'';
   const xssAttackQuery = `"<span><img src=sdf onerror="${xssCode}"`;
   await searchComponent.enterQuery(xssAttackQuery);
   await searchComponent.submitQuery();

--- a/tests/acceptance/percysnapshots.js
+++ b/tests/acceptance/percysnapshots.js
@@ -14,5 +14,5 @@ fixture`Percy Snapshots for the Facets Page`
 test.page`http://localhost:9999/tests/acceptance/fixtures/html/facets`(
   'Facets page',
   async t => {
-    await percySnapshot(t, `facets page pre search`);
+    await percySnapshot(t, 'facets page pre search');
   });

--- a/tests/conf/i18n/runtimecallgeneratorutils.js
+++ b/tests/conf/i18n/runtimecallgeneratorutils.js
@@ -6,15 +6,15 @@ describe('generateProcessTranslationJsCall works as expected', () => {
     const interpolationValues = {};
 
     const actualJsCall = generateProcessTranslationJsCall(translation, interpolationValues);
-    const expectedJsCall = `ANSWERS.processTranslation('Bonjour', {})`;
+    const expectedJsCall = 'ANSWERS.processTranslation(\'Bonjour\', {})';
 
     expect(actualJsCall).toEqual(expectedJsCall);
   });
 
   it('translation with plural form', () => {
     const translations = {
-      '0': '[[count]] résultat pour [[verticalName]]',
-      '1': '[[count]] résultats pour [[verticalName]]'
+      0: '[[count]] résultat pour [[verticalName]]',
+      1: '[[count]] résultats pour [[verticalName]]'
     };
     const interpolationValues = {
       count: 'myCount',
@@ -22,7 +22,7 @@ describe('generateProcessTranslationJsCall works as expected', () => {
     };
 
     const actualJsCall = generateProcessTranslationJsCall(translations, interpolationValues, 'myCount');
-    const expectedJsCall = `ANSWERS.processTranslation({0:'[[count]] résultat pour [[verticalName]]',1:'[[count]] résultats pour [[verticalName]]'}, {count:myCount,verticalName:verticalName}, myCount)`;
+    const expectedJsCall = 'ANSWERS.processTranslation({0:\'[[count]] résultat pour [[verticalName]]\',1:\'[[count]] résultats pour [[verticalName]]\'}, {count:myCount,verticalName:verticalName}, myCount)';
 
     expect(actualJsCall).toEqual(expectedJsCall);
   });

--- a/tests/conf/i18n/translatehelpervisitor.js
+++ b/tests/conf/i18n/translatehelpervisitor.js
@@ -5,11 +5,15 @@ const _ = require('lodash');
 
 async function createTranslator () {
   const locale = 'fr';
-  return Translator.create(locale, [], { [locale]: { translation: {
-    'Hello': 'Bonjour',
-    'result': 'résultat',
-    'result_plural': 'résultats'
-  } } });
+  return Translator.create(locale, [], {
+    [locale]: {
+      translation: {
+        Hello: 'Bonjour',
+        result: 'résultat',
+        result_plural: 'résultats'
+      }
+    }
+  });
 }
 
 describe('TranslateHelperVisitor translates visited nodes', () => {
@@ -19,7 +23,7 @@ describe('TranslateHelperVisitor translates visited nodes', () => {
   });
 
   it('static translation', () => {
-    const template = `{{ translate phrase='Hello' }}`;
+    const template = '{{ translate phrase=\'Hello\' }}';
     const ast = Handlebars.parse(template);
 
     new TranslateHelperVisitor(translator).accept(ast);
@@ -30,7 +34,7 @@ describe('TranslateHelperVisitor translates visited nodes', () => {
   });
 
   it('plural translation', () => {
-    const template = `{{ translate phrase='result' pluralForm='results' count=resultCount }}`;
+    const template = '{{ translate phrase=\'result\' pluralForm=\'results\' count=resultCount }}';
     const ast = Handlebars.parse(template);
 
     new TranslateHelperVisitor(translator).accept(ast);
@@ -54,7 +58,7 @@ describe('TranslateHelperVisitor translates visited nodes', () => {
   });
 
   it('a non-translate helper should not be modified', () => {
-    const template = `{{ yext phrase='Hello' }}`;
+    const template = '{{ yext phrase=\'Hello\' }}';
     const ast = Handlebars.parse(template);
     const originalAst = _.cloneDeep(ast);
 

--- a/tests/conf/i18n/translationresolver.js
+++ b/tests/conf/i18n/translationresolver.js
@@ -10,14 +10,18 @@ async function createTranslationResolver () {
 
 async function createTranslator () {
   const locale = 'fr';
-  return Translator.create(locale, [], { [locale]: { translation: {
-    'Hello': 'Bonjour',
-    'result': 'résultat',
-    'result_plural': 'résultats',
-    'object_noun': 'objet',
-    'object_noun_plural': 'objets',
-    'mail_noun': 'courrier'
-  } } });
+  return Translator.create(locale, [], {
+    [locale]: {
+      translation: {
+        Hello: 'Bonjour',
+        result: 'résultat',
+        result_plural: 'résultats',
+        object_noun: 'objet',
+        object_noun_plural: 'objets',
+        mail_noun: 'courrier'
+      }
+    }
+  });
 }
 
 describe('TranslationResolver can resolve various TranslationPlaceholders', () => {
@@ -51,8 +55,8 @@ describe('TranslationResolver can resolve various TranslationPlaceholders', () =
       interpolationValues: {}
     });
     const expectedResult = {
-      '0': 'résultat',
-      '1': 'résultats'
+      0: 'résultat',
+      1: 'résultats'
     };
     const resolverResult = translationResolver.resolve(placeholder);
     expect(resolverResult).toMatchObject(expectedResult);
@@ -68,8 +72,8 @@ describe('TranslationResolver can resolve various TranslationPlaceholders', () =
       interpolationValues: {}
     });
     const expectedResult = {
-      '0': 'objet',
-      '1': 'objets'
+      0: 'objet',
+      1: 'objets'
     };
     const resolverResult = translationResolver.resolve(placeholder);
     expect(resolverResult).toMatchObject(expectedResult);

--- a/tests/conf/i18n/translator.js
+++ b/tests/conf/i18n/translator.js
@@ -186,7 +186,8 @@ describe('translations with one plural form (French)', () => {
         '<a href="https://www.yext.com">View our websites [[name]]</a>');
       const expectedResult = {
         0: '<a href="https://www.yext.com">Voir notre site web [[name]]</a>',
-        1: '<a href="https://www.yext.com">Voir nos sites web [[name]]</a>' };
+        1: '<a href="https://www.yext.com">Voir nos sites web [[name]]</a>'
+      };
       expect(translation).toEqual(expectedResult);
     });
 
@@ -197,7 +198,8 @@ describe('translations with one plural form (French)', () => {
         'internet web, not spider web');
       const expectedResult = {
         0: '<a href="https://www.yext.com">Voir notre site web [[name]]</a>',
-        1: '<a href="https://www.yext.com">Voir nos sites web [[name]]</a>' };
+        1: '<a href="https://www.yext.com">Voir nos sites web [[name]]</a>'
+      };
       expect(translation).toEqual(expectedResult);
     });
   });
@@ -209,7 +211,8 @@ describe('translations with one plural form (French)', () => {
         '([[resultsCount]] results)');
       const expectedResult = {
         0: '([[resultsCount]] résultat)',
-        1: '([[resultsCount]] résultats)' };
+        1: '([[resultsCount]] résultats)'
+      };
       expect(translation).toEqual(expectedResult);
     });
   });

--- a/tests/core/analytics/analyticsreporter.js
+++ b/tests/core/analytics/analyticsreporter.js
@@ -34,7 +34,7 @@ describe('reporting events', () => {
     expect(mockedBeacon).toBeCalledTimes(1);
     expect(mockedBeacon).toBeCalledWith(
       expect.anything(),
-      expect.objectContaining({ 'data': expectedEvent.toApiEvent() }));
+      expect.objectContaining({ data: expectedEvent.toApiEvent() }));
   });
 
   it('includes global options', () => {
@@ -45,7 +45,7 @@ describe('reporting events', () => {
     expect(mockedBeacon).toBeCalledTimes(1);
     expect(mockedBeacon).toBeCalledWith(
       expect.anything(),
-      expect.objectContaining({ 'data': expect.objectContaining({ testOption: 'test' }) }));
+      expect.objectContaining({ data: expect.objectContaining({ testOption: 'test' }) }));
   });
 
   it('includes experienceVersion when supplied', () => {
@@ -56,7 +56,7 @@ describe('reporting events', () => {
     expect(mockedBeacon).toBeCalledTimes(1);
     expect(mockedBeacon).toBeCalledWith(
       expect.anything(),
-      expect.objectContaining({ 'data': expect.objectContaining({ experienceVersion: 'PRODUCTION' }) }));
+      expect.objectContaining({ data: expect.objectContaining({ experienceVersion: 'PRODUCTION' }) }));
   });
 
   it('doesn\'t send cookies by default', () => {

--- a/tests/core/filters/filternodefactory.js
+++ b/tests/core/filters/filternodefactory.js
@@ -119,17 +119,17 @@ describe('FilterNodeFactory', () => {
     filter2 = Filter.from(filter2);
     const node3 = FilterNodeFactory.or(node1, node2);
     const filter3 = Filter.from({
-      [ FilterCombinators.OR ]: [ filter1, filter2 ]
+      [FilterCombinators.OR]: [filter1, filter2]
     });
     expect(node3.getFilter()).toEqual(filter3);
     const node4 = FilterNodeFactory.and(node1, node2);
     const filter4 = Filter.from({
-      [ FilterCombinators.AND ]: [ filter1, filter2 ]
+      [FilterCombinators.AND]: [filter1, filter2]
     });
     expect(node4.getFilter()).toEqual(filter4);
     const rootNode = FilterNodeFactory.and(node1, node3, node4);
     expect(rootNode.getFilter()).toEqual(Filter.from({
-      [ FilterCombinators.AND ]: [ filter1, filter3, filter4 ]
+      [FilterCombinators.AND]: [filter1, filter3, filter4]
     }));
 
     const leafNodes = getLeafNodes(rootNode);
@@ -153,7 +153,7 @@ describe('FilterNodeFactory', () => {
     const orNode = FilterNodeFactory.or(node1, node2, FilterNodeFactory.from({ filter: Filter.empty() }));
     expect(orNode.children).toHaveLength(2);
     const expectedFilter = Filter.from({
-      [FilterCombinators.OR]: [ filter1, filter2 ]
+      [FilterCombinators.OR]: [filter1, filter2]
     });
     expect(orNode.getFilter()).toEqual(expectedFilter);
   });

--- a/tests/core/filters/filterregistry.js
+++ b/tests/core/filters/filterregistry.js
@@ -53,12 +53,12 @@ describe('FilterRegistry', () => {
     const transformedFilter1 = {
       fieldId: 'c_1',
       matcher: '$eq',
-      value: filter1.c_1['$eq']
+      value: filter1.c_1.$eq
     };
     const transformedFilter2 = {
       fieldId: 'c_2',
       matcher: '$eq',
-      value: filter2.c_2['$eq']
+      value: filter2.c_2.$eq
     };
     registry.setStaticFilterNodes('namespace1', node1);
     expect(registry.getStaticFilterNodes()).toHaveLength(1);
@@ -96,18 +96,18 @@ describe('FilterRegistry', () => {
     const transformedFilter1 = {
       fieldId: 'c_1',
       matcher: '$eq',
-      value: filter1.c_1['$eq']
+      value: filter1.c_1.$eq
     };
     const transformedFilter2 = {
       fieldId: 'c_2',
       matcher: '$eq',
-      value: filter2.c_2['$eq']
+      value: filter2.c_2.$eq
     };
     const orNode = FilterNodeFactory.or(node1, node2);
     registry.setStaticFilterNodes('namespace1', orNode);
     expect(registry.getStaticFilterNodes()).toHaveLength(1);
     const expectedFilter1 = {
-      [ FilterCombinators.OR ]: [ filter1, filter2 ]
+      [FilterCombinators.OR]: [filter1, filter2]
     };
     expect(orNode.getFilter()).toEqual(expectedFilter1);
     const expectedTransformedFilter1 = {
@@ -145,7 +145,7 @@ describe('FilterRegistry', () => {
         expectedTransformedFilter1,
         {
           combinator: FilterCombinators.AND,
-          filters: [ transformedFilter1, transformedFilter2 ]
+          filters: [transformedFilter1, transformedFilter2]
         },
         transformedFilter1
       ]
@@ -154,7 +154,7 @@ describe('FilterRegistry', () => {
   });
 
   it('can set facet filter nodes, always overriding previous facets', () => {
-    registry.setFacetFilterNodes([ 'random_field', 'another_field' ], [node1, node2]);
+    registry.setFacetFilterNodes(['random_field', 'another_field'], [node1, node2]);
     const expectedFacets = [
       {
         fieldId: 'random_field',
@@ -196,9 +196,9 @@ describe('FilterRegistry', () => {
     const node3 = FilterNodeFactory.from({
       filter: filter3
     });
-    const facetNodes = [ FilterNodeFactory.or(node1, node3), node2 ];
+    const facetNodes = [FilterNodeFactory.or(node1, node3), node2];
 
-    registry.setFacetFilterNodes([ 'random_field', 'another_field' ], facetNodes);
+    registry.setFacetFilterNodes(['random_field', 'another_field'], facetNodes);
     const expectedFacets = [
       {
         fieldId: 'random_field',
@@ -265,7 +265,7 @@ describe('FilterRegistry', () => {
   });
 
   it('can clear facet filter nodes', () => {
-    registry.setFacetFilterNodes([ 'random_field', 'another_field' ], [node1, node2]);
+    registry.setFacetFilterNodes(['random_field', 'another_field'], [node1, node2]);
     registry.clearFacetFilterNodes();
     expect(registry.getFacetFilterNodes()).toEqual([]);
   });
@@ -285,12 +285,12 @@ describe('FilterRegistry', () => {
   });
 
   it('createFacetsFromFilterNodes', () => {
-    registry.setFacetFilterNodes([ 'random_field', 'another_field' ], [node1, node2]);
+    registry.setFacetFilterNodes(['random_field', 'another_field'], [node1, node2]);
     const expectedFacets = {
-      'another_field': [],
-      'c_1': [{ 'c_1': { '$eq': '1' } }],
-      'c_2': [{ 'c_2': { '$eq': '2' } }],
-      'random_field': []
+      another_field: [],
+      c_1: [{ c_1: { $eq: '1' } }],
+      c_2: [{ c_2: { $eq: '2' } }],
+      random_field: []
     };
     expect(registry.createFacetsFromFilterNodes()).toEqual(expectedFacets);
   });

--- a/tests/core/filters/simplefilternode.js
+++ b/tests/core/filters/simplefilternode.js
@@ -3,10 +3,10 @@ import FilterNodeFactory from '../../../src/core/filters/filternodefactory';
 
 describe('haveEqualSimpleFilters helper', () => {
   const joeFilterNode = FilterNodeFactory.from({
-    filter: { name: { '$eq': 'joe' } }
+    filter: { name: { $eq: 'joe' } }
   });
   const bobFilterNode = FilterNodeFactory.from({
-    filter: { name: { '$eq': 'bob' } }
+    filter: { name: { $eq: 'bob' } }
   });
 
   it('works for equivalent simple filters', () => {
@@ -23,8 +23,8 @@ describe('haveEqualSimpleFilters helper', () => {
     const rangeFilterNode = FilterNodeFactory.from({
       filter: {
         fieldId: {
-          '$ge': 5,
-          '$le': 7
+          $ge: 5,
+          $le: 7
         }
       }
     });
@@ -32,8 +32,8 @@ describe('haveEqualSimpleFilters helper', () => {
     const rangeFilterNodeReverse = FilterNodeFactory.from({
       filter: {
         fieldId: {
-          '$le': 7,
-          '$ge': 5
+          $le: 7,
+          $ge: 5
         }
       }
     });
@@ -44,8 +44,8 @@ describe('haveEqualSimpleFilters helper', () => {
     const rangeFilterNode = FilterNodeFactory.from({
       filter: {
         iamDifferent: {
-          '$ge': 5,
-          '$le': 7
+          $ge: 5,
+          $le: 7
         }
       }
     });
@@ -53,8 +53,8 @@ describe('haveEqualSimpleFilters helper', () => {
     const rangeFilterNodeReverse = FilterNodeFactory.from({
       filter: {
         thanBefore: {
-          '$le': 7,
-          '$ge': 5
+          $le: 7,
+          $ge: 5
         }
       }
     });
@@ -65,9 +65,9 @@ describe('haveEqualSimpleFilters helper', () => {
     const rangeFilterNode = FilterNodeFactory.from({
       filter: {
         aFieldId: {
-          '$eq': 5,
-          '$eq': 5,
-          '$le': 7
+          $eq: 5,
+          $eq: 5,
+          $le: 7
         }
       }
     });
@@ -75,9 +75,9 @@ describe('haveEqualSimpleFilters helper', () => {
     const rangeFilterNodeReverse = FilterNodeFactory.from({
       filter: {
         aFieldId: {
-          '$eq': 5,
-          '$le': 7,
-          '$le': 7
+          $eq: 5,
+          $le: 7,
+          $le: 7
         }
       }
     });

--- a/tests/core/models/filter.js
+++ b/tests/core/models/filter.js
@@ -3,68 +3,68 @@ import Filter from '../../../src/core/models/filter';
 describe('creating filters', () => {
   it('correctly parses filters from the server', () => {
     const serverFilter = '{"name": { "$eq": "Billy Bastardi" }}';
-    const expectedFilter = new Filter({ name: { '$eq': 'Billy Bastardi' } });
+    const expectedFilter = new Filter({ name: { $eq: 'Billy Bastardi' } });
 
     const actualFilter = Filter.fromResponse(serverFilter);
     expect(actualFilter).toEqual(expectedFilter);
   });
 
   it('properly ORs filters together', () => {
-    const filter1 = new Filter({ name: { '$eq': 'Billy Bastardi' } });
-    const filter2 = new Filter({ name: { '$eq': 'Jesse Sharps' } });
-    const expectedFilter = new Filter({ '$or': [filter1, filter2] });
+    const filter1 = new Filter({ name: { $eq: 'Billy Bastardi' } });
+    const filter2 = new Filter({ name: { $eq: 'Jesse Sharps' } });
+    const expectedFilter = new Filter({ $or: [filter1, filter2] });
 
     const actualFilter = Filter.or(filter1, filter2);
     expect(actualFilter).toEqual(expectedFilter);
   });
 
   it('properly ANDs filters together', () => {
-    const filter1 = new Filter({ name: { '$eq': 'Billy Bastardi' } });
-    const filter2 = new Filter({ name: { '$eq': 'Jesse Sharps' } });
-    const expectedFilter = new Filter({ '$and': [filter1, filter2] });
+    const filter1 = new Filter({ name: { $eq: 'Billy Bastardi' } });
+    const filter2 = new Filter({ name: { $eq: 'Jesse Sharps' } });
+    const expectedFilter = new Filter({ $and: [filter1, filter2] });
 
     const actualFilter = Filter.and(filter1, filter2);
     expect(actualFilter).toEqual(expectedFilter);
   });
 
   it('properly creates "equal to" filters', () => {
-    const expectedFilter = new Filter({ name: { '$eq': 'Billy Bastardi' } });
+    const expectedFilter = new Filter({ name: { $eq: 'Billy Bastardi' } });
 
     const actualFilter = Filter.equal('name', 'Billy Bastardi');
     expect(actualFilter).toEqual(expectedFilter);
   });
 
   it('properly creates "less than" filters', () => {
-    const expectedFilter = new Filter({ age: { '$lt': 30 } });
+    const expectedFilter = new Filter({ age: { $lt: 30 } });
 
     const actualFilter = Filter.lessThan('age', 30);
     expect(actualFilter).toEqual(expectedFilter);
   });
 
   it('properly creates "less than or equal to" filters', () => {
-    const expectedFilter = new Filter({ age: { '$le': 30 } });
+    const expectedFilter = new Filter({ age: { $le: 30 } });
 
     const actualFilter = Filter.lessThanEqual('age', 30);
     expect(actualFilter).toEqual(expectedFilter);
   });
 
   it('properly creates "greater than" filters', () => {
-    const expectedFilter = new Filter({ age: { '$gt': 30 } });
+    const expectedFilter = new Filter({ age: { $gt: 30 } });
 
     const actualFilter = Filter.greaterThan('age', 30);
     expect(actualFilter).toEqual(expectedFilter);
   });
 
   it('properly creates "greater than or equal to" filters', () => {
-    const expectedFilter = new Filter({ age: { '$ge': 30 } });
+    const expectedFilter = new Filter({ age: { $ge: 30 } });
 
     const actualFilter = Filter.greaterThanEqual('age', 30);
     expect(actualFilter).toEqual(expectedFilter);
   });
 
   it('properly creates range filters', () => {
-    const expectedInclusiveFilter = new Filter({ 'age': { '$ge': 30, '$le': 40 } });
-    const expectedExclusiveFilter = new Filter({ 'age': { '$gt': 30, '$lt': 40 } });
+    const expectedInclusiveFilter = new Filter({ age: { $ge: 30, $le: 40 } });
+    const expectedExclusiveFilter = new Filter({ age: { $gt: 30, $lt: 40 } });
 
     const actualInclusiveFilter = Filter.inclusiveRange('age', 30, 40);
     expect(actualInclusiveFilter).toEqual(expectedInclusiveFilter);
@@ -74,14 +74,14 @@ describe('creating filters', () => {
   });
 
   it('properly creates generic filters from a given matcher', () => {
-    const expectedFilter = new Filter({ 'myField': { '$myMatcher': 'myValue' } });
+    const expectedFilter = new Filter({ myField: { $myMatcher: 'myValue' } });
 
     const actualFilter = Filter._fromMatcher('myField', '$myMatcher', 'myValue');
     expect(actualFilter).toEqual(expectedFilter);
   });
 
   it('can properly parse the key of a filter', () => {
-    let filter = new Filter({ 'myField': { '$myMatcher': 'myValue' } });
+    let filter = new Filter({ myField: { $myMatcher: 'myValue' } });
     expect(filter.getFilterKey()).toEqual('myField');
     filter = Filter.empty();
     expect(filter.getFilterKey()).toBeFalsy();

--- a/tests/core/models/highlightedvalue.js
+++ b/tests/core/models/highlightedvalue.js
@@ -5,13 +5,13 @@ describe('createing highlighted values', () => {
     const data = {
       key: 'jesse',
       value: 'Jesse Sharps',
-      matchedSubstrings: [ { offset: 8, length: 2 } ]
+      matchedSubstrings: [{ offset: 8, length: 2 }]
     };
 
     const expectedResult = 'Jesse Sh<strong>ar</strong>ps';
     const expectedInvertedResult = '<strong>Jesse Sh</strong>ar<strong>ps</strong>';
 
-    let highlightedValue = new HighlightedValue(data);
+    const highlightedValue = new HighlightedValue(data);
     const result = highlightedValue.get();
     const invertedResult = highlightedValue.getInverted();
 
@@ -23,13 +23,13 @@ describe('createing highlighted values', () => {
     const data = {
       key: 'jesse',
       value: 'Jesse Sharps',
-      matchedSubstrings: [ { offset: 7, length: 4 }, { offset: 1, length: 3 } ]
+      matchedSubstrings: [{ offset: 7, length: 4 }, { offset: 1, length: 3 }]
     };
 
     const expectedResult = 'J<strong>ess</strong>e S<strong>harp</strong>s';
     const expectedInvertedResult = '<strong>J</strong>ess<strong>e S</strong>harp<strong>s</strong>';
 
-    let highlightedValue = new HighlightedValue(data);
+    const highlightedValue = new HighlightedValue(data);
     const result = highlightedValue.get();
     const invertedResult = highlightedValue.getInverted();
 
@@ -41,13 +41,13 @@ describe('createing highlighted values', () => {
     const data = {
       key: 'jesse',
       value: 'Jesse',
-      matchedSubstrings: [ { offset: 0, length: 5 } ]
+      matchedSubstrings: [{ offset: 0, length: 5 }]
     };
 
     const expectedResult = '<strong>Jesse</strong>';
     const expectedInvertedResult = 'Jesse';
 
-    let highlightedValue = new HighlightedValue(data);
+    const highlightedValue = new HighlightedValue(data);
     const result = highlightedValue.get();
     const invertedResult = highlightedValue.getInverted();
 
@@ -61,7 +61,7 @@ describe('createing highlighted values', () => {
     const expectedResult = '';
     const expectedInvertedResult = '';
 
-    let highlightedValue = new HighlightedValue(data);
+    const highlightedValue = new HighlightedValue(data);
     const result = highlightedValue.get();
     const invertedResult = highlightedValue.getInverted();
 
@@ -73,13 +73,13 @@ describe('createing highlighted values', () => {
     const data = {
       key: 'jesse',
       value: 'Jes\'se Sharps',
-      matchedSubstrings: [ { offset: 8, length: 4 }, { offset: 1, length: 4 } ]
+      matchedSubstrings: [{ offset: 8, length: 4 }, { offset: 1, length: 4 }]
     };
 
     const expectedResult = 'J<strong>es%27s</strong>e S<strong>harp</strong>s';
     const expectedInvertedResult = '<strong>J</strong>es%27s<strong>e S</strong>harp<strong>s</strong>';
 
-    let highlightedValue = new HighlightedValue(data);
+    const highlightedValue = new HighlightedValue(data);
     const transformFn = (string) => {
       return string.replace(/'/gi, '%27');
     };

--- a/tests/core/search/searchdatatransformer.js
+++ b/tests/core/search/searchdatatransformer.js
@@ -63,9 +63,9 @@ describe('forming no results response', () => {
       resultsCount: 0,
       facets: [
         {
-          'fieldId': 'c_features',
-          'displayName': 'Features',
-          'options': []
+          fieldId: 'c_features',
+          displayName: 'Features',
+          options: []
         }
       ],
       allResultsForVertical: {
@@ -83,16 +83,16 @@ describe('forming no results response', () => {
         ],
         facets: [
           {
-            'fieldId': 'c_features',
-            'displayName': 'Features',
-            'options': [
+            fieldId: 'c_features',
+            displayName: 'Features',
+            options: [
               {
-                'displayName': 'Dog Friendly',
-                'count': 1,
-                'selected': false,
-                'filter': {
-                  'c_features': {
-                    '$eq': 'Dog Friendly'
+                displayName: 'Dog Friendly',
+                count: 1,
+                selected: false,
+                filter: {
+                  c_features: {
+                    $eq: 'Dog Friendly'
                   }
                 }
               }

--- a/tests/setup/enzymeadapter.js
+++ b/tests/setup/enzymeadapter.js
@@ -186,7 +186,7 @@ function toDomRstNode (domElement) {
   const attr = domElement.attributes;
   for (let i = 0; i < attr.length; i++) {
     if (attr[i].name === 'class') {
-      props['className'] = attr[i].value;
+      props.className = attr[i].value;
       continue;
     }
     props[attr[i].name] = attr[i].value;

--- a/tests/ui/components/component.js
+++ b/tests/ui/components/component.js
@@ -15,8 +15,8 @@ const DEFAULT_TEMPLATE = '<div>This is a default template {{name}}</div>';
 // Our render requires the native handlebars compiler,
 // and the set of precompiled templates for the components to use
 const RENDERER = new HandlebarsRenderer({
-  '_hb': Handlebars,
-  'default': Handlebars.compile(DEFAULT_TEMPLATE)
+  _hb: Handlebars,
+  default: Handlebars.compile(DEFAULT_TEMPLATE)
 });
 
 const COMPONENT_MANAGER = new MockComponentManager();
@@ -32,7 +32,7 @@ describe('rendering component templates', () => {
     const component = COMPONENT_MANAGER.create('Component', {
       data: { name: 'Billy' }
     });
-    let wrapper = render(component);
+    const wrapper = render(component);
     expect(wrapper.text()).toBe('This is a default template Billy');
   });
 
@@ -42,14 +42,14 @@ describe('rendering component templates', () => {
       data: { name: 'Adrian' }
     });
     component.setTemplate(customTemplate);
-    let wrapper = render(component);
+    const wrapper = render(component);
     expect(wrapper.text()).toBe('This is a test template Adrian');
   });
 });
 
 describe('creating subcomponents', () => {
   it('creates subcomponents based on data attributes during mount', () => {
-    const template = `<div data-component="Component" data-prop="child"></div>`;
+    const template = '<div data-component="Component" data-prop="child"></div>';
     const component = COMPONENT_MANAGER.create('Component', {
       data: {
         child: { name: 'Bowen' }
@@ -68,7 +68,7 @@ describe('attaching analytics events', () => {
   });
 
   it('attaches analytics events based on data attributes during mount', () => {
-    const template = `<div id='test' data-eventtype="test_event" data-eventoptions='{"name":"{{name}}"}'>This is a test template</div>`;
+    const template = '<div id=\'test\' data-eventtype="test_event" data-eventoptions=\'{"name":"{{name}}"}\'>This is a test template</div>';
 
     const component = COMPONENT_MANAGER.create(
       'Component',
@@ -112,7 +112,7 @@ describe('attaching analytics events', () => {
   });
 
   it('reports analyticsOptions provided to the component', () => {
-    const template = `<div id='test' data-eventtype="test_event" data-eventoptions='{"name":"{{name}}"}'>This is a test template</div>`;
+    const template = '<div id=\'test\' data-eventtype="test_event" data-eventoptions=\'{"name":"{{name}}"}\'>This is a test template</div>';
 
     const component = COMPONENT_MANAGER.create(
       'Component',

--- a/tests/ui/components/filters/filterboxcomponent.js
+++ b/tests/ui/components/filters/filterboxcomponent.js
@@ -154,8 +154,8 @@ describe('filter box component', () => {
     it('can save simple filternodes', () => {
       const component = COMPONENT_MANAGER.create('FilterBox', config);
       mount(component);
-      let child0 = component._filterComponents[0];
-      let child1 = component._filterComponents[1];
+      const child0 = component._filterComponents[0];
+      const child1 = component._filterComponents[1];
       child0._updateOption(0, true);
       expect(child0.getFilterNode().getFilter()).toEqual(nodes0[0].getFilter());
       expect(child0.getFilterNode().getMetadata()).toEqual(nodes0[0].getMetadata());
@@ -169,8 +169,8 @@ describe('filter box component', () => {
     it('can save combined filternodes', () => {
       const component = COMPONENT_MANAGER.create('FilterBox', config);
       mount(component);
-      let child0 = component._filterComponents[0];
-      let child1 = component._filterComponents[1];
+      const child0 = component._filterComponents[0];
+      const child1 = component._filterComponents[1];
       child0._updateOption(0, true);
       child1._updateOption(0, true);
       child1._updateOption(3, true);
@@ -321,14 +321,14 @@ describe('filter box component', () => {
       expect(setStaticFilterNodes).toHaveBeenCalledTimes(1);
       expect(setStaticFilterNodes.mock.calls[0][1]).toMatchObject({
         filter: {
-          'witcher': {
-            '$eq': 'cirilla'
+          witcher: {
+            $eq: 'cirilla'
           }
         },
         metadata: {
-          'displayValue': 'ciri',
-          'fieldName': 'first filter options',
-          'filterType': 'filter-type-static'
+          displayValue: 'ciri',
+          fieldName: 'first filter options',
+          filterType: 'filter-type-static'
         }
       });
       setStaticFilterNodes.mockClear();

--- a/tests/ui/components/filters/filteroptionscomponent.js
+++ b/tests/ui/components/filters/filteroptionscomponent.js
@@ -319,7 +319,7 @@ describe('filter options component', () => {
     };
     expect(setStaticFilterNodes.mock.calls).toHaveLength(0);
     const component = COMPONENT_MANAGER.create('FilterOptions', config);
-    let filterNode = component.getFilterNode();
+    const filterNode = component.getFilterNode();
     expect(filterNode.getFilter()).toEqual(FilterNodeFactory.from().getFilter());
     expect(filterNode.getMetadata()).toEqual(FilterNodeFactory.from().getMetadata());
     expect(setStaticFilterNodes.mock.calls).toHaveLength(1);

--- a/tests/ui/components/filters/sortoptionscomponent.js
+++ b/tests/ui/components/filters/sortoptionscomponent.js
@@ -192,7 +192,7 @@ describe('sort options component', () => {
     };
     const setSortBys = jest.fn();
     COMPONENT_MANAGER.core.setSortBys = setSortBys;
-    COMPONENT_MANAGER.core.storage.setWithPersist(StorageKeys.SORT_BYS, [ threeOptions[1] ]);
+    COMPONENT_MANAGER.core.storage.setWithPersist(StorageKeys.SORT_BYS, [threeOptions[1]]);
     const component = COMPONENT_MANAGER.create('SortOptions', opts);
     const wrapper = mount(component);
     expect(setSortBys).toHaveBeenCalledTimes(0);

--- a/tests/ui/components/map/providers/mapboxmapprovider.js
+++ b/tests/ui/components/map/providers/mapboxmapprovider.js
@@ -1,7 +1,7 @@
 import { MapBoxMarkerConfig } from '../../../../../src/ui/components/map/providers/mapboxmapprovider';
 
 const map = { tmp: 'test value' };
-const wrapper = `<button>this is the pin</button>`;
+const wrapper = '<button>this is the pin</button>';
 
 describe('create MapBoxMarkerConfig', () => {
   it('constructs a MapBoxMarkerConfig with provided options', () => {
@@ -14,7 +14,7 @@ describe('create MapBoxMarkerConfig', () => {
     const expected = {
       map: map,
       position: { latitude: 91.234, longitude: 71.578 },
-      wrapper: `<button>this is the pin</button>`
+      wrapper: '<button>this is the pin</button>'
     };
 
     expect(mapboxMarkerConfig).toMatchObject(expected);
@@ -110,7 +110,7 @@ describe('converts array of markers into MapboxMarkers', () => {
     ];
 
     const pinConfig = {
-      wrapper: `<button>this is the pin</button>`
+      wrapper: '<button>this is the pin</button>'
     };
 
     const actual = MapBoxMarkerConfig.from(markers, pinConfig, map);
@@ -144,7 +144,7 @@ describe('converts array of markers into MapboxMarkers', () => {
           latitude: 44,
           longitude: 45
         },
-        wrapper: `<svg><tspan>1</tspan></svg>`,
+        wrapper: '<svg><tspan>1</tspan></svg>',
         label: '1'
       }),
       new MapBoxMarkerConfig({
@@ -153,7 +153,7 @@ describe('converts array of markers into MapboxMarkers', () => {
           latitude: 44,
           longitude: 45
         },
-        wrapper: `<svg><tspan>2</tspan></svg>`,
+        wrapper: '<svg><tspan>2</tspan></svg>',
         label: '2'
       })
     ];

--- a/tests/ui/components/map/providers/mapprovider.js
+++ b/tests/ui/components/map/providers/mapprovider.js
@@ -55,12 +55,12 @@ describe('can show/hide map behavior for no results with blank map data', () => 
     const visibleForNoResults = undefined;
     const mapData = { mapMarkers: [1] };
     it('shows map if showEmptyMap is true and tehre is no mapt data', () => {
-      let showEmptyMap = true;
+      const showEmptyMap = true;
       expect(MapProvider.shouldHideMap(null, resultsContext, showEmptyMap, visibleForNoResults)).toBeFalsy();
     });
 
     it('hides map if showEmptyMap is false and there is no map data', () => {
-      let showEmptyMap = false;
+      const showEmptyMap = false;
       expect(MapProvider.shouldHideMap(null, resultsContext, showEmptyMap, visibleForNoResults)).toBeTruthy();
     });
 

--- a/tests/ui/components/navigation/navigationcomponent.js
+++ b/tests/ui/components/navigation/navigationcomponent.js
@@ -14,7 +14,7 @@ DOM.setup(
 
 beforeEach(() => {
   // Always reset the DOM before each component render test
-  let bodyEl = DOM.query('body');
+  const bodyEl = DOM.query('body');
   DOM.empty(bodyEl);
 
   // Create the container that our component will be injected into

--- a/tests/ui/components/navigation/navigationcomponent.js
+++ b/tests/ui/components/navigation/navigationcomponent.js
@@ -190,8 +190,6 @@ describe('navigation tab links are correct', () => {
 });
 
 describe('navigation tab order', () => {
-  let COMPONENT_MANAGER;
-
   const defaultConfig = {
     container: '#test-component',
     verticalKey: 'verticalKey',
@@ -202,7 +200,7 @@ describe('navigation tab order', () => {
     ]
   };
 
-  COMPONENT_MANAGER = mockManager();
+  const COMPONENT_MANAGER = mockManager();
 
   COMPONENT_MANAGER.getComponentNamesForComponentTypes = () => [];
 

--- a/tests/ui/components/results/directanswercomponent.js
+++ b/tests/ui/components/results/directanswercomponent.js
@@ -51,10 +51,10 @@ describe('types logic works properly', () => {
       ...defaultConfig,
       defaultCard: 'default-card',
       types: {
-        'FEATURED_SNIPPET': {
+        FEATURED_SNIPPET: {
           cardType: 'documentsearch-standard'
         },
-        'FIELD_VALUE': {
+        FIELD_VALUE: {
           cardType: 'allfields-standard'
         }
       }
@@ -68,7 +68,7 @@ describe('types logic works properly', () => {
       ...defaultConfig,
       defaultCard: 'default-card',
       types: {
-        'FEATURED_SNIPPET': {
+        FEATURED_SNIPPET: {
           cardType: 'custom-card'
         }
       }
@@ -82,7 +82,7 @@ describe('types logic works properly', () => {
       ...defaultConfig,
       defaultCard: 'default-card',
       types: {
-        'FIELD_VALUE': {
+        FIELD_VALUE: {
           cardType: 'custom-card',
           cardOverrides: [
             {
@@ -102,7 +102,7 @@ describe('types logic works properly', () => {
       ...defaultConfig,
       defaultCard: 'default-card',
       types: {
-        'FIELD_VALUE': {
+        FIELD_VALUE: {
           cardType: 'custom-card',
           cardOverrides: [
             {
@@ -126,7 +126,7 @@ describe('types logic works properly', () => {
       ...defaultConfig,
       defaultCard: 'default-card',
       types: {
-        'FIELD_VALUE': {
+        FIELD_VALUE: {
           cardType: 'custom-card',
           cardOverrides: [
             {
@@ -147,7 +147,7 @@ describe('types logic works properly', () => {
         ...defaultConfig,
         defaultCard: 'default-card',
         types: {
-          'FIELD_VALUE': {
+          FIELD_VALUE: {
             cardType: 'custom-card',
             cardOverrides: [
               {
@@ -168,7 +168,7 @@ describe('types logic works properly', () => {
       ...defaultConfig,
       defaultCard: 'default-card',
       types: {
-        'FIELD_VALUE': {
+        FIELD_VALUE: {
           cardType: 'custom-card'
         }
       },

--- a/tests/ui/components/results/resultsheadercomponent.js
+++ b/tests/ui/components/results/resultsheadercomponent.js
@@ -63,11 +63,11 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
   });
 
   it('works with simpleFilterNodes, removable = false by default', () => {
-    const simpleFilterNodes = [ node_f0_v0, node_f0_v1, node_f1_v0 ];
+    const simpleFilterNodes = [node_f0_v0, node_f0_v1, node_f1_v0];
     resultsHeaderComponent.appliedFilterNodes = simpleFilterNodes;
     const groupedFilters = resultsHeaderComponent._groupAppliedFilters();
     expect(Object.keys(groupedFilters)).toHaveLength(2);
-    expect(groupedFilters['name0']).toEqual([
+    expect(groupedFilters.name0).toEqual([
       {
         displayValue: 'display0',
         dataFilterId: 0,
@@ -79,7 +79,7 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
         removable: false
       }
     ]);
-    expect(groupedFilters['name1']).toEqual([
+    expect(groupedFilters.name1).toEqual([
       {
         displayValue: 'display0',
         dataFilterId: 2,
@@ -89,21 +89,21 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
   });
 
   it('duplicate display values should still be repeated', () => {
-    const simpleFilterNodes = [ node_f1_v1, node_f1_v1 ];
+    const simpleFilterNodes = [node_f1_v1, node_f1_v1];
     resultsHeaderComponent.appliedFilterNodes = simpleFilterNodes;
     const groupedFilters = resultsHeaderComponent._groupAppliedFilters();
     expect(Object.keys(groupedFilters)).toHaveLength(1);
-    expect(groupedFilters['name1']).toHaveLength(2);
+    expect(groupedFilters.name1).toHaveLength(2);
   });
 
   it('nlp filter nodes that are duplicates are removed', () => {
-    const appliedFilterNodes = [ node_f0_v0, node_f1_v0 ];
-    const nlpFilterNodes = [ node_f0_v0, node_f0_v1, node_f1_v0 ];
+    const appliedFilterNodes = [node_f0_v0, node_f1_v0];
+    const nlpFilterNodes = [node_f0_v0, node_f0_v1, node_f1_v0];
     resultsHeaderComponent.appliedFilterNodes = appliedFilterNodes;
     resultsHeaderComponent.nlpFilterNodes = nlpFilterNodes;
     const groupedFilters = resultsHeaderComponent._groupAppliedFilters();
     expect(Object.keys(groupedFilters)).toHaveLength(2);
-    expect(groupedFilters['name0']).toEqual([
+    expect(groupedFilters.name0).toEqual([
       {
         displayValue: 'display0',
         dataFilterId: 0,
@@ -113,7 +113,7 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
         displayValue: 'display1'
       }
     ]);
-    expect(groupedFilters['name1']).toEqual([
+    expect(groupedFilters.name1).toEqual([
       {
         displayValue: 'display0',
         dataFilterId: 1,
@@ -123,12 +123,12 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
   });
 
   it('can display removable filters', () => {
-    const simpleFilterNodes = [ node_f0_v0, node_f0_v1, node_f1_v0 ];
+    const simpleFilterNodes = [node_f0_v0, node_f0_v1, node_f1_v0];
     resultsHeaderComponent._config.removable = true;
     resultsHeaderComponent.appliedFilterNodes = simpleFilterNodes;
     const groupedFilters = resultsHeaderComponent._groupAppliedFilters();
     expect(Object.keys(groupedFilters)).toHaveLength(2);
-    expect(groupedFilters['name0']).toEqual([
+    expect(groupedFilters.name0).toEqual([
       {
         displayValue: 'display0',
         dataFilterId: 0,
@@ -140,7 +140,7 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
         removable: true
       }
     ]);
-    expect(groupedFilters['name1']).toEqual([
+    expect(groupedFilters.name1).toEqual([
       {
         displayValue: 'display0',
         dataFilterId: 2,
@@ -161,7 +161,7 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
     COMPONENT_MANAGER = mockManager({
       triggerSearch: triggerSearchFn,
       filterRegistry: {
-        getAllFilterNodes: () => [ node_f0_v0, node_f0_v1, node_f1_v0 ]
+        getAllFilterNodes: () => [node_f0_v0, node_f0_v1, node_f1_v0]
       }
     });
 

--- a/tests/ui/components/search/searchcomponent.js
+++ b/tests/ui/components/search/searchcomponent.js
@@ -13,7 +13,7 @@ describe('SearchBar component', () => {
   };
   let COMPONENT_MANAGER, storage;
   beforeEach(() => {
-    let bodyEl = DOM.query('body');
+    const bodyEl = DOM.query('body');
     DOM.empty(bodyEl);
     DOM.append(bodyEl, DOM.createEl('div', { id: 'test-component' }));
 

--- a/tests/ui/components/search/spellcheckcomponent.js
+++ b/tests/ui/components/search/spellcheckcomponent.js
@@ -6,8 +6,6 @@ import SpellCheckComponent from '../../../../src/ui/components/search/spellcheck
 const COMPONENT_MANAGER = mockManager();
 
 describe('spellcheck redirect links', () => {
-  let linkUrlParams;
-
   setupDOM();
 
   const component = createSpellcheckComponent();
@@ -20,7 +18,7 @@ describe('spellcheck redirect links', () => {
   });
 
   const correctedQueryUrl = component.getState('correctedQueryUrl');
-  linkUrlParams = new URLSearchParams(correctedQueryUrl);
+  const linkUrlParams = new URLSearchParams(correctedQueryUrl);
 
   it('redirect links contain a query url param', () => {
     const query = linkUrlParams.get('query');

--- a/tests/ui/dom/searchparams.js
+++ b/tests/ui/dom/searchparams.js
@@ -9,44 +9,44 @@ beforeEach(() => {
 
 describe('searchparams parse', () => {
   it('parses standard url with no params', () => {
-    let u = new SearchParams('https://www.yext.com/');
+    const u = new SearchParams('https://www.yext.com/');
     expect(u.get('https://www.yext.com/')).toStrictEqual('');
     expect(u.get('askjfhsdkjhfs')).not.toStrictEqual('');
   });
   it('parses standard url', () => {
-    let u = new SearchParams('https://www.yext.com/?query=hello');
+    const u = new SearchParams('https://www.yext.com/?query=hello');
     expect(u.get('query')).toStrictEqual('hello');
   });
   it('parses standard url with &', () => {
-    let u = new SearchParams('https://www.yext.com/?query=hello&q=area51');
+    const u = new SearchParams('https://www.yext.com/?query=hello&q=area51');
     expect(u.get('query')).toStrictEqual('hello');
     expect(u.get('q')).toStrictEqual('area51');
   });
   it('parses url starting with ?', () => {
-    let u = new SearchParams('?query=hello');
+    const u = new SearchParams('?query=hello');
     expect(u.get('query')).toStrictEqual('hello');
   });
   it('parses url starting with ? with &', () => {
-    let u = new SearchParams('?query=hello&q=area51');
+    const u = new SearchParams('?query=hello&q=area51');
     expect(u.get('query')).toStrictEqual('hello');
     expect(u.get('q')).toStrictEqual('area51');
   });
   it('parses url without ?', () => {
-    let u = new SearchParams('query=hello');
+    const u = new SearchParams('query=hello');
     expect(u.get('query')).toStrictEqual('hello');
   });
   it('parses url without ? with &', () => {
-    let u = new SearchParams('query=hello&q=area51');
+    const u = new SearchParams('query=hello&q=area51');
     expect(u.get('query')).toStrictEqual('hello');
     expect(u.get('q')).toStrictEqual('area51');
   });
   it('parses url with +', () => {
-    let u = new SearchParams('query=hello+world&q=area51+event');
+    const u = new SearchParams('query=hello+world&q=area51+event');
     expect(u.get('query')).toStrictEqual('hello world');
     expect(u.get('q')).toStrictEqual('area51 event');
   });
   it('parses query without value', () => {
-    let u = new SearchParams('query=&q=area51+event');
+    const u = new SearchParams('query=&q=area51+event');
     expect(u.get('query')).toStrictEqual('');
     expect(u.get('q')).toStrictEqual('area51 event');
   });
@@ -54,36 +54,36 @@ describe('searchparams parse', () => {
 
 describe('searchparams get', () => {
   it('gets undefined', () => {
-    let u = new SearchParams('query=hello+world&q=area51');
+    const u = new SearchParams('query=hello+world&q=area51');
     expect(u.get(undefined)).toStrictEqual(null);
   });
   it('gets null', () => {
-    let u = new SearchParams('query=hello+world&q=area51');
+    const u = new SearchParams('query=hello+world&q=area51');
     expect(u.get(null)).toStrictEqual(null);
   });
   it('gets empty string', () => {
-    let u = new SearchParams('query=hello+world&q=area51');
+    const u = new SearchParams('query=hello+world&q=area51');
     expect(u.get('')).toStrictEqual(null);
   });
   it('gets empty', () => {
-    let u = new SearchParams('query=hello+world&q=area51');
+    const u = new SearchParams('query=hello+world&q=area51');
     expect(u.get()).toStrictEqual(null);
   });
 });
 
 describe('searchparams set', () => {
   it('sets undefined', () => {
-    let u = new SearchParams('query=hello+world&q=area51');
+    const u = new SearchParams('query=hello+world&q=area51');
     u.set(undefined, 'aliens');
     expect(u.get('undefined')).toStrictEqual('aliens');
   });
   it('sets null', () => {
-    let u = new SearchParams('query=hello+world&q=area51');
+    const u = new SearchParams('query=hello+world&q=area51');
     u.set(null, 'aliens');
     expect(u.get('null')).toStrictEqual('aliens');
   });
   it('sets empty string', () => {
-    let u = new SearchParams('query=hello+world&q=area51');
+    const u = new SearchParams('query=hello+world&q=area51');
     u.set('', 'aliens');
     expect(u.get('')).toStrictEqual('aliens');
   });
@@ -91,7 +91,7 @@ describe('searchparams set', () => {
 
 describe('searchparams encode', () => {
   it('toStrings correctly', () => {
-    let u = new SearchParams('http://www.yext.com/?query=hello+world&q=area51');
+    const u = new SearchParams('http://www.yext.com/?query=hello+world&q=area51');
     expect(u.toString()).toStrictEqual('query=hello+world&q=area51');
   });
   it('encodes !\'()%20', () => {

--- a/tests/ui/rendering/handlebarsrenderer.js
+++ b/tests/ui/rendering/handlebarsrenderer.js
@@ -4,7 +4,7 @@ import Handlebars from 'handlebars';
 describe('the handlebars processTranslation helper', () => {
   const renderer = new HandlebarsRenderer();
   renderer.init({
-    '_hb': Handlebars
+    _hb: Handlebars
   }, 'en');
 
   it('can translate a string phrase', () => {
@@ -96,7 +96,7 @@ describe('the handlebars processTranslation helper', () => {
     it('use locale specified in the renderer init', () => {
       const rendererWithLocale = new HandlebarsRenderer();
       rendererWithLocale.init({
-        '_hb': Handlebars
+        _hb: Handlebars
       }, 'lt-LT');
 
       const template = `{{processTranslation
@@ -115,7 +115,7 @@ describe('the handlebars processTranslation helper', () => {
     it('locale in the template overrides the one in the init if specified', () => {
       const rendererWithLocale = new HandlebarsRenderer();
       rendererWithLocale.init({
-        '_hb': Handlebars
+        _hb: Handlebars
       }, 'en');
 
       const template = `{{processTranslation

--- a/tests/ui/tools/filterutils.js
+++ b/tests/ui/tools/filterutils.js
@@ -140,7 +140,7 @@ describe('findSimpleFiltersWithFieldId', () => {
     const filter1 = Filter.from({
       c_aField: { $eq: 5 }
     });
-    expect(findSimpleFiltersWithFieldId(filter1, 'c_aField')).toEqual([ filter1 ]);
+    expect(findSimpleFiltersWithFieldId(filter1, 'c_aField')).toEqual([filter1]);
   });
 });
 

--- a/tests/ui/tools/taborder.js
+++ b/tests/ui/tools/taborder.js
@@ -34,7 +34,7 @@ describe('core configuration', () => {
       }
     ];
 
-    let params = new URLSearchParams('tabOrder=tab2,tab1');
+    const params = new URLSearchParams('tabOrder=tab2,tab1');
     const defaultOrder = getDefaultTabOrder(tabConfig, params);
     expect(defaultOrder).toMatchObject(['tab2', 'tab1']);
   });


### PR DESCRIPTION
Use ESLint with the same configuration as Semistandard version 16.0.0
Updated codebase to match new version

Fixed the following rules(automatic):
- Using const when possible
- Strings using single quotes
- Spacing tweaks
- Using dot accessors instead of bracket accessors
- Not using quotes for object properties when possible

Fixed the following rules(manual):
- Using Regex literals instead of RegExp
- Added default values for latter parameters
- Not using hasOwnProperty()
- Using forEach instead of map
- Added brackets around case declarations
- Using const when possible

J = SLAP-1343
TEST = Manual

Built a page in Japanese and opened it.