### PR TITLE
update scss to use math.div instead of slash division

### DIFF
--- a/src/ui/sass/_fonts.scss
+++ b/src/ui/sass/_fonts.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $font-weight-bold: 700 !default;
 $font-weight-semibold: 600 !default;
 $font-weight-medium: 500 !default;
@@ -14,10 +16,10 @@ $font-size-xxlg: 40px !default;
 
 $line-height-xs: 1 !default;
 $line-height-sm: 1.2 !default;
-$line-height-md-sm: 4/3 !default;
+$line-height-md-sm: math.div(4, 3) !default;
 $line-height-md: 1.4 !default;
 $line-height-lg: 1.5 !default;
-$line-height-xlg: 5/3 !default;
+$line-height-xlg: math.div(5, 3) !default;
 $line-height-xxlg: 1.7 !default;
 
 $font-family: system-ui,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif !default;


### PR DESCRIPTION
Slash division is deprecated and throws annoying warnings during the build.
We can still (to be more specific *have* to) use slash division inside calc()s

J=SLAP-1454
TEST=manual

open dev tools, see that the css variables that use the changed scss
variables ($line-height-xlg and $line-height-md-sm) still have the correct values