### PR TITLE
pin regenerator-runtime to 0.13.1

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -6227,31 +6227,41 @@ IN THE SOFTWARE.
 
 The following NPM packages may be included in this product:
 
- - regenerator-runtime@0.13.7
+ - regenerator-runtime@0.13.1
 
 These packages each contain the following license and notice below:
 
-MIT License
+# regenerator-runtime
 
-Copyright (c) 2014-present, Facebook, Inc.
+Standalone runtime for
+[Regenerator](https://github.com/facebook/regenerator)-compiled generator
+and `async` functions.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+To import the runtime as a module (recommended), either of the following
+import styles will work:
+```js
+// CommonJS
+const regeneratorRuntime = require("regenerator-runtime");
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+// ECMAScript 2015
+import regeneratorRuntime from "regenerator-runtime";
+```
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+To ensure that `regeneratorRuntime` is defined globally, either of the
+following styles will work:
+```js
+// CommonJS
+require("regenerator-runtime/runtime");
+
+// ECMAScript 2015
+import "regenerator-runtime/runtime";
+```
+
+To get the absolute file system path of `runtime.js`, evaluate the
+following expression:
+```js
+require("regenerator-runtime/path").path
+```
 
 -----------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3685,6 +3685,14 @@
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.1.tgz",
+          "integrity": "sha512-5KzMIyPLvfdPmvsdlYsHqITrDfK9k7bmvf97HvHSN4810i254ponbxCQ1NukpRWlu6en2MBWzAlhDExEKISwAA==",
+          "dev": true
+        }
       }
     },
     "@babel/runtime-corejs3": {
@@ -3694,6 +3702,13 @@
       "requires": {
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.1.tgz",
+          "integrity": "sha512-5KzMIyPLvfdPmvsdlYsHqITrDfK9k7bmvf97HvHSN4810i254ponbxCQ1NukpRWlu6en2MBWzAlhDExEKISwAA=="
+        }
       }
     },
     "@babel/template": {
@@ -4641,6 +4656,14 @@
       "requires": {
         "@babel/runtime": "^7.7.2",
         "regenerator-runtime": "^0.13.3"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.1.tgz",
+          "integrity": "sha512-5KzMIyPLvfdPmvsdlYsHqITrDfK9k7bmvf97HvHSN4810i254ponbxCQ1NukpRWlu6en2MBWzAlhDExEKISwAA==",
+          "dev": true
+        }
       }
     },
     "@mapbox/mapbox-gl-language": {
@@ -14835,6 +14858,14 @@
         "@jimp/plugins": "^0.16.1",
         "@jimp/types": "^0.16.1",
         "regenerator-runtime": "^0.13.3"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.1.tgz",
+          "integrity": "sha512-5KzMIyPLvfdPmvsdlYsHqITrDfK9k7bmvf97HvHSN4810i254ponbxCQ1NukpRWlu6en2MBWzAlhDExEKISwAA==",
+          "dev": true
+        }
       }
     },
     "jpeg-js": {
@@ -14989,6 +15020,12 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
+    "json-format": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-format/-/json-format-1.0.1.tgz",
+      "integrity": "sha1-FD9n5irxKda//tKIpGJl6iPQ3ww=",
       "dev": true
     },
     "json-parse-better-errors": {
@@ -16836,6 +16873,17 @@
         "once": "^1.3.2"
       }
     },
+    "npm-force-resolutions": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/npm-force-resolutions/-/npm-force-resolutions-0.0.10.tgz",
+      "integrity": "sha512-Jscex+xIU6tw3VsyrwxM1TeT+dd9Fd3UOMAjy6J1TMpuYeEqg4LQZnATQO5vjPrsARm3und6zc6Dii/GUyRE5A==",
+      "dev": true,
+      "requires": {
+        "json-format": "^1.0.1",
+        "source-map-support": "^0.5.5",
+        "xmlhttprequest": "^1.8.0"
+      }
+    },
     "npm-normalize-package-bin": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
@@ -17661,6 +17709,14 @@
         "request": "^2.87.0",
         "request-promise": "^4.2.2",
         "walk": "^2.3.14"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.1.tgz",
+          "integrity": "sha512-5KzMIyPLvfdPmvsdlYsHqITrDfK9k7bmvf97HvHSN4810i254ponbxCQ1NukpRWlu6en2MBWzAlhDExEKISwAA==",
+          "dev": true
+        }
       }
     },
     "performance-now": {
@@ -19777,7 +19833,8 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -25097,6 +25154,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.3.tgz",
       "integrity": "sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==",
+      "dev": true
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "i18next-conv": "^10.0.2",
     "jest": "^24.8.0",
     "jsdoc": "^3.6.3",
+    "npm-force-resolutions": "0.0.10",
     "postcss-pxtorem": "4.0.1",
     "regenerator-runtime": "^0.13.7",
     "rollup": "^1.4.1",
@@ -110,9 +111,13 @@
     "size": "size-limit",
     "fix": "eslint . --fix",
     "extract-translations": "gulp extractTranslations",
+    "preinstall": "npx npm-force-resolutions",
     "prepublishOnly": "./conf/npm/prepublishOnly.sh",
     "postpublish": "./conf/npm/postpublish.sh",
     "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES"
+  },
+  "resolutions": {
+    "regenerator-runtime": "0.13.1"
   },
   "jest": {
     "bail": 0,


### PR DESCRIPTION
npm-force-resolutions ports a yarn only feature where
you can pin transient dependencies to a specific version.

We're using it for regenerator-runtime so that a searchbar
only integration will comply with a CSP prohibiting unsafe-eval.

Due to testcafe not working with <meta> tags prescribing CSP,
we will need some workaround to get an acceptance test for this.

This commit will be cherrypicked into support/v1.8

J=SLAP-1433
TEST=manual

test that I can load the searchbar with a meta tag prohibiting unsafe-eval
see that trying to use v1.9 without these changes causes the searchbar to
not render at all