### PR TITLE
add opacity to DirectAnswer during search loading state

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -329,7 +329,6 @@ export default class Core {
       }
     }
 
-    this.storage.set(StorageKeys.DIRECT_ANSWER, {});
     const universalResults = this.storage.get(StorageKeys.UNIVERSAL_RESULTS);
     if (!universalResults || universalResults.searchState !== SearchStates.SEARCH_LOADING) {
       this.storage.set(StorageKeys.UNIVERSAL_RESULTS, UniversalResults.searchLoading());
@@ -337,6 +336,7 @@ export default class Core {
     this.storage.set(StorageKeys.QUESTION_SUBMISSION, {});
     this.storage.set(StorageKeys.SPELL_CHECK, {});
     this.storage.set(StorageKeys.LOCATION_BIAS, LocationBias.searchLoading());
+    this.storage.set(StorageKeys.DIRECT_ANSWER, DirectAnswer.searchLoading());
 
     const queryTrigger = this.storage.get(StorageKeys.QUERY_TRIGGER);
     const queryTriggerForApi = this.getQueryTriggerForSearchApi(queryTrigger);

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -329,6 +329,7 @@ export default class Core {
       }
     }
 
+    this.storage.set(StorageKeys.DIRECT_ANSWER, DirectAnswer.searchLoading());
     const universalResults = this.storage.get(StorageKeys.UNIVERSAL_RESULTS);
     if (!universalResults || universalResults.searchState !== SearchStates.SEARCH_LOADING) {
       this.storage.set(StorageKeys.UNIVERSAL_RESULTS, UniversalResults.searchLoading());
@@ -336,7 +337,6 @@ export default class Core {
     this.storage.set(StorageKeys.QUESTION_SUBMISSION, {});
     this.storage.set(StorageKeys.SPELL_CHECK, {});
     this.storage.set(StorageKeys.LOCATION_BIAS, LocationBias.searchLoading());
-    this.storage.set(StorageKeys.DIRECT_ANSWER, DirectAnswer.searchLoading());
 
     const queryTrigger = this.storage.get(StorageKeys.QUERY_TRIGGER);
     const queryTriggerForApi = this.getQueryTriggerForSearchApi(queryTrigger);

--- a/src/core/models/directanswer.js
+++ b/src/core/models/directanswer.js
@@ -1,8 +1,10 @@
 /** @module DirectAnswer */
 
+import SearchStates from '../storage/searchstates';
+
 export default class DirectAnswer {
   constructor (directAnswer = {}) {
-    Object.assign(this, directAnswer);
+    Object.assign(this, { searchState: SearchStates.SEARCH_COMPLETE }, directAnswer);
     Object.freeze(this);
   }
 
@@ -70,5 +72,13 @@ export default class DirectAnswer {
       data.relatedItem.data.fieldValues,
       data.relatedItem.verticalConfigId,
       true);
+  }
+
+  /**
+   * Construct a DirectAnswer object representing loading results
+   * @return {DirectAnswer}
+   */
+  static searchLoading () {
+    return new DirectAnswer({ searchState: SearchStates.SEARCH_LOADING });
   }
 }

--- a/src/core/statelisteners/queryupdatelistener.js
+++ b/src/core/statelisteners/queryupdatelistener.js
@@ -1,3 +1,4 @@
+import DirectAnswer from '../models/directanswer';
 import QueryTriggers from '../models/querytriggers';
 import UniversalResults from '../models/universalresults';
 import VerticalResults from '../models/verticalresults';
@@ -77,6 +78,7 @@ export default class QueryUpdateListener {
     this.config.verticalKey
       ? this.core.storage.set(StorageKeys.VERTICAL_RESULTS, VerticalResults.searchLoading())
       : this.core.storage.set(StorageKeys.UNIVERSAL_RESULTS, UniversalResults.searchLoading());
+    this.core.storage.set(StorageKeys.DIRECT_ANSWER, DirectAnswer.searchLoading());
   }
 
   _search (query) {

--- a/src/ui/components/results/directanswercomponent.js
+++ b/src/ui/components/results/directanswercomponent.js
@@ -229,14 +229,13 @@ export default class DirectAnswerComponent extends Component {
   }
 
   eventOptions (data) {
-    if (!data || Object.keys(data).length === 0 ||
-      (Object.keys(data).length === 1 && Object.keys(data)[0] === 'searchState')) {
+    if (!data || Object.keys(data).length === 0) {
       return data;
     }
     return JSON.stringify({
-      verticalConfigId: data.relatedItem.verticalConfigId,
+      verticalConfigId: data.relatedItem?.verticalConfigId,
       searcher: 'UNIVERSAL',
-      entityId: data.relatedItem.data.id,
+      entityId: data.relatedItem?.data.id,
       ctaLabel: this._viewDetailsText.toUpperCase().replace(' ', '_')
     });
   }

--- a/src/ui/components/results/directanswercomponent.js
+++ b/src/ui/components/results/directanswercomponent.js
@@ -123,10 +123,6 @@ export default class DirectAnswerComponent extends Component {
     return 'results/directanswer';
   }
 
-  onCreate () {
-    this.updateContainerClass(SearchStates.PRE_SEARCH);
-  }
-
   /**
    * beforeMount, only display the direct answer component if it has data
    */

--- a/src/ui/components/results/directanswercomponent.js
+++ b/src/ui/components/results/directanswercomponent.js
@@ -5,6 +5,8 @@ import AnalyticsEvent from '../../../core/analytics/analyticsevent';
 import StorageKeys from '../../../core/storage/storagekeys';
 import DOM from '../../dom/dom';
 import TranslationFlagger from '../../i18n/translationflagger';
+import SearchStates from '../../../core/storage/searchstates';
+import { getContainerClass } from '../../../core/utils/resultsutils';
 
 /**
  * EventTypes are explicit strings defined
@@ -121,6 +123,10 @@ export default class DirectAnswerComponent extends Component {
     return 'results/directanswer';
   }
 
+  onCreate () {
+    this.updateContainerClass(SearchStates.PRE_SEARCH);
+  }
+
   /**
    * beforeMount, only display the direct answer component if it has data
    */
@@ -200,8 +206,25 @@ export default class DirectAnswerComponent extends Component {
     this.setState(newState);
   }
 
+  /**
+   * Updates the search state css class on this component's container.
+   */
+  updateContainerClass (searchState) {
+    Object.values(SearchStates).forEach(searchState => {
+      this.removeContainerClass(getContainerClass(searchState));
+    });
+    this.addContainerClass(getContainerClass(searchState));
+  }
+
   setState (data) {
+    const searchState = data.searchState || SearchStates.PRE_SEARCH;
+    this.updateContainerClass(searchState);
+    if (searchState === SearchStates.SEARCH_LOADING) {
+      return;
+    }
+
     return super.setState(Object.assign({}, data, {
+      searchState: searchState,
       eventOptions: this.eventOptions(data),
       viewDetailsText: this._viewDetailsText,
       directAnswer: data,
@@ -210,7 +233,8 @@ export default class DirectAnswerComponent extends Component {
   }
 
   eventOptions (data) {
-    if (!data || Object.keys(data).length === 0) {
+    if (!data || Object.keys(data).length === 0 ||
+      (Object.keys(data).length === 1 && Object.keys(data)[0] === 'searchState')) {
       return data;
     }
     return JSON.stringify({

--- a/tests/ui/components/results/directanswercomponent.js
+++ b/tests/ui/components/results/directanswercomponent.js
@@ -3,6 +3,8 @@ import mockManager from '../../../setup/managermocker';
 import DirectAnswerComponent from '../../../../src/ui/components/results/directanswercomponent';
 import StorageKeys from '../../../../src/core/storage/storagekeys';
 import { mount } from 'enzyme';
+import DirectAnswer from '../../../../src/core/models/directanswer';
+import SearchStates from '../../../../src/core/storage/searchstates';
 
 DOM.setup(document, new DOMParser());
 let COMPONENT_MANAGER, defaultConfig;
@@ -287,4 +289,17 @@ it('displays the answer correctly', () => {
   const wrapper = mount(component);
   const actualAnswer = wrapper.find('.yxt-DirectAnswer-fieldValue').text().trim();
   expect(actualAnswer).toEqual('+18003332222');
+});
+
+it('sets correct loading state css class', () => {
+  const component = COMPONENT_MANAGER.create(DirectAnswerComponent.type, defaultConfig);
+  const container = DOM.query('#test-component');
+  mount(component, { attachTo: container });
+  expect(container.classList.contains('yxt-Results--preSearch')).toBeTruthy();
+
+  component.core.storage.set(StorageKeys.DIRECT_ANSWER, DirectAnswer.searchLoading());
+  expect(container.classList.contains('yxt-Results--searchLoading')).toBeTruthy();
+
+  component.core.storage.set(StorageKeys.DIRECT_ANSWER, { searchState: SearchStates.SEARCH_COMPLETE });
+  expect(container.classList.contains('yxt-Results--searchComplete')).toBeTruthy();
 });


### PR DESCRIPTION
Add opacity to DirectAnswer while search is loading

- Update DirectAnswer to have searchState 
- add the corresponding css class to container based on searchState for opacity styling

J=SLAP-1445
TEST=auto&manual

- added jest test to verify the right css class is set for different loading state
- Launched test site and verified that opacity is added to direct answer on universal page