### PR TITLE
Query Source Setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ function initAnswers() {
     onUniversalSearch: function() {},
     // Optional, opt-out of automatic css variable resolution on init for legacy browsers
     disableCssVariablesPonyfill: false,
-    // Optional, the analytics key describing the Answers integration type. Accepts 'STANDARD' or 'OVERLAY', defaults to 'STANDARD'
+    // Optional, the analytics key describing the Answers integration type. Accepts 'STANDARD', 'OVERLAY', or arbitrary strings. Defaults to 'STANDARD'
     querySource: 'STANDARD',
   })
 }

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -499,6 +499,14 @@ class Answers {
   }
 
   /**
+   * Sets the query source which is included with universal and vertical searches
+   * @param {string} source
+   */
+  setQuerySource (source) {
+    this.core.storage.set(StorageKeys.QUERY_SOURCE, source);
+  }
+
+  /**
    * Sets a search query on initialization for vertical searchers that have a
    * defaultInitialSearch provided, if the user hasn't already provided their
    * own via URL param. A default initial search should not be persisted in the URL,

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -15,7 +15,7 @@ export const SANDBOX = 'sandbox';
 /** The default url for compiled component templates */
 export const COMPILED_TEMPLATES_URL = `https://assets.sitescdn.net/answers/${LIB_VERSION}/answerstemplates.compiled.min.js`;
 
-/** The query source, reported with analytics */
+/** The default query source reported with analytics */
 export const QUERY_SOURCE = 'STANDARD';
 
 export const ENDPOINTS = {


### PR DESCRIPTION
Add ability to set the querySource at runtime with a call to `ANSWERS.setQuerySource()`

J=SLAP-1438
TEST=manual

Use the setter and observe the updated query param in subsequent network requests