### PR TITLE
use package-lock.json for cache instead of package.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
       - save_cache:
           paths:
             - node_modules
-          key: v2-dependencies-{{ checksum "package-lockpack.json" }}
+          key: v2-dependencies-{{ checksum "package-lock.json" }}
   deploy-to-aws:
     description: "Deploys the dist directory to a given subdirectory of the answers bucket"
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,14 +10,14 @@ commands:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package.json" }}
+            - v2-dependencies-{{ checksum "package-lock.json" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v2-dependencies-
       - run: npm install
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: v2-dependencies-{{ checksum "package-lockpack.json" }}
   deploy-to-aws:
     description: "Deploys the dist directory to a given subdirectory of the answers bucket"
     parameters:


### PR DESCRIPTION
The package-lock.json is a unique identifier for the node module
dependencies for a repo. The package.json is not, so we shouldn't
use its hash as part of the circleci cache key.

TEST=manual
J=none

saw that the circleci build still saves a cache and uses it in subsequent builds