### PR TITLE
Spellcheck integration testing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
    "ignorePatterns": ["dist", "docs"],
    "globals": {
       "beforeEach": true,
+      "afterEach": true,
       "beforeAll": true,
       "describe": true,
       "it": true,

--- a/__mocks__/@yext/answers-core/lib/commonjs.js
+++ b/__mocks__/@yext/answers-core/lib/commonjs.js
@@ -1,0 +1,14 @@
+const provideCore = function () {
+  return {
+    universalSearch: jest.fn(),
+    verticalSearch: jest.fn(),
+    universalAutocomplete: jest.fn(),
+    verticalAutocomplete: jest.fn(),
+    filterSearch: jest.fn(),
+    submitQuestion: jest.fn()
+  };
+};
+
+module.exports = {
+  provideCore
+};

--- a/__mocks__/@yext/answers-core/lib/commonjs.js
+++ b/__mocks__/@yext/answers-core/lib/commonjs.js
@@ -1,11 +1,26 @@
 const provideCore = function () {
   return {
-    universalSearch: jest.fn(),
-    verticalSearch: jest.fn(),
-    universalAutocomplete: jest.fn(),
-    verticalAutocomplete: jest.fn(),
-    filterSearch: jest.fn(),
-    submitQuestion: jest.fn()
+    universalSearch: jest.fn(() => {
+      return Promise.resolve({
+        queryId: '123',
+        verticalResults: []
+      });
+    }),
+    verticalSearch: jest.fn(() => {
+      return Promise.resolve({});
+    }),
+    universalAutocomplete: jest.fn(() => {
+      return Promise.resolve({});
+    }),
+    verticalAutocomplete: jest.fn(() => {
+      return Promise.resolve({});
+    }),
+    filterSearch: jest.fn(() => {
+      return Promise.resolve({});
+    }),
+    submitQuestion: jest.fn(() => {
+      return Promise.resolve({});
+    })
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -134,7 +134,8 @@
     "testMatch": [
       "**/tests/core/**/*.js",
       "**/tests/ui/**/*.js",
-      "**/tests/conf/**/*.js"
+      "**/tests/conf/**/*.js",
+      "**/tests/answers-umd.js"
     ]
   },
   "percy": {

--- a/tests/acceptance/acceptancesuites/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuites/acceptancesuite.js
@@ -104,12 +104,6 @@ test('spell check flow', async t => {
   await spellCheckComponent.clickLink();
   pageNum = await paginationComponent.getActivePageLabelAndNumber();
   await t.expect(pageNum).eql('Page 1');
-
-  // Check that clicking spell check sends a queryTrigger=suggest url param
-  // TODO(SLAP-1062) investigate making this an integration test
-  const queryParams = await getMostRecentQueryParamsFromLogger(spellCheckLogger);
-  const queryTriggerParam = queryParams.get('queryTrigger');
-  await t.expect(queryTriggerParam).eql('suggest');
 });
 
 test('navigating pages and hitting the browser back button lands you on the right page', async t => {

--- a/tests/acceptance/acceptancesuites/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuites/acceptancesuite.js
@@ -14,7 +14,6 @@ import {
   browserRefreshPage,
   registerIE11NoCacheHook
 } from '../utils';
-import { getMostRecentQueryParamsFromLogger } from '../requestUtils';
 import StorageKeys from '../../../src/core/storage/storagekeys';
 
 /**

--- a/tests/answers-umd.js
+++ b/tests/answers-umd.js
@@ -36,7 +36,14 @@ function mockWindowWithData (data) {
     performance: {
       mark: jest.fn()
     },
+    sessionStorage: {
+      getItem: jest.fn(),
+      setItem: jest.fn()
+    },
     addEventListener: jest.fn(),
+    history: {
+      replaceState: jest.fn()
+    },
     ...data
   }));
 }

--- a/tests/answers-umd.js
+++ b/tests/answers-umd.js
@@ -1,0 +1,56 @@
+import ANSWERS from '../src/answers-umd';
+
+let windowSpy;
+
+describe('ANSWERS instance integration testing', () => {
+  beforeEach(() => {
+    windowSpy = jest.spyOn(window, 'window', 'get');
+  });
+
+  afterEach(() => {
+    windowSpy.mockRestore();
+  });
+
+  it('Spellcheck query params in the URL trigger a spellcheck search during ANSWERS initialization', async () => {
+    mockWindowWithData({
+      location: {
+        search: '?query=office+space&queryTrigger=suggest&skipSpellCheck=true'
+      }
+    });
+    await initAnswers();
+    const expectedParams = expect.objectContaining({
+      query: 'office space',
+      queryTrigger: 'suggest',
+      skipSpellCheck: 'true'
+    });
+    expect(ANSWERS.core._coreLibrary.universalSearch).toHaveBeenCalledWith(expectedParams);
+  });
+});
+
+/**
+ * Mocks the window for jest testing while putting the provided data on the window
+ * @param {*} data
+ */
+function mockWindowWithData (data) {
+  windowSpy.mockImplementation(() => ({
+    performance: {
+      mark: jest.fn()
+    },
+    addEventListener: jest.fn(),
+    ...data
+  }));
+}
+
+/**
+ * Initializes ANSWERS for jest testing with some functionality disabled
+ */
+async function initAnswers () {
+  // Don't load the templates during testing
+  ANSWERS._loadTemplates = () => Promise.resolve();
+  await ANSWERS.init({
+    apiKey: 'test',
+    experienceKey: 'test',
+    // Don't load this polyfill during testing
+    disableCssVariablesPonyfill: 'true'
+  });
+}

--- a/tests/ui/components/search/spellcheckcomponent.js
+++ b/tests/ui/components/search/spellcheckcomponent.js
@@ -1,5 +1,6 @@
 import DOM from '../../../../src/ui/dom/dom';
 import mockManager from '../../../setup/managermocker';
+import { mount } from 'enzyme';
 import StorageKeys from '../../../../src/core/storage/storagekeys';
 import SpellCheckComponent from '../../../../src/ui/components/search/spellcheckcomponent';
 
@@ -17,8 +18,10 @@ describe('spellcheck redirect links', () => {
     type: 'SUGGEST'
   });
 
-  const correctedQueryUrl = component.getState('correctedQueryUrl');
-  const linkUrlParams = new URLSearchParams(correctedQueryUrl);
+  const wrapper = mount(component);
+  const suggestionLinkWrapper = wrapper.find('.yxt-SpellCheck-container a');
+  const suggestionLinkURL = new URL(suggestionLinkWrapper.getDOMNode().href);
+  const linkUrlParams = new URLSearchParams(suggestionLinkURL.search);
 
   it('redirect links contain a query url param', () => {
     const query = linkUrlParams.get('query');


### PR DESCRIPTION
Convert a spellcheck acceptance test into integration tests

This test coverage has two parts. In the first part, our test coverage confirms that the spellcheck components renders with the correct query params in the hyperlink. To accomplish this, I converted the previous spellcheck tests to more of an integration test by mounting the component with the enzyme adapter.

In the second part, I confirm that when ANSWERS initializes with the spellcheck params in the URL, a search is fired with those spellcheck params. To make this possible, this PR sets up integration testing for answers-umd which previously did not exist in our jest tests. This PR mocks the core library so that we don't actually fire HTTP requests when running these tests.

J=SLAP-1062
TEST=auto

Add integration test coverage