### PR TITLE
handle plural form not being present + error message

### DIFF
--- a/src/core/i18n/translationprocessor.js
+++ b/src/core/i18n/translationprocessor.js
@@ -34,7 +34,7 @@ export default class TranslationProcessor {
     const oneToNArray = this._generateArrayOneToN(language);
     const pluralFormIndex = getPluralFunc(language)(count, oneToNArray);
     if (!(pluralFormIndex in translations)) {
-      console.error(`msgstr[${pluralFormIndex}] not found for msgid "${translations[0]}" and language "${language}".`);
+      console.error(`msgstr[${pluralFormIndex}] not found for msgid "${translations[0]}" and locale "${language}".`);
       return translations[0];
     }
     return translations[pluralFormIndex];

--- a/src/core/i18n/translationprocessor.js
+++ b/src/core/i18n/translationprocessor.js
@@ -33,6 +33,10 @@ export default class TranslationProcessor {
     }
     const oneToNArray = this._generateArrayOneToN(language);
     const pluralFormIndex = getPluralFunc(language)(count, oneToNArray);
+    if (!(pluralFormIndex in translations)) {
+      console.error(`msgstr[${pluralFormIndex}] not found for msgid "${translations[0]}" and language "${language}".`);
+      return translations[0];
+    }
     return translations[pluralFormIndex];
   }
 

--- a/tests/core/i18n/translationprocessor.js
+++ b/tests/core/i18n/translationprocessor.js
@@ -107,4 +107,17 @@ describe('selecting the correct plural form', () => {
     const translation = TranslationProcessor.process(translations, { count: 100 }, 100, 'hawaii', escapeExpression);
     expect(translation).toEqual('Pasirinkta 100 tinklalapiai');
   });
+
+  it('logs an error, and returns the singular form when the plural form is not found', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const translation = TranslationProcessor.process({
+      0: 'original msgid',
+      1: 'plural form',
+    }, { count: 4 }, 4, 'ar-DZ', escapeExpression);
+    expect(translation).toEqual('original msgid');
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'msgstr[3] not found for msgid "original msgid" and locale "ar-DZ".');
+    errorSpy.mockRestore();
+  });
 });

--- a/tests/core/i18n/translationprocessor.js
+++ b/tests/core/i18n/translationprocessor.js
@@ -112,7 +112,7 @@ describe('selecting the correct plural form', () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const translation = TranslationProcessor.process({
       0: 'original msgid',
-      1: 'plural form',
+      1: 'plural form'
     }, { count: 4 }, 4, 'ar-DZ', escapeExpression);
     expect(translation).toEqual('original msgid');
     expect(errorSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
When I was trying to get arabic to work the SDK (it
was hard to even tell it was the SDK) was throwing a very
unhelpful error message regarding translations.

The issue was that our translation processor was trying to access
a plural form that did not exist in the arabic po file, since we
only received translations for the SDK and not the theme.
The method would then return undefined, and break later on.

I chose to display the original msgid instead of trying to find the "closest"
english plural form, for simplicity.

J=SLAP-1394
TEST=manual

see that the error is handled gracefully now