### PR TITLE
add icons/bakedInIcon partial

### DIFF
--- a/src/ui/templates/cards/accordion.hbs
+++ b/src/ui/templates/cards/accordion.hbs
@@ -11,7 +11,7 @@ id="{{id}}">
         {{{_config.title}}}
       </h3>
       <div class="yxt-AccordionCard-icon js-yxt-AccordionCard-icon{{#if isExpanded}} yxt-AccordionCard-icon--expanded{{/if}}">
-        {{> icons/iconPartial iconName='chevron'}}
+        {{> icons/bakedInIcon iconName='chevron'}}
       </div>
     </button>
   {{else}}

--- a/src/ui/templates/cards/standard.hbs
+++ b/src/ui/templates/cards/standard.hbs
@@ -76,10 +76,10 @@
           <span>
             {{#if hideExcessDetails}}
               {{_config.showMoreText}}
-              {{> icons/iconPartial iconName='chevron' classNames='Icon--sm Icon-collapseDown'}}
+              {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon-collapseDown'}}
             {{else}}
               {{_config.showLessText}}
-              {{> icons/iconPartial iconName='chevron' classNames='Icon--sm Icon-collapseUp'}}
+              {{> icons/bakedInIcon iconName='chevron' classNames='Icon--sm Icon-collapseUp'}}
             {{/if}}
           </span>
         </button>

--- a/src/ui/templates/controls/filteroptions.hbs
+++ b/src/ui/templates/controls/filteroptions.hbs
@@ -15,11 +15,11 @@
 
             {{#if expanded}}
               <span class="yxt-FilterOptions-expand yxt-FilterOptions-collapseUp">
-                {{> icons/iconPartial iconName='chevron'}}
+                {{> icons/bakedInIcon iconName='chevron'}}
               </span>
             {{else}}
               <span class="yxt-FilterOptions-expand yxt-FilterOptions-collapseDown">
-                {{> icons/iconPartial iconName='chevron'}}
+                {{> icons/bakedInIcon iconName='chevron'}}
               </span>
             {{/if}}
           </div>
@@ -49,7 +49,7 @@
       <div class="yxt-FilterOptions-search js-yxt-FilterOptions-search">
         <input type="text" class="yxt-FilterOptions-filter js-yxt-FilterOptions-filter" aria-label="{{searchLabelText}}" placeholder="{{placeholderText}}">
         <button class="yxt-FilterOptions-clearSearch js-yxt-FilterOptions-clearSearch js-hidden">
-          {{> icons/iconPartial iconName='close'}}
+          {{> icons/bakedInIcon iconName='close'}}
         </button>
       </div>
     {{/if}}
@@ -115,7 +115,7 @@
           {{showLessLabel}}
         </span>
         <span class="yxt-FilterOptions-collapseUp">
-          {{> icons/iconPartial iconName='chevron'}}
+          {{> icons/bakedInIcon iconName='chevron'}}
         </span>
       </button>
       <button class="yxt-FilterOptions-showToggle js-yxt-FilterOptions-showToggle js-yxt-FilterOptions-showMore{{#unless showMoreState}} hidden{{/unless}}">
@@ -123,7 +123,7 @@
           {{showMoreLabel}}
         </span>
         <span class="yxt-FilterOptions-collapseDown">
-          {{> icons/iconPartial iconName='chevron'}}
+          {{> icons/bakedInIcon iconName='chevron'}}
         </span>
       </button>
     {{/if}}

--- a/src/ui/templates/controls/sortoptions.hbs
+++ b/src/ui/templates/controls/sortoptions.hbs
@@ -32,14 +32,14 @@
         <button class='yxt-SortOptions-showToggle'>
           {{_config.showMoreLabel}}
           <span class='yxt-SortOptions-collapseDown'>
-            {{> icons/iconPartial iconName='chevron'}}
+            {{> icons/bakedInIcon iconName='chevron'}}
           </span>
         </button>
       {{else}}
         <button class='yxt-SortOptions-showToggle'>
           {{_config.showLessLabel}}
           <span class='yxt-SortOptions-collapseUp'>
-            {{> icons/iconPartial iconName='chevron'}}
+            {{> icons/bakedInIcon iconName='chevron'}}
           </span>
         </button>
       {{/if}}

--- a/src/ui/templates/filters/filterbox.hbs
+++ b/src/ui/templates/filters/filterbox.hbs
@@ -2,7 +2,7 @@
   {{#if title}}
     <h2 class="yxt-FilterBox-titleContainer">
       <div>
-        {{> icons/iconPartial iconName='elements'}}
+        {{> icons/bakedInIcon iconName='elements'}}
       </div>
       <span class="yxt-FilterBox-title">{{title}}</span>
     </h2>

--- a/src/ui/templates/icons/bakedInIcon.hbs
+++ b/src/ui/templates/icons/bakedInIcon.hbs
@@ -1,0 +1,3 @@
+<div class="Icon Icon--{{iconName}} {{classNames}}" aria-hidden="true">
+  {{icon iconName complexContentsParams}}
+</div>

--- a/src/ui/templates/navigation/navigation.hbs
+++ b/src/ui/templates/navigation/navigation.hbs
@@ -21,7 +21,7 @@
     <div class="yxt-Nav-moreContainer">
       <button id="yxt-Nav-moreButton" class="yxt-Nav-item yxt-Nav-more yxt-Nav-item--more js-yxt-navMore">
         <span class="yxt-Nav-moreIcon">
-          {{> icons/iconPartial iconName=overflowIcon}}
+          {{> icons/bakedInIcon iconName=overflowIcon}}
         </span>
         {{overflowLabel}}
       </button>

--- a/src/ui/templates/questions/questionsubmission.hbs
+++ b/src/ui/templates/questions/questionsubmission.hbs
@@ -9,7 +9,7 @@
     aria-expanded="{{#if questionExpanded}}true{{else}}false{{/if}}">
     <div class="yxt-QuestionSubmission-left">
       <div class="yxt-QuestionSubmission-titleIconWrapper">
-        {{> icons/iconPartial iconName=_config.sectionTitleIconName}}
+        {{> icons/bakedInIcon iconName=_config.sectionTitleIconName}}
       </div>
       <div class="yxt-QuestionSubmission-title">
         {{_config.sectionTitle}}
@@ -20,7 +20,7 @@
         {{_config.teaser}}
       </div>
       <span class="yxt-QuestionSubmission-toggle{{#if questionExpanded}}--expanded{{else}}--collapsed{{/if}} yxt-QuestionSubmission-toggle">
-        {{> icons/iconPartial iconName='chevron'}}
+        {{> icons/bakedInIcon iconName='chevron'}}
       </span>
     </div>
   </button>

--- a/src/ui/templates/results/alternativeverticals.hbs
+++ b/src/ui/templates/results/alternativeverticals.hbs
@@ -29,7 +29,7 @@
                 </span>
               </div>
               <div class="yxt-AlternativeVerticals-arrowIconWrapper">
-                {{> icons/iconPartial iconName='chevron'}}
+                {{> icons/bakedInIcon iconName='chevron'}}
               </div>
             </a>
           </li>

--- a/src/ui/templates/results/directanswer.hbs
+++ b/src/ui/templates/results/directanswer.hbs
@@ -48,7 +48,7 @@
           <form class="yxt-DirectAnswer-thumbs js-directAnswer-feedback-form">
             <label class="yxt-DirectAnswer-thumb">
               <span class="yxt-DirectAnswer-thumbUpIcon">
-                {{> icons/iconPartial iconName='thumb'}}
+                {{> icons/bakedInIcon iconName='thumb'}}
               </span>
               <input type="radio"
                     name="feedback"
@@ -60,7 +60,7 @@
             </label>
             <label class="yxt-DirectAnswer-thumb">
               <span class="yxt-DirectAnswer-thumbDownIcon">
-                {{> icons/iconPartial iconName='thumb'}}
+                {{> icons/bakedInIcon iconName='thumb'}}
               </span>
               <input type="radio"
                     name="feedback"

--- a/src/ui/templates/results/pagination.hbs
+++ b/src/ui/templates/results/pagination.hbs
@@ -9,10 +9,10 @@
       >
         {{#unless icons.firstButtonIcon}}
           <span class="yxt-Pagination-doubleChevron--left">
-            {{> icons/iconPartial iconName='chevron'}}
+            {{> icons/bakedInIcon iconName='chevron'}}
           </span>
           <span class="yxt-Pagination-chevron--left">
-            {{> icons/iconPartial iconName='chevron'}}
+            {{> icons/bakedInIcon iconName='chevron'}}
           </span>
         {{else}}
           <span class="yxt-Pagination-doubleChevron--left">
@@ -30,7 +30,7 @@
     >
       {{#unless icons.previousButtonIcon}}
         <span class="yxt-Pagination-chevron--left">
-          {{> icons/iconPartial iconName='chevron'}}
+          {{> icons/bakedInIcon iconName='chevron'}}
         </span>
       {{else}}
         <span class="yxt-Pagination-chevron--left">
@@ -96,7 +96,7 @@
     >
       {{#unless icons.nextButtonIcon}}
         <span class="yxt-Pagination-chevron">
-          {{> icons/iconPartial iconName='chevron'}}
+          {{> icons/bakedInIcon iconName='chevron'}}
         </span>
       {{else}}
         <span class="yxt-Pagination-chevron">
@@ -113,10 +113,10 @@
       >
         {{#unless icons.lastButtonIcon}}
         <span class="yxt-Pagination-doubleChevron">
-          {{> icons/iconPartial iconName='chevron'}}
+          {{> icons/bakedInIcon iconName='chevron'}}
         </span>
         <span class="yxt-Pagination-chevron">
-          {{> icons/iconPartial iconName='chevron'}}
+          {{> icons/bakedInIcon iconName='chevron'}}
         </span>
         {{else}}
           <span class="yxt-Pagination-doubleChevron">

--- a/src/ui/templates/results/resultsaccordion.hbs
+++ b/src/ui/templates/results/resultsaccordion.hbs
@@ -19,7 +19,7 @@
                 {{this.title}}
                 <div class="yxt-AccordionResult-indicatorWrapper" aria-hidden="true">
                   <span class="yxt-AccordionResult-indicator">
-                    {{> icons/iconPartial iconName='chevron'}}
+                    {{> icons/bakedInIcon iconName='chevron'}}
                   </span>
                 </div>
               </button>
@@ -42,7 +42,7 @@
                             {{#if this.icon}}
                               <div class="yxt-AccordionResult-ctaIconWrapper">
                                 <span class="yxt-AccordionResult-ctaIcon">
-                                  {{> icons/iconPartial iconName=this.icon}}
+                                  {{> icons/bakedInIcon iconName=this.icon}}
                                 </span>
                               </div>
                             {{/if}}

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -29,7 +29,7 @@
       {{#if _config.icon}}
         <div class="yxt-Results-titleIconWrapper">
           {{#if iconIsBuiltIn}}
-            {{> icons/iconPartial iconName=_config.icon }}
+            {{> icons/bakedInIcon iconName=_config.icon }}
           {{else}}
             {{> icons/iconPartial iconUrl=_config.icon }}
           {{/if}}
@@ -78,7 +78,7 @@
     >
       <div class="yxt-Results-viewAllLabel">{{_config.viewMoreLabel}}</div>
       <div>
-        {{> icons/iconPartial iconName='chevron'}}
+        {{> icons/bakedInIcon iconName='chevron'}}
       </div>
     </a>
   {{/if}}

--- a/src/ui/templates/search/search.hbs
+++ b/src/ui/templates/search/search.hbs
@@ -47,16 +47,16 @@
           {{else}}
             <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedForward
               {{#if autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/if}}">
-              {{> icons/iconPartial
-                bakedInIcon='yext_animated_forward'
+              {{> icons/bakedInIcon
+                iconName='yext_animated_forward'
                 classNames='Icon--lg'
                 complexContentsParams=forwardIconOpts.complexContentsParams
               }}
             </div>
             <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedReverse
               {{#unless autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/unless}}">
-              {{> icons/iconPartial
-                bakedInIcon='yext_animated_reverse'
+              {{> icons/bakedInIcon
+                iconName='yext_animated_reverse'
                 classNames='Icon--lg'
                 complexContentsParams=reverseIconOpts.complexContentsParams
               }}

--- a/src/ui/templates/search/search.hbs
+++ b/src/ui/templates/search/search.hbs
@@ -29,7 +29,7 @@
                 data-eventtype="SEARCH_CLEAR_BUTTON"
                 data-eventoptions="{{eventOptions}}"
         >
-          {{> icons/iconPartial iconName='close'}}
+          {{> icons/bakedInIcon iconName='close'}}
           <span class="yxt-SearchBar-clearButtonText sr-only">
             {{clearText}}
           </span>
@@ -38,7 +38,7 @@
           class="js-yext-submit yxt-SearchBar-button">
           {{#if submitIcon}}
             <div class="yxt-SearchBar-buttonImage">
-              {{> icons/iconPartial iconName=submitIcon}}
+              {{> icons/bakedInIcon iconName=submitIcon}}
             </div>
           {{else if _config.customIconUrl}}
             <div class="yxt-SearchBar-buttonImage">
@@ -48,7 +48,7 @@
             <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedForward
               {{#if autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/if}}">
               {{> icons/iconPartial
-                iconName='yext_animated_forward'
+                bakedInIcon='yext_animated_forward'
                 classNames='Icon--lg'
                 complexContentsParams=forwardIconOpts.complexContentsParams
               }}
@@ -56,7 +56,7 @@
             <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedReverse
               {{#unless autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/unless}}">
               {{> icons/iconPartial
-                iconName='yext_animated_reverse'
+                bakedInIcon='yext_animated_reverse'
                 classNames='Icon--lg'
                 complexContentsParams=reverseIconOpts.complexContentsParams
               }}
@@ -91,7 +91,7 @@
                 data-eventtype="SEARCH_CLEAR_BUTTON"
                 data-eventoptions="{{eventOptions}}"
         >
-          {{> icons/iconPartial iconName='close' }}
+          {{> icons/bakedInIcon iconName='close' }}
           <span class="yxt-SearchBar-clearButtonText sr-only">
             {{clearText}}
           </span>
@@ -100,7 +100,7 @@
           class="js-yext-submit yxt-SearchBar-button">
           {{#if submitIcon}}
             <div class="yxt-SearchBar-buttonImage">
-              {{> icons/iconPartial iconName=submitIcon}}
+              {{> icons/bakedInIcon iconName=submitIcon}}
             </div>
           {{else if _config.customIconUrl}}
             <div class="yxt-SearchBar-buttonImage">


### PR DESCRIPTION
This PR replaces all icon usages that only are meant to use a 
baked in icon with the icons/bakedInIcon partial.

The issue with just using iconPartial for everything is that, some icons are intended
to always use a baked in icon instead of switch between an iconName
(for built in icons) and an iconUrl (for custom icons).
However, handlebars partials operate on the context on which they are called, not only
on the variables passed into it. So, if an iconUrl exists on the scope somebody calls
`{{> icons/iconPartial iconName='chevron'}}`, an iconUrl will be passed into the partial
even though none was explicitly passed in.

Since iconUrl has higher priority than iconName, this can cause undesired behavior.
I think the best workaround is just creating a separate partial when we want an icon
that is built into the SDK.

J=SLAP-1297
TEST=manual

test that baked in icons display as expected and do not have this
behavior

see the animated search icon working as expected

manually check that all iconPartial usages have a specified iconUrl