### PR TITLE
build develop with i18n assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - dev/i18n-develop
+                - develop
                 - master
                 - /^support\/.*/
                 - /^hotfix\/.*/
@@ -219,7 +219,7 @@ workflows:
           filters:
             branches:
               only:
-                - dev/i18n-develop
+                - develop
                 - /^support\/.*/
                 - /^hotfix\/.*/
                 - /^feature\/.*-i18n/
@@ -243,7 +243,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - dev/i18n-develop
+                - develop
           requires:
             - unit_test
             - browserstack_acceptance_test
@@ -253,7 +253,7 @@ workflows:
       - deploy_canary:
           filters:
             branches:
-              only: dev/i18n-develop
+              only: develop
           requires:
             - unit_test
             - headless_acceptance_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,6 +185,7 @@ workflows:
           filters:
             branches:
               ignore:
+                - dev/i18n-develop
                 - master
                 - /^support\/.*/
                 - /^hotfix\/.*/
@@ -205,21 +206,7 @@ workflows:
       - third_party_notices_test:
           requires:
             - build
-      - deploy_canary:
-          filters:
-            branches:
-              only: develop
-          requires:
-            - unit_test
-            - headless_acceptance_test
-            - browserstack_acceptance_test
-            - translation_test
-            - third_party_notices_test
       - deploy_branch:
-          filters:
-            branches:
-              ignore:
-                - develop
           requires:
             - unit_test
             - browserstack_acceptance_test
@@ -232,6 +219,7 @@ workflows:
           filters:
             branches:
               only:
+                - dev/i18n-develop
                 - /^support\/.*/
                 - /^hotfix\/.*/
                 - /^feature\/.*-i18n/
@@ -252,10 +240,24 @@ workflows:
           requires:
             - build_i18n
       - deploy_branch:
+          filters:
+            branches:
+              ignore:
+                - dev/i18n-develop
           requires:
             - unit_test
             - browserstack_acceptance_test
             - headless_acceptance_test
+            - translation_test
+            - third_party_notices_test
+      - deploy_canary:
+          filters:
+            branches:
+              only: dev/i18n-develop
+          requires:
+            - unit_test
+            - headless_acceptance_test
+            - browserstack_acceptance_test
             - translation_test
             - third_party_notices_test
   build_and_deploy_hold:


### PR DESCRIPTION
This way the theme's test-site can point to canary/latest
and have i18n snapshots work.
I was wrong, and the i18n build will build ALL the locales, not just the languages.
On the other hand, this still shouldn't cost too much storage since it's only a single branch.

J=SLAP-1423
TEST=manual

use this branch's name (dev/i18n-develop) instead of develop in the circleci config,
see the i18n build run