### PR TITLE
analyticsEventsEnabled flag added

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -474,10 +474,10 @@ class Answers {
 
   /**
    * Opt in or out of analytic events
-   * @param {boolean} bool
+   * @param {boolean} analyticsEventsEnabled
    */
-  setAnalyticsOptIn (bool) {
-    this._analyticsReporterService.setAnalyticsOptIn(bool);
+  setAnalyticsOptIn (analyticsEventsEnabled) {
+    this._analyticsReporterService.setAnalyticsOptIn(analyticsEventsEnabled);
   }
 
   /**

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -41,7 +41,8 @@ import QueryUpdateListener from './core/statelisteners/queryupdatelistener';
 
 const DEFAULTS = {
   locale: LOCALE,
-  querySource: QUERY_SOURCE
+  querySource: QUERY_SOURCE,
+  analyticsEventsEnabled: true
 };
 
 /**
@@ -223,10 +224,8 @@ class Answers {
    * is ever called, a check to the relevant Answers Status page is made.
    *
    * @param {Object} config The Answers configuration.
-   * @param {Object} statusPage An override for the baseUrl and endpoint of the
-   *                            experience's Answers Status page.
    */
-  init (config, statusPage) {
+  init (config) {
     window.performance.mark('yext.answers.initStart');
     const parsedConfig = this.parseConfig(config);
     this.validateConfig(parsedConfig);
@@ -248,6 +247,7 @@ class Answers {
         parsedConfig.experienceKey,
         parsedConfig.experienceVersion,
         parsedConfig.businessId,
+        parsedConfig.analyticsEventsEnabled,
         parsedConfig.analyticsOptions,
         parsedConfig.environment);
 

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -473,6 +473,14 @@ class Answers {
   }
 
   /**
+   * Opt in or out of analytic events
+   * @param {boolean} bool
+   */
+  setAnalyticsOptIn (bool) {
+    this._analyticsReporterService.setAnalyticsOptIn(bool);
+  }
+
+  /**
    * Opt in or out of convertion tracking analytics
    * @param {boolean} optIn
    */

--- a/src/core/analytics/analyticsreporter.js
+++ b/src/core/analytics/analyticsreporter.js
@@ -31,8 +31,8 @@ export default class AnalyticsReporter {
      * Boolean indicating if the Answers Search UI submits analytic click events
      * @type {boolean}
      */
-
     this._analyticsEventsEnabled = analyticsEventsEnabled;
+
     /**
      * Options to include with every analytic event reported to the server
      * @type {object}

--- a/src/core/analytics/analyticsreporter.js
+++ b/src/core/analytics/analyticsreporter.js
@@ -18,6 +18,7 @@ export default class AnalyticsReporter {
     experienceKey,
     experienceVersion,
     businessId,
+    analyticsEventsEnabled,
     globalOptions = {},
     environment = PRODUCTION) {
     /**
@@ -26,6 +27,12 @@ export default class AnalyticsReporter {
      */
     this._businessId = businessId;
 
+    /**
+     * Boolean indicating if the Answers Search UI submits analytic click events
+     * @type {boolean}
+     */
+
+    this._analyticsEventsEnabled = analyticsEventsEnabled;
     /**
      * Options to include with every analytic event reported to the server
      * @type {object}
@@ -67,8 +74,19 @@ export default class AnalyticsReporter {
     this._globalOptions.queryId = queryId;
   }
 
+  /**
+   * Opt in or out of analytics click events
+   * @param {boolean} bool
+   */
+  setAnalyticsOptIn (bool) {
+    this._analyticsEventsEnabled = bool;
+  }
+
   /** @inheritdoc */
   report (event) {
+    if (!this._analyticsEventsEnabled) {
+      return false;
+    }
     let cookieData = {};
     if (this._conversionTrackingEnabled && typeof ytag === 'function') {
       ytag('optin', true);

--- a/src/core/analytics/analyticsreporter.js
+++ b/src/core/analytics/analyticsreporter.js
@@ -76,10 +76,10 @@ export default class AnalyticsReporter {
 
   /**
    * Opt in or out of analytics click events
-   * @param {boolean} bool
+   * @param {boolean} analyticsEventsEnabled
    */
-  setAnalyticsOptIn (bool) {
-    this._analyticsEventsEnabled = bool;
+  setAnalyticsOptIn (analyticsEventsEnabled) {
+    this._analyticsEventsEnabled = analyticsEventsEnabled;
   }
 
   /** @inheritdoc */

--- a/tests/core/analytics/analyticsreporter.js
+++ b/tests/core/analytics/analyticsreporter.js
@@ -18,7 +18,7 @@ describe('reporting events', () => {
         beacon: mockedBeacon
       };
     });
-    analyticsReporter = new AnalyticsReporter('abc123', null, '213412');
+    analyticsReporter = new AnalyticsReporter('abc123', null, '213412', true);
   });
 
   it('throws an error if given a non-AnalyticsEvent', () => {
@@ -38,7 +38,7 @@ describe('reporting events', () => {
   });
 
   it('includes global options', () => {
-    const analyticsReporter = new AnalyticsReporter('abc123', null, '213412', { testOption: 'test' });
+    const analyticsReporter = new AnalyticsReporter('abc123', null, '213412', true, { testOption: 'test' });
     const expectedEvent = new AnalyticsEvent('thumbs_up');
     analyticsReporter.report(expectedEvent);
 
@@ -49,7 +49,7 @@ describe('reporting events', () => {
   });
 
   it('includes experienceVersion when supplied', () => {
-    const analyticsReporter = new AnalyticsReporter('abc123', 'PRODUCTION', '213412', { testOption: 'test' });
+    const analyticsReporter = new AnalyticsReporter('abc123', 'PRODUCTION', '213412', true, { testOption: 'test' });
     const expectedEvent = new AnalyticsEvent('thumbs_up');
     analyticsReporter.report(expectedEvent);
 
@@ -86,5 +86,26 @@ describe('reporting events', () => {
     expect(mockedBeacon).toBeCalledWith(
       expect.stringContaining(getAnalyticsUrl(PRODUCTION, true)),
       { data: { eventType: 'THUMBS_UP', experienceKey: 'abc123' }, ...cookieData });
+  });
+
+  it('All analytic events are enabled when analyticsEventsEnabled is set to true', () => {
+    analyticsReporter.report(new AnalyticsEvent('thumbs_up'));
+
+    expect(mockedBeacon).toBeCalledTimes(1);
+  });
+
+  it('All analytic events are disabled when analyticsEventsEnabled is set to false', () => {
+    analyticsReporter = new AnalyticsReporter('abc123', null, '213412', false);
+    analyticsReporter.report(new AnalyticsEvent('thumbs_up'));
+
+    expect(mockedBeacon).toBeCalledTimes(0);
+  });
+
+  it('All analytic events are disabled when analyticsEventsEnabled is set to false with setAnalyticsOptIn(bool)', () => {
+    analyticsReporter = new AnalyticsReporter('abc123', null, '213412');
+    analyticsReporter.setAnalyticsOptIn(false);
+    analyticsReporter.report(new AnalyticsEvent('thumbs_up'));
+
+    expect(mockedBeacon).toBeCalledTimes(0);
   });
 });


### PR DESCRIPTION
Added analyticEventsEnabled flag to analytics reporter. Also added setAnalyticsOptIn(analyticEventsEnabled), a function that modifies analyticsEventsEnabled.

J=SLAP-1392
TEST=manual/auto

Checked website to see if events were reported with flag set to true and false. Also checked to make sure the ANSWERS.setAnalyticsOptIn(analyticEventsEnabled) works as expected.
Created unit tests to see if events were reported.