### PR TITLE
replace IconComponent usages with iconPartial

### DIFF
--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -659,15 +659,11 @@ export default class SearchComponent extends Component {
 
   setState (data) {
     const forwardIconOpts = {
-      iconName: 'yext_animated_forward',
-      classNames: 'Icon--lg',
       complexContentsParams: {
         iconPrefix: this.name
       }
     };
     const reverseIconOpts = {
-      iconName: 'yext_animated_reverse',
-      classNames: 'Icon--lg',
       complexContentsParams: {
         iconPrefix: this.name
       }

--- a/src/ui/templates/cards/accordion.hbs
+++ b/src/ui/templates/cards/accordion.hbs
@@ -10,10 +10,8 @@ id="{{id}}">
       <h3 class="yxt-AccordionCard-title">
         {{{_config.title}}}
       </h3>
-      <div class="yxt-AccordionCard-icon js-yxt-AccordionCard-icon{{#if isExpanded}} yxt-AccordionCard-icon--expanded{{/if}}"
-        data-component="IconComponent"
-        data-opts='{"iconName": "chevron"}'
-        data-prop="icon">
+      <div class="yxt-AccordionCard-icon js-yxt-AccordionCard-icon{{#if isExpanded}} yxt-AccordionCard-icon--expanded{{/if}}">
+        {{> icons/iconPartial iconName='chevron'}}
       </div>
     </button>
   {{else}}

--- a/src/ui/templates/cards/standard.hbs
+++ b/src/ui/templates/cards/standard.hbs
@@ -73,15 +73,15 @@
       </div>
       {{#if _config.showToggle}}
         <button class="yxt-StandardCard-toggle js-yxt-StandardCard-toggle">
-          {{#if hideExcessDetails}}
-            {{_config.showMoreText}}
-            <span data-component="IconComponent"
-              data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
-          {{else}}
-            {{_config.showLessText}}
-            <span data-component="IconComponent"
-              data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>
-          {{/if}}
+          <span>
+            {{#if hideExcessDetails}}
+              {{_config.showMoreText}}
+              {{> icons/iconPartial iconName='chevron' classNames='Icon--sm Icon-collapseDown'}}
+            {{else}}
+              {{_config.showLessText}}
+              {{> icons/iconPartial iconName='chevron' classNames='Icon--sm Icon-collapseUp'}}
+            {{/if}}
+          </span>
         </button>
       {{/if}}
     </div>

--- a/src/ui/templates/controls/filteroptions.hbs
+++ b/src/ui/templates/controls/filteroptions.hbs
@@ -14,13 +14,13 @@
             {{/if}}
 
             {{#if expanded}}
-              <span class="yxt-FilterOptions-expand yxt-FilterOptions-collapseUp"
-                data-component="IconComponent"
-                data-opts='{ "iconName": "chevron" }'></span>
+              <span class="yxt-FilterOptions-expand yxt-FilterOptions-collapseUp">
+                {{> icons/iconPartial iconName='chevron'}}
+              </span>
             {{else}}
-              <span class="yxt-FilterOptions-expand yxt-FilterOptions-collapseDown"
-                data-component="IconComponent"
-                data-opts='{ "iconName": "chevron" }'></span>
+              <span class="yxt-FilterOptions-expand yxt-FilterOptions-collapseDown">
+                {{> icons/iconPartial iconName='chevron'}}
+              </span>
             {{/if}}
           </div>
         {{else}}
@@ -48,10 +48,9 @@
     {{#if searchable}}
       <div class="yxt-FilterOptions-search js-yxt-FilterOptions-search">
         <input type="text" class="yxt-FilterOptions-filter js-yxt-FilterOptions-filter" aria-label="{{searchLabelText}}" placeholder="{{placeholderText}}">
-        <button class="yxt-FilterOptions-clearSearch js-yxt-FilterOptions-clearSearch js-hidden"
-          data-component="IconComponent"
-          data-opts='{ "iconName": "close" }'
-          data-prop="icon"></button>
+        <button class="yxt-FilterOptions-clearSearch js-yxt-FilterOptions-clearSearch js-hidden">
+          {{> icons/iconPartial iconName='close'}}
+        </button>
       </div>
     {{/if}}
     </div>
@@ -115,17 +114,17 @@
         <span class="yxt-FilterOptions-showToggleLabel">
           {{showLessLabel}}
         </span>
-        <span class="yxt-FilterOptions-collapseUp"
-          data-component="IconComponent"
-          data-opts='{ "iconName": "chevron" }'></span>
+        <span class="yxt-FilterOptions-collapseUp">
+          {{> icons/iconPartial iconName='chevron'}}
+        </span>
       </button>
       <button class="yxt-FilterOptions-showToggle js-yxt-FilterOptions-showToggle js-yxt-FilterOptions-showMore{{#unless showMoreState}} hidden{{/unless}}">
         <span class="yxt-FilterOptions-showToggleLabel">
           {{showMoreLabel}}
         </span>
-        <span class="yxt-FilterOptions-collapseDown"
-          data-component="IconComponent"
-          data-opts='{ "iconName": "chevron" }'></span>
+        <span class="yxt-FilterOptions-collapseDown">
+          {{> icons/iconPartial iconName='chevron'}}
+        </span>
       </button>
     {{/if}}
   </div>

--- a/src/ui/templates/controls/sortoptions.hbs
+++ b/src/ui/templates/controls/sortoptions.hbs
@@ -31,16 +31,16 @@
       {{#if hideExcessOptions}}
         <button class='yxt-SortOptions-showToggle'>
           {{_config.showMoreLabel}}
-          <span class='yxt-SortOptions-collapseDown'
-            data-component='IconComponent'
-            data-opts='{ "iconName": "chevron" }'></span>
+          <span class='yxt-SortOptions-collapseDown'>
+            {{> icons/iconPartial iconName='chevron'}}
+          </span>
         </button>
       {{else}}
         <button class='yxt-SortOptions-showToggle'>
           {{_config.showLessLabel}}
-          <span class='yxt-SortOptions-collapseUp'
-            data-component='IconComponent'
-            data-opts='{ "iconName": "chevron" }'></span>
+          <span class='yxt-SortOptions-collapseUp'>
+            {{> icons/iconPartial iconName='chevron'}}
+          </span>
         </button>
       {{/if}}
     {{/if}}

--- a/src/ui/templates/ctas/cta.hbs
+++ b/src/ui/templates/ctas/cta.hbs
@@ -4,14 +4,13 @@
   rel="noopener noreferrer nofollow"
 >
   {{#if hasIcon}}
-    <div class='yxt-CTA-icon{{#if _config.includeLegacyClasses}} yxt-Result-ctaIconWrapper{{/if}}'
-         data-component='IconComponent'
-         data-opts='{
-           "iconName": "{{_config.icon}}",
-           "iconUrl": "{{_config.iconUrl}}"
-           {{#if _config.includeLegacyClasses}}, "classNames": "yxt-Result-ctaIcon"{{/if}} 
-          }'
-         ></div>
+    <div class='yxt-CTA-icon{{#if _config.includeLegacyClasses}} yxt-Result-ctaIconWrapper{{/if}}'>
+      {{#if _config.includeLegacyClasses}}
+        {{> icons/iconPartial iconName=_config.icon iconUrl=_config.iconUrl classNames="yxt-Results-ctaIcon" }}
+      {{else}}
+        {{> icons/iconPartial iconName=_config.icon iconUrl=_config.iconUrl }}
+      {{/if}}
+    </div>
   {{/if}}
   <div class='yxt-CTA-iconLabel{{#if _config.includeLegacyClasses}} yxt-Result-ctaLabel{{/if}}'>
     {{{_config.label}}}

--- a/src/ui/templates/filters/filterbox.hbs
+++ b/src/ui/templates/filters/filterbox.hbs
@@ -1,9 +1,8 @@
 <div class="yxt-FilterBox-container">
   {{#if title}}
     <h2 class="yxt-FilterBox-titleContainer">
-      <div
-        data-component="IconComponent"
-        data-opts='{ "iconName": "elements" }'>
+      <div>
+        {{> icons/iconPartial iconName='elements'}}
       </div>
       <span class="yxt-FilterBox-title">{{title}}</span>
     </h2>

--- a/src/ui/templates/icons/iconPartial.hbs
+++ b/src/ui/templates/icons/iconPartial.hbs
@@ -1,0 +1,7 @@
+<div class="Icon Icon--{{#if iconName}}{{iconName}}{{else}}custom{{/if}} {{classNames}}" aria-hidden="true">
+  {{#if iconUrl}}
+    <img src="{{iconUrl}}" alt="" class="Icon-image">
+  {{else}}
+    {{icon iconName complexContentsParams}}
+  {{/if}}
+</div>

--- a/src/ui/templates/navigation/navigation.hbs
+++ b/src/ui/templates/navigation/navigation.hbs
@@ -20,10 +20,9 @@
   {{#if showCollapse}}
     <div class="yxt-Nav-moreContainer">
       <button id="yxt-Nav-moreButton" class="yxt-Nav-item yxt-Nav-more yxt-Nav-item--more js-yxt-navMore">
-        <span class="yxt-Nav-moreIcon"
-        data-component="IconComponent"
-        data-opts='{"iconName": "{{overflowIcon}}"}'
-        data-prop="icon"></span>
+        <span class="yxt-Nav-moreIcon">
+          {{> icons/iconPartial iconName=overflowIcon}}
+        </span>
         {{overflowLabel}}
       </button>
       <ul class="yxt-Nav-modal js-yxt-navModal {{#if expanded}}is-active{{/if}}"

--- a/src/ui/templates/questions/questionsubmission.hbs
+++ b/src/ui/templates/questions/questionsubmission.hbs
@@ -8,13 +8,9 @@
     aria-controls="yxt-QuestionSubmission-form-{{name}}"
     aria-expanded="{{#if questionExpanded}}true{{else}}false{{/if}}">
     <div class="yxt-QuestionSubmission-left">
-      <div class="yxt-QuestionSubmission-titleIconWrapper"
-          data-component="IconComponent"
-          data-opts='{
-              "iconName": "{{_config.sectionTitleIconName}}"
-            }'
-          data-prop="icon"
-      ></div>
+      <div class="yxt-QuestionSubmission-titleIconWrapper">
+        {{> icons/iconPartial iconName=_config.sectionTitleIconName}}
+      </div>
       <div class="yxt-QuestionSubmission-title">
         {{_config.sectionTitle}}
       </div>
@@ -23,11 +19,9 @@
       <div class="yxt-QuestionSubmission-titleDescription">
         {{_config.teaser}}
       </div>
-      <span class="yxt-QuestionSubmission-toggle{{#if questionExpanded}}--expanded{{else}}--collapsed{{/if}} yxt-QuestionSubmission-toggle"
-        data-component="IconComponent"
-        data-opts='{ "iconName": "chevron" }'
-        data-prop="icon"
-      ></span>
+      <span class="yxt-QuestionSubmission-toggle{{#if questionExpanded}}--expanded{{else}}--collapsed{{/if}} yxt-QuestionSubmission-toggle">
+        {{> icons/iconPartial iconName='chevron'}}
+      </span>
     </div>
   </button>
 

--- a/src/ui/templates/results/alternativeverticals.hbs
+++ b/src/ui/templates/results/alternativeverticals.hbs
@@ -16,12 +16,8 @@
             <a class="yxt-AlternativeVerticals-suggestionLink"
                 href="{{url}}">
               {{#if hasIcon}}
-                <div class="yxt-AlternativeVerticals-verticalIconWrapper"
-                      data-component="IconComponent"
-                      data-opts='{
-                        "iconName": "{{iconName}}",
-                        "iconUrl": "{{iconUrl}}"
-                      }'>
+                <div class="yxt-AlternativeVerticals-verticalIconWrapper">
+                  {{> icons/iconPartial iconName=iconName iconUrl=iconUrl}}
                 </div>
               {{/if}}
               <div class="yxt-AlternativeVerticals-suggestionLink--copy">
@@ -32,11 +28,8 @@
                   {{translate phrase='([[resultsCount]] result)' pluralForm='([[resultsCount]] results)' count=resultsCount resultsCount=resultsCount }}
                 </span>
               </div>
-              <div class="yxt-AlternativeVerticals-arrowIconWrapper"
-                    data-component="IconComponent"
-                    data-opts='{
-                      "iconName": "chevron"
-                    }'>
+              <div class="yxt-AlternativeVerticals-arrowIconWrapper">
+                {{> icons/iconPartial iconName='chevron'}}
               </div>
             </a>
           </li>

--- a/src/ui/templates/results/directanswer.hbs
+++ b/src/ui/templates/results/directanswer.hbs
@@ -3,14 +3,9 @@
 {{else}}
   <div class="yxt-DirectAnswer">
     <div class="yxt-DirectAnswer-title">
-      <div class="yxt-DirectAnswer-titleIconWrapper yxt-Results-titleIconWrapper"
-          data-component="IconComponent"
-          data-opts='{
-              "iconName": "{{iconName}}",
-              "iconUrl": "{{customIconUrl}}"
-            }'
-          data-prop="icon"
-      ></div>
+      <div class="yxt-DirectAnswer-titleIconWrapper yxt-Results-titleIconWrapper">
+        {{> icons/iconPartial iconName=iconName iconUrl=customIconUrl}}
+      </div>
       <h2 class="yxt-DirectAnswer-titleText">
         <span class="yxt-DirectAnswer-entityName">
           {{answer.entityName}}
@@ -52,11 +47,9 @@
           </div>
           <form class="yxt-DirectAnswer-thumbs js-directAnswer-feedback-form">
             <label class="yxt-DirectAnswer-thumb">
-              <span class="yxt-DirectAnswer-thumbUpIcon"
-                  data-component="IconComponent"
-                  data-opts='{"iconName": "thumb"}'
-                  data-prop="icon"
-              ></span>
+              <span class="yxt-DirectAnswer-thumbUpIcon">
+                {{> icons/iconPartial iconName='thumb'}}
+              </span>
               <input type="radio"
                     name="feedback"
                     value="true"
@@ -66,11 +59,9 @@
               </span>
             </label>
             <label class="yxt-DirectAnswer-thumb">
-              <span class="yxt-DirectAnswer-thumbDownIcon"
-                  data-component="IconComponent"
-                  data-opts='{"iconName": "thumb"}'
-                  data-prop="icon"
-              ></span>
+              <span class="yxt-DirectAnswer-thumbDownIcon">
+                {{> icons/iconPartial iconName='thumb'}}
+              </span>
               <input type="radio"
                     name="feedback"
                     value="false"

--- a/src/ui/templates/results/pagination.hbs
+++ b/src/ui/templates/results/pagination.hbs
@@ -8,16 +8,16 @@
         tabindex="0"
       >
         {{#unless icons.firstButtonIcon}}
-          <span class="yxt-Pagination-doubleChevron--left"
-                data-component="IconComponent"
-                data-opts='{ "iconName": "chevron" }'></span>
-          <span class="yxt-Pagination-chevron--left"
-                data-component="IconComponent"
-                data-opts='{ "iconName": "chevron" }'></span>
+          <span class="yxt-Pagination-doubleChevron--left">
+            {{> icons/iconPartial iconName='chevron'}}
+          </span>
+          <span class="yxt-Pagination-chevron--left">
+            {{> icons/iconPartial iconName='chevron'}}
+          </span>
         {{else}}
-          <span class="yxt-Pagination-doubleChevron--left"
-                data-component="IconComponent"
-                data-opts='{ "iconUrl": "{{icons.firstButtonIcon}}" }'></span>
+          <span class="yxt-Pagination-doubleChevron--left">
+            {{> icons/iconPartial iconUrl=icons.firstButtonIcon}}
+          </span>
         {{/unless}}
       </a>
     {{/if}}
@@ -29,13 +29,13 @@
       tabindex="0"
     >
       {{#unless icons.previousButtonIcon}}
-        <span class="yxt-Pagination-chevron--left"
-              data-component="IconComponent"
-              data-opts='{ "iconName": "chevron" }'></span>
+        <span class="yxt-Pagination-chevron--left">
+          {{> icons/iconPartial iconName='chevron'}}
+        </span>
       {{else}}
-        <span class="yxt-Pagination-chevron--left"
-              data-component="IconComponent"
-              data-opts='{ "iconUrl": "{{icons.previousButtonIcon}}" }'></span>
+        <span class="yxt-Pagination-chevron--left">
+          {{> icons/iconPartial iconUrl=icons.previousButtonIcon}}      
+        </span>
       {{/unless}}
     </a>
 
@@ -95,13 +95,13 @@
       tabindex="0"
     >
       {{#unless icons.nextButtonIcon}}
-        <span class="yxt-Pagination-chevron"
-              data-component="IconComponent"
-              data-opts='{ "iconName": "chevron" }'></span>
+        <span class="yxt-Pagination-chevron">
+          {{> icons/iconPartial iconName='chevron'}}
+        </span>
       {{else}}
-        <span class="yxt-Pagination-chevron"
-              data-component="IconComponent"
-              data-opts='{ "iconUrl": "{{icons.nextButtonIcon}}" }'></span>
+        <span class="yxt-Pagination-chevron">
+          {{> icons/iconPartial iconUrl=icons.nextButtonIcon}}
+        </span>
       {{/unless}}
     </a>
     {{#if lastPageButtonEnabled}}
@@ -112,16 +112,16 @@
         tabindex="0"
       >
         {{#unless icons.lastButtonIcon}}
-        <span class="yxt-Pagination-doubleChevron"
-              data-component="IconComponent"
-              data-opts='{ "iconName": "chevron" }'></span>
-        <span class="yxt-Pagination-chevron"
-              data-component="IconComponent"
-              data-opts='{ "iconName": "chevron" }'></span>
+        <span class="yxt-Pagination-doubleChevron">
+          {{> icons/iconPartial iconName='chevron'}}
+        </span>
+        <span class="yxt-Pagination-chevron">
+          {{> icons/iconPartial iconName='chevron'}}
+        </span>
         {{else}}
-          <span class="yxt-Pagination-doubleChevron"
-              data-component="IconComponent"
-              data-opts='{ "iconUrl": "{{icons.lastButtonIcon}}" }'></span>
+          <span class="yxt-Pagination-doubleChevron">
+            {{> icons/iconPartial iconUrl=icons.lastButtonIcon}}
+          </span>
         {{/unless}}
       </a>
     {{/if}}

--- a/src/ui/templates/results/resultsaccordion.hbs
+++ b/src/ui/templates/results/resultsaccordion.hbs
@@ -18,10 +18,9 @@
                       data-entity-id="{{this.id}}">
                 {{this.title}}
                 <div class="yxt-AccordionResult-indicatorWrapper" aria-hidden="true">
-                  <span class="yxt-AccordionResult-indicator"
-                        data-component="IconComponent"
-                        data-opts='{"iconName": "chevron"}'
-                        data-prop="icon"></span>
+                  <span class="yxt-AccordionResult-indicator">
+                    {{> icons/iconPartial iconName='chevron'}}
+                  </span>
                 </div>
               </button>
             </h3>
@@ -42,10 +41,9 @@
                           >
                             {{#if this.icon}}
                               <div class="yxt-AccordionResult-ctaIconWrapper">
-                                <span class="yxt-AccordionResult-ctaIcon"
-                                      data-component="IconComponent"
-                                      data-opts='{"iconName": "{{this.icon}}"}'
-                                      data-prop="icon"></span>
+                                <span class="yxt-AccordionResult-ctaIcon">
+                                  {{> icons/iconPartial iconName=this.icon}}
+                                </span>
                               </div>
                             {{/if}}
                             <span class="yxt-AccordionResult-ctaLabel">

--- a/src/ui/templates/results/resultssectionheader.hbs
+++ b/src/ui/templates/results/resultssectionheader.hbs
@@ -1,13 +1,8 @@
 <div class="yxt-Results-titleBar">
   <div class="yxt-Results-left">
-    <div class="yxt-Results-titleIconWrapper"
-         data-component="IconComponent"
-         data-opts='{
-            "iconName": "{{_config.sectionTitleIconName}}",
-            "iconUrl": "{{_config.sectionTitleIconUrl}}"
-          }'
-         data-prop="icon"
-    ></div>
+    <div class="yxt-Results-titleIconWrapper">
+      {{> icons/iconPartial iconName=_config.sectionTitleIconName iconUrl=_config.sectionTitleIconUrl}}
+    </div>
     <h2 class="yxt-Results-title">
       {{_config.sectionTitle}}
     </h2>

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -27,15 +27,13 @@
   {{#if _config.isUniversal}}
     <div class="yxt-Results-titleBar">
       {{#if _config.icon}}
-        {{#if iconIsBuiltIn}}
-          <div class="yxt-Results-titleIconWrapper"
-            data-component="IconComponent"
-            data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
-        {{else}}
-          <div class="yxt-Results-titleIconWrapper"
-            data-component="IconComponent"
-            data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
-        {{/if}}
+        <div class="yxt-Results-titleIconWrapper">
+          {{#if iconIsBuiltIn}}
+            {{> icons/iconPartial iconName=_config.icon }}
+          {{else}}
+            {{> icons/iconPartial iconUrl=_config.icon }}
+          {{/if}}
+        </div>
       {{/if}}
       <h2 class="yxt-Results-title">{{_config.title}}</h2>
     </div>
@@ -79,7 +77,9 @@
       data-eventoptions='{{eventOptions}}'
     >
       <div class="yxt-Results-viewAllLabel">{{_config.viewMoreLabel}}</div>
-      <div data-component="IconComponent" data-opts='{ "iconName": "chevron" }'></div>
+      <div>
+        {{> icons/iconPartial iconName='chevron'}}
+      </div>
     </a>
   {{/if}}
 {{/inline}}

--- a/src/ui/templates/search/search.hbs
+++ b/src/ui/templates/search/search.hbs
@@ -28,10 +28,8 @@
                 class="js-yxt-SearchBar-clear yxt-SearchBar-clear yxt-SearchBar--hidden"
                 data-eventtype="SEARCH_CLEAR_BUTTON"
                 data-eventoptions="{{eventOptions}}"
-                data-component="IconComponent"
-                data-opts='{ "iconName": "close" }'
-                data-prop="icon"
         >
+          {{> icons/iconPartial iconName='close'}}
           <span class="yxt-SearchBar-clearButtonText sr-only">
             {{clearText}}
           </span>
@@ -39,15 +37,13 @@
         <button {{#if useForm}}type="submit"{{else}}type="button"{{/if}}
           class="js-yext-submit yxt-SearchBar-button">
           {{#if submitIcon}}
-            <div class="yxt-SearchBar-buttonImage"
-                data-component="IconComponent"
-                data-opts='{ "iconName": "{{submitIcon}}" }'
-            ></div>
+            <div class="yxt-SearchBar-buttonImage">
+              {{> icons/iconPartial iconName=submitIcon}}
+            </div>
           {{else if _config.customIconUrl}}
-            <div class="yxt-SearchBar-buttonImage"
-                data-component="IconComponent"
-                data-opts='{ "iconUrl": "{{_config.customIconUrl}}" }'
-            ></div>
+            <div class="yxt-SearchBar-buttonImage">
+              {{> icons/iconPartial iconUrl=_config.customIconUrl}}
+            </div>
           {{else}}
             <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedForward
               {{#if autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/if}}"
@@ -88,10 +84,8 @@
                 class="js-yxt-SearchBar-clear yxt-SearchBar-clear yxt-SearchBar--hidden"
                 data-eventtype="SEARCH_CLEAR_BUTTON"
                 data-eventoptions="{{eventOptions}}"
-                data-component="IconComponent"
-                data-opts='{ "iconName": "close" }'
-                data-prop="icon"
         >
+          {{> icons/iconPartial iconName='close' }}
           <span class="yxt-SearchBar-clearButtonText sr-only">
             {{clearText}}
           </span>
@@ -99,15 +93,13 @@
         <button {{#if useForm}}type="submit"{{else}}type="button"{{/if}}
           class="js-yext-submit yxt-SearchBar-button">
           {{#if submitIcon}}
-            <div class="yxt-SearchBar-buttonImage"
-                data-component="IconComponent"
-                data-opts='{ "iconName": "{{submitIcon}}" }'
-            ></div>
+            <div class="yxt-SearchBar-buttonImage">
+              {{> icons/iconPartial iconName=submitIcon}}
+            </div>
           {{else if _config.customIconUrl}}
-            <div class="yxt-SearchBar-buttonImage"
-                data-component="IconComponent"
-                data-opts='{ "iconUrl": "{{_config.customIconUrl}}" }'
-            ></div>
+            <div class="yxt-SearchBar-buttonImage">
+              {{> icons/iconPartial iconUrl=_config.customIconUrl}}
+            </div>
           {{else}}
             <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedForward
               {{#if autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/if}}"

--- a/src/ui/templates/search/search.hbs
+++ b/src/ui/templates/search/search.hbs
@@ -46,14 +46,20 @@
             </div>
           {{else}}
             <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedForward
-              {{#if autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/if}}"
-              data-component="IconComponent"
-              data-opts="{{json forwardIconOpts}}">
+              {{#if autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/if}}">
+              {{> icons/iconPartial
+                iconName='yext_animated_forward'
+                classNames='Icon--lg'
+                complexContentsParams=forwardIconOpts.complexContentsParams
+              }}
             </div>
             <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedReverse
-              {{#unless autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/unless}}"
-              data-component="IconComponent"
-              data-opts="{{json reverseIconOpts}}">
+              {{#unless autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/unless}}">
+              {{> icons/iconPartial
+                iconName='yext_animated_reverse'
+                classNames='Icon--lg'
+                complexContentsParams=reverseIconOpts.complexContentsParams
+              }}
             </div>
           {{/if}}
           <span class="yxt-SearchBar-buttonText sr-only">

--- a/tests/ui/components/filters/facetscomponent.js
+++ b/tests/ui/components/filters/facetscomponent.js
@@ -147,10 +147,10 @@ describe('Facets Component', () => {
     const dynamicFilters = DynamicFilters.fromCore(coreFacets);
     storage.set(StorageKeys.DYNAMIC_FILTERS, dynamicFilters);
     mount(component);
+    expect(remove).toHaveBeenCalledTimes(2);
+    storage.set(StorageKeys.DYNAMIC_FILTERS, { resultsContext: ResultsContext.NO_RESULTS });
     expect(remove).toHaveBeenCalledTimes(4);
     storage.set(StorageKeys.DYNAMIC_FILTERS, { resultsContext: ResultsContext.NO_RESULTS });
-    expect(remove).toHaveBeenCalledTimes(8);
-    storage.set(StorageKeys.DYNAMIC_FILTERS, { resultsContext: ResultsContext.NO_RESULTS });
-    expect(remove).toHaveBeenCalledTimes(8);
+    expect(remove).toHaveBeenCalledTimes(4);
   });
 });


### PR DESCRIPTION
This commit replaces all data-component="IconComponent" usages
with iconPartial instead. As a result, we...

1. cut down the number of data- attributes scanned by the SDK
2. remove a majority of the components tracked by the ComponentManager, which by extension will
3. reduce the number of component lifecycles that need to be run

J=SLAP-1297
TEST=manual

smoke tested that the page loads as expected, can run searches and things
like filters, navigation, and pagination icons look as expected

tested that I could access the icons/iconPartial partial from a component using a custom template
(to make sure it will work with the theme)

tried setting a custom icon for the searchbar

check that the animated search icon keyframes are still namespaced correctly by the searchbar's component
name (both the default of "SearchBar" and setting a custom name)

hooked up my local SDK to the theme, before this change on a vertical-full-page-map there were 50 icon components
after this change there were only 40
these 40 icons come from the 20 results cards that were rendered, each having 2 cta buttons
updating the theme will remove these remaining ones