### PR TITLE
State Machine for SearchBar Icon

### DIFF
--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -390,12 +390,12 @@ export default class SearchComponent extends Component {
       searchBarContainer: this._container,
       inputEl: this._inputEl
     };
-    const searchBarIconController = new SearchBarIconController(config);
+    this.searchBarIconController = new SearchBarIconController(config);
     if (this._showLoadingIndicator) {
-      searchBarIconController.setupLoadingIconEvents(this.core.storage, this._verticalKey);
+      this.searchBarIconController.setupLoadingIconEvents(this.core.storage, this._verticalKey);
     }
     if (!config.useCustomIcon) {
-      searchBarIconController.setupAnimatedIconEvents();
+      this.searchBarIconController.setupAnimatedIconEvents();
     }
   }
 

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -7,16 +7,9 @@ import SearchParams from '../../dom/searchparams';
 import TranslationFlagger from '../../i18n/translationflagger';
 import QueryUpdateListener from '../../../core/statelisteners/queryupdatelistener';
 import QueryTriggers from '../../../core/models/querytriggers';
-import SearchStates from '../../../core/storage/searchstates';
 import VoiceSearchController from '../../controllers/voicesearchcontroller';
 import { speechRecognitionIsSupported } from '../../../core/speechrecognition/support';
-
-const IconState = {
-  LOADING: '.js-yxt-SearchBar-LoadingIndicator',
-  CUSTOM_ICON: '.js-yxt-SearchBar-buttonImage',
-  YEXT: '.js-yxt-AnimatedReverse',
-  MAGNIFYING_GLASS: '.js-yxt-AnimatedForward'
-};
+import SearchBarIconController from '../../controllers/searchbariconcontroller';
 
 /**
  * SearchComponent exposes an interface in order to create
@@ -296,21 +289,7 @@ export default class SearchComponent extends Component {
      * Custom icon url for loading indicator
      * @type {string}
      */
-    this.customLoadingIconUrl = config.loadingIndicator?.iconUrl || null;
-
-    if (this._showLoadingIndicator) {
-      this.core.storage.registerListener({
-        eventType: 'update',
-        storageKey: this._verticalKey ? StorageKeys.VERTICAL_RESULTS : StorageKeys.UNIVERSAL_RESULTS,
-        callback: results => {
-          results.searchState === SearchStates.SEARCH_LOADING
-            ? this.animateIconToLoading()
-            : this.animateIconToDoneLoading();
-        }
-      });
-    }
-
-    this.onMouseUp = this.oneTimeMouseUpListener.bind(this);
+    this._customLoadingIconUrl = config.loadingIndicator?.iconUrl || null;
 
     this._voiceSearchConfig = config.voiceSearch || {};
 
@@ -381,8 +360,7 @@ export default class SearchComponent extends Component {
       this.focusInputElement();
     }
 
-    this.isUsingYextAnimatedIcon = !this._config.customIconUrl && !this.submitIcon;
-    this.isUsingYextAnimatedIcon ? this.initAnimatedIcon() : this.iconState = IconState.CUSTOM_ICON;
+    this.initSearchBarIconController();
 
     if (this._showVoiceSearch) {
       const voiceSearchController = new VoiceSearchController(this._container, this._voiceSearchConfig);
@@ -405,93 +383,20 @@ export default class SearchComponent extends Component {
     }
   }
 
-  requestIconAnimationFrame (iconState) {
-    if (this.iconState === iconState) {
-      return;
+  initSearchBarIconController () {
+    const config = {
+      useCustomIcon: this._config.customIconUrl || this.submitIcon,
+      isFocus: this.autoFocus && !this.query,
+      searchBarContainer: this._container,
+      inputEl: this._inputEl
+    };
+    const searchBarIconController = new SearchBarIconController(config);
+    if (this._showLoadingIndicator) {
+      searchBarIconController.setupLoadingIconEvents(this.core.storage, this._verticalKey);
     }
-    if (this.animationID) {
-      window.cancelAnimationFrame(this.animationID);
+    if (!config.useCustomIcon) {
+      searchBarIconController.setupAnimatedIconEvents();
     }
-    this.animationID = window.requestAnimationFrame(() => {
-      this.prevState = this.iconState;
-      this.iconState = iconState;
-      DOM.query(this._container, this.prevState).classList.add('yxt-SearchBar-Icon--inactive');
-      const activeIcon = DOM.query(this._container, this.iconState);
-      activeIcon.classList.remove('yxt-SearchBar-Icon--inactive');
-      if (this.iconState === IconState.MAGNIFYING_GLASS) {
-        DOM.query(activeIcon, '.Icon--yext_animated_forward').classList.remove('yxt-SearchBar-MagnifyingGlass--static');
-      }
-      if (this.iconState === IconState.YEXT) {
-        DOM.query(activeIcon, '.Icon--yext_animated_reverse').classList.remove('yxt-SearchBar-Yext--static');
-      }
-
-      // Static yext icon is used after loading to avoid unecessary transition from magnifying glass to yext.
-      if (this.iconState === IconState.YEXT) {
-        const yextIconEl = DOM.query(activeIcon, '.Icon--yext_animated_reverse');
-        this.prevState === IconState.LOADING
-          ? yextIconEl.classList.add('yxt-SearchBar-Yext--static')
-          : yextIconEl.classList.remove('yxt-SearchBar-Yext--static');
-      }
-      this.animationID = null;
-    });
-  }
-
-  animateIconToLoading () {
-    this.requestIconAnimationFrame(IconState.LOADING);
-  }
-
-  animateIconToDoneLoading () {
-    this.iconIsFrozen = false;
-    if (this.isUsingYextAnimatedIcon) {
-      this.queryEl === document.activeElement
-        ? this.requestIconAnimationFrame(IconState.MAGNIFYING_GLASS)
-        : this.requestIconAnimationFrame(IconState.YEXT);
-    } else {
-      this.requestIconAnimationFrame(IconState.CUSTOM_ICON);
-    }
-  }
-
-  animateIconToMagnifyingGlass () {
-    if (this.iconState === IconState.LOADING || this.iconIsFrozen) {
-      return;
-    }
-    this.requestIconAnimationFrame(IconState.MAGNIFYING_GLASS);
-  }
-
-  animateIconToYext (e) {
-    let focusStillInSearchbar = false;
-    if (e && e.relatedTarget) {
-      focusStillInSearchbar = this._container.contains(e.relatedTarget);
-    }
-    if (this.iconState === IconState.LOADING || this.iconIsFrozen || focusStillInSearchbar) {
-      return;
-    }
-    this.requestIconAnimationFrame(IconState.YEXT);
-  }
-
-  oneTimeMouseUpListener () {
-    document.removeEventListener('mouseup', this.onMouseUp);
-    this.iconIsFrozen = false;
-  }
-
-  initAnimatedIcon () {
-    this.iconState = (this.autoFocus && !this.query) ? IconState.MAGNIFYING_GLASS : IconState.YEXT;
-    const clickableElementSelectors = ['.js-yext-submit', '.js-yxt-SearchBar-clear'];
-    for (const selector of clickableElementSelectors) {
-      const clickableEl = DOM.query(this._container, selector);
-      if (clickableEl) {
-        DOM.on(clickableEl, 'mousedown', () => {
-          this.iconIsFrozen = true;
-          DOM.on(document, 'mouseup', this.onMouseUp);
-        });
-      }
-    }
-    DOM.on(this.queryEl, 'focus', () => {
-      this.animateIconToMagnifyingGlass();
-    });
-    DOM.on(this._container, 'focusout', e => {
-      this.animateIconToYext(e);
-    });
   }
 
   remove () {

--- a/src/ui/controllers/searchbariconcontroller.js
+++ b/src/ui/controllers/searchbariconcontroller.js
@@ -35,25 +35,27 @@ export default class SearchBarIconController {
     this.searchBarContainer = config.searchBarContainer;
     this.onMouseUp = this.oneTimeMouseUpListener.bind(this);
 
-    const loadingState = new LoadingIconState(this, IconState.LOADING_ICON);
-    const searchState = new SearchIconState(this, IconState.SEARCH_ICON, config.useCustomIcon);
-    const defaultState = new DefaultIconState(this, IconState.DEFAULT_ICON, config.useCustomIcon);
+    const stateMap = {
+      [IconState.LOADING_ICON]: new LoadingIconState(this, IconState.LOADING_ICON),
+      [IconState.DEFAULT_ICON]: new DefaultIconState(this, IconState.DEFAULT_ICON, config.useCustomIcon),
+      [IconState.SEARCH_ICON]: new SearchIconState(this, IconState.SEARCH_ICON, config.useCustomIcon)
+    };
 
     const possibleTransitions = {
       [IconState.LOADING_ICON]: {
-        SEARCH_COMPLETE: defaultState
+        [IconEvent.SEARCH_COMPLETE]: IconState.DEFAULT_ICON
       },
       [IconState.DEFAULT_ICON]: {
-        SUBMIT: loadingState,
-        FOCUS: searchState
+        [IconEvent.SUBMIT]: IconState.LOADING_ICON,
+        [IconEvent.FOCUS]: IconState.SEARCH_ICON
       },
       [IconState.SEARCH_ICON]: {
-        SUBMIT: loadingState,
-        FOCUS_OUT: defaultState
+        [IconEvent.SUBMIT]: IconState.LOADING_ICON,
+        [IconEvent.FOCUS_OUT]: IconState.DEFAULT_ICON
       }
     };
-    const initialIconState = config.isFocus ? searchState : defaultState;
-    this._fsm = new StateMachine(initialIconState, possibleTransitions);
+    const initialIconState = config.isFocus ? stateMap[IconState.SEARCH_ICON] : stateMap[IconState.DEFAULT_ICON];
+    this._fsm = new StateMachine(initialIconState, stateMap, possibleTransitions);
   }
 
   handleEvent (event, context) {

--- a/src/ui/controllers/searchbariconcontroller.js
+++ b/src/ui/controllers/searchbariconcontroller.js
@@ -1,0 +1,83 @@
+import SearchStates from '../../core/storage/searchstates';
+import StorageKeys from '../../core/storage/storagekeys';
+import DOM from '../dom/dom';
+import LoadingIconState from '../statemachine/loadingiconstate';
+import SearchIconState from '../statemachine/searchiconstate';
+import DefaultIconState from '../statemachine/defaulticonstate';
+import { StateMachine } from '../statemachine/statemachine';
+
+/**
+ * Responsible for controlling the search bar icon behavior
+ */
+export default class SearchBarIconController {
+  constructor (config) {
+    this.iconIsFrozen = false;
+    this.inputEl = config.inputEl;
+    this.searchBarContainer = config.searchBarContainer;
+    this.onMouseUp = this.oneTimeMouseUpListener.bind(this);
+
+    const IconState = {
+      LOADING: new LoadingIconState(this),
+      SEARCH: new SearchIconState(this, config.useCustomIcon),
+      DEFAULT: new DefaultIconState(this, config.useCustomIcon)
+    };
+
+    const transitions = {
+      [IconState.LOADING.id]: {
+        SEARCH_COMPLETE: IconState.DEFAULT
+      },
+      [IconState.DEFAULT.id]: {
+        SUBMIT: IconState.LOADING,
+        FOCUS: IconState.SEARCH
+      },
+      [IconState.SEARCH.id]: {
+        SUBMIT: IconState.LOADING,
+        FOCUS_OUT: IconState.DEFAULT
+      }
+    };
+    const initialIconState = config.isFocus ? IconState.SEARCH : IconState.DEFAULT;
+    this._fsm = new StateMachine(initialIconState, transitions);
+  }
+
+  handleEvent (event, context) {
+    this._fsm.updateState(event, context);
+  }
+
+  setupLoadingIconEvents (storage, verticalKey) {
+    storage.registerListener({
+      eventType: 'update',
+      storageKey: verticalKey ? StorageKeys.VERTICAL_RESULTS : StorageKeys.UNIVERSAL_RESULTS,
+      callback: results => {
+        this.iconIsFrozen = false;
+        results.searchState === SearchStates.SEARCH_LOADING
+          ? this.handleEvent('SUBMIT')
+          : this.handleEvent('SEARCH_COMPLETE');
+      }
+    });
+  }
+
+  setupAnimatedIconEvents () {
+    const clickableElementSelectors = ['.js-yext-submit', '.js-yxt-SearchBar-clear'];
+    for (const selector of clickableElementSelectors) {
+      const clickableEl = DOM.query(this.searchBarContainer, selector);
+      if (clickableEl) {
+        DOM.on(clickableEl, 'mousedown', () => {
+          this.iconIsFrozen = true;
+          DOM.on(document, 'mouseup', this.onMouseUp);
+        });
+      }
+    }
+    const queryEl = DOM.query(this.searchBarContainer, this.inputEl);
+    DOM.on(queryEl, 'focus', () => {
+      this.handleEvent('FOCUS');
+    });
+    DOM.on(this.searchBarContainer, 'focusout', e => {
+      this.handleEvent('FOCUS_OUT', e);
+    });
+  }
+
+  oneTimeMouseUpListener () {
+    document.removeEventListener('mouseup', this.onMouseUp);
+    this.iconIsFrozen = false;
+  }
+}

--- a/src/ui/statemachine/defaulticonstate.js
+++ b/src/ui/statemachine/defaulticonstate.js
@@ -1,0 +1,45 @@
+import { State } from './statemachine';
+import LoadingIconState from './loadingiconstate';
+import DOM from '../dom/dom';
+
+/**
+ * Defines behavior for search bar icon in default state and during state transitions
+ */
+export default class DefaultIconState extends State {
+  constructor (controller, useCustomIcon) {
+    super('default');
+    this._controller = controller;
+    this._useCustomIcon = useCustomIcon;
+    this._defaultIconElement = useCustomIcon
+      ? DOM.query(this._controller.searchBarContainer, '.js-yxt-SearchBar-buttonImage')
+      : DOM.query(this._controller.searchBarContainer, '.js-yxt-AnimatedReverse');
+  }
+
+  canEnter (e) {
+    let focusStillInSearchbar = false;
+    if (e && e.relatedTarget) {
+      focusStillInSearchbar = this._controller.searchBarContainer.contains(e.relatedTarget);
+    }
+    return !this._controller.iconIsFrozen && !focusStillInSearchbar;
+  }
+
+  onEnter (prevState) {
+    this._useCustomIcon ? this._handleTransitionToCustom() : this._handleTransitionToYext(prevState);
+  }
+
+  _handleTransitionToYext (prevState) {
+    this._defaultIconElement.classList.remove('yxt-SearchBar-Icon--inactive');
+    const svgWrapper = DOM.query(this._defaultIconElement, '.Icon--yext_animated_reverse');
+    prevState instanceof LoadingIconState
+      ? svgWrapper.classList.add('yxt-SearchBar-Yext--static')
+      : svgWrapper.classList.remove('yxt-SearchBar-Yext--static');
+  }
+
+  _handleTransitionToCustom () {
+    this._defaultIconElement.classList.remove('yxt-SearchBar-Icon--inactive');
+  }
+
+  onExit (nextState) {
+    this._defaultIconElement.classList.add('yxt-SearchBar-Icon--inactive');
+  }
+}

--- a/src/ui/statemachine/defaulticonstate.js
+++ b/src/ui/statemachine/defaulticonstate.js
@@ -3,16 +3,19 @@ import LoadingIconState from './loadingiconstate';
 import DOM from '../dom/dom';
 
 /**
- * Defines behavior for search bar icon in default state and during state transitions
+ * Defines behavior for search bar icon in default state (Yext logo) and during state transitions
  */
 export default class DefaultIconState extends State {
-  constructor (controller, useCustomIcon) {
-    super('default');
+  constructor (controller, stateId, useCustomIcon) {
+    super(stateId);
     this._controller = controller;
     this._useCustomIcon = useCustomIcon;
-    this._defaultIconElement = useCustomIcon
-      ? DOM.query(this._controller.searchBarContainer, '.js-yxt-SearchBar-buttonImage')
-      : DOM.query(this._controller.searchBarContainer, '.js-yxt-AnimatedReverse');
+    if (useCustomIcon) {
+      this._defaultIconElement = DOM.query(this._controller.searchBarContainer, '.js-yxt-SearchBar-buttonImage');
+    } else {
+      this._defaultIconElement = DOM.query(this._controller.searchBarContainer, '.js-yxt-AnimatedReverse');
+      this.svgWrapper = DOM.query(this._defaultIconElement, '.Icon--yext_animated_reverse');
+    }
   }
 
   canEnter (e) {
@@ -29,10 +32,9 @@ export default class DefaultIconState extends State {
 
   _handleTransitionToYext (prevState) {
     this._defaultIconElement.classList.remove('yxt-SearchBar-Icon--inactive');
-    const svgWrapper = DOM.query(this._defaultIconElement, '.Icon--yext_animated_reverse');
     prevState instanceof LoadingIconState
-      ? svgWrapper.classList.add('yxt-SearchBar-Yext--static')
-      : svgWrapper.classList.remove('yxt-SearchBar-Yext--static');
+      ? this.svgWrapper.classList.add('yxt-SearchBar-Yext--static')
+      : this.svgWrapper.classList.remove('yxt-SearchBar-Yext--static');
   }
 
   _handleTransitionToCustom () {

--- a/src/ui/statemachine/loadingiconstate.js
+++ b/src/ui/statemachine/loadingiconstate.js
@@ -5,10 +5,11 @@ import DOM from '../dom/dom';
  * Defines behavior for search bar icon in loading state and during state transitions
  */
 export default class LoadingIconState extends State {
-  constructor (controller) {
-    super('loading');
+  constructor (controller, stateId) {
+    super(stateId);
     this._controller = controller;
     this._loadingIconElement = DOM.query(this._controller.searchBarContainer, '.js-yxt-SearchBar-LoadingIndicator');
+    this.inputEl = DOM.query(this._controller.searchBarContainer, this._controller.inputEl);
   }
 
   onEnter (prevState) {
@@ -16,7 +17,7 @@ export default class LoadingIconState extends State {
   }
 
   onExit (nextState) {
-    DOM.query(this._controller.searchBarContainer, this._controller.inputEl).blur();
+    this.inputEl.blur();
     this._loadingIconElement.classList.add('yxt-SearchBar-Icon--inactive');
   }
 }

--- a/src/ui/statemachine/loadingiconstate.js
+++ b/src/ui/statemachine/loadingiconstate.js
@@ -1,0 +1,22 @@
+import { State } from './statemachine';
+import DOM from '../dom/dom';
+
+/**
+ * Defines behavior for search bar icon in loading state and during state transitions
+ */
+export default class LoadingIconState extends State {
+  constructor (controller) {
+    super('loading');
+    this._controller = controller;
+    this._loadingIconElement = DOM.query(this._controller.searchBarContainer, '.js-yxt-SearchBar-LoadingIndicator');
+  }
+
+  onEnter (prevState) {
+    this._loadingIconElement.classList.remove('yxt-SearchBar-Icon--inactive');
+  }
+
+  onExit (nextState) {
+    DOM.query(this._controller.searchBarContainer, this._controller.inputEl).blur();
+    this._loadingIconElement.classList.add('yxt-SearchBar-Icon--inactive');
+  }
+}

--- a/src/ui/statemachine/searchiconstate.js
+++ b/src/ui/statemachine/searchiconstate.js
@@ -1,0 +1,37 @@
+import { State } from './statemachine';
+import DOM from '../dom/dom';
+
+/**
+ * Defines behavior for search bar icon in search state and during state transitions
+ */
+export default class SearchIconState extends State {
+  constructor (controller, useCustomIcon) {
+    super('search');
+    this._controller = controller;
+    this._useCustomIcon = useCustomIcon;
+    this._searchIconElement = useCustomIcon
+      ? DOM.query(this._controller.searchBarContainer, '.js-yxt-SearchBar-buttonImage')
+      : DOM.query(this._controller.searchBarContainer, '.js-yxt-AnimatedForward');
+  }
+
+  canEnter (context) {
+    return !this._controller.iconIsFrozen;
+  }
+
+  onEnter (prevState) {
+    this._useCustomIcon ? this._handleTransitionToCustom() : this._handleTransitionToMagifyingGlass();
+  }
+
+  _handleTransitionToMagifyingGlass () {
+    this._searchIconElement.classList.remove('yxt-SearchBar-Icon--inactive');
+    DOM.query(this._searchIconElement, '.Icon--yext_animated_forward').classList.remove('yxt-SearchBar-MagnifyingGlass--static');
+  }
+
+  _handleTransitionToCustom () {
+    this._searchIconElement.classList.remove('yxt-SearchBar-Icon--inactive');
+  }
+
+  onExit (nextState) {
+    this._searchIconElement.classList.add('yxt-SearchBar-Icon--inactive');
+  }
+}

--- a/src/ui/statemachine/searchiconstate.js
+++ b/src/ui/statemachine/searchiconstate.js
@@ -5,13 +5,16 @@ import DOM from '../dom/dom';
  * Defines behavior for search bar icon in search state and during state transitions
  */
 export default class SearchIconState extends State {
-  constructor (controller, useCustomIcon) {
-    super('search');
+  constructor (controller, stateId, useCustomIcon) {
+    super(stateId);
     this._controller = controller;
     this._useCustomIcon = useCustomIcon;
-    this._searchIconElement = useCustomIcon
-      ? DOM.query(this._controller.searchBarContainer, '.js-yxt-SearchBar-buttonImage')
-      : DOM.query(this._controller.searchBarContainer, '.js-yxt-AnimatedForward');
+    if (useCustomIcon) {
+      this._searchIconElement = DOM.query(this._controller.searchBarContainer, '.js-yxt-SearchBar-buttonImage');
+    } else {
+      this._searchIconElement = DOM.query(this._controller.searchBarContainer, '.js-yxt-AnimatedForward');
+      this.svgWrapper = DOM.query(this._searchIconElement, '.Icon--yext_animated_forward');
+    }
   }
 
   canEnter (context) {
@@ -24,7 +27,7 @@ export default class SearchIconState extends State {
 
   _handleTransitionToMagifyingGlass () {
     this._searchIconElement.classList.remove('yxt-SearchBar-Icon--inactive');
-    DOM.query(this._searchIconElement, '.Icon--yext_animated_forward').classList.remove('yxt-SearchBar-MagnifyingGlass--static');
+    this.svgWrapper.classList.remove('yxt-SearchBar-MagnifyingGlass--static');
   }
 
   _handleTransitionToCustom () {

--- a/src/ui/statemachine/statemachine.js
+++ b/src/ui/statemachine/statemachine.js
@@ -1,3 +1,7 @@
+/**
+ * Defines a status of a system, including entry and exit behaviors and
+ * any related data and actions during this state.
+ */
 export class State {
   constructor (id) {
     this.id = id;

--- a/src/ui/statemachine/statemachine.js
+++ b/src/ui/statemachine/statemachine.js
@@ -1,0 +1,45 @@
+export class State {
+  constructor (id) {
+    this.id = id;
+  }
+
+  canEnter (context) { return true; }
+  onEnter (prevState) {}
+  onExit (nextState) {}
+}
+
+/**
+ * Finite state machine model that tracks current behavior status and performs state transitions.
+ */
+export class StateMachine {
+  constructor (initialState, transitions) {
+    /**
+     * @type {State} initial state where the execution of the machine starts
+     */
+    this._state = initialState;
+
+    /**
+     * @type {Object<string, Object<string, State>>}  state-transition map that defines
+     * what states that machine can move to based on current state and event
+     */
+    this.transitions = transitions;
+  }
+
+  /**
+   * Change current state to new state if the given event is associated
+   * with one of the possible transitions from the current state
+   *
+   * @param {string} event an event to trigger a state transition
+   * @param {*} context event context and/or data to pass to the possible next state
+   * @returns {State} updated state
+   */
+  updateState (event, context) {
+    const nextState = this.transitions[this._state.id][event];
+    if (nextState && nextState !== this._state && nextState.canEnter(context)) {
+      this._state.onExit(nextState);
+      nextState.onEnter(this._state);
+      this._state = nextState;
+    }
+    return this._state;
+  }
+}

--- a/src/ui/statemachine/statemachine.js
+++ b/src/ui/statemachine/statemachine.js
@@ -16,14 +16,19 @@ export class State {
  * Finite state machine model that tracks current behavior status and performs state transitions.
  */
 export class StateMachine {
-  constructor (initialState, transitions) {
+  constructor (initialState, stateMap, transitions) {
     /**
      * @type {State} initial state where the execution of the machine starts
      */
     this._state = initialState;
 
     /**
-     * @type {Object<string, Object<string, State>>}  state-transition map that defines
+     * @type {Object<string, State>} map state id to state instances
+     */
+    this._stateMap = stateMap;
+
+    /**
+     * @type {Object<string, Object<string, string>>}  state-transition map that defines
      * what states that machine can move to based on current state and event
      */
     this.transitions = transitions;
@@ -38,7 +43,7 @@ export class StateMachine {
    * @returns {State} updated state
    */
   updateState (event, context) {
-    const nextState = this.transitions[this._state.id][event];
+    const nextState = this._stateMap[this.transitions[this._state.id][event]];
     if (nextState && nextState !== this._state && nextState.canEnter(context)) {
       this._state.onExit(nextState);
       nextState.onEnter(this._state);

--- a/tests/ui/components/controllers/searchbariconcontroller.js
+++ b/tests/ui/components/controllers/searchbariconcontroller.js
@@ -34,29 +34,37 @@ describe('Search bar icon controller', () => {
     COMPONENT_MANAGER = mockManager();
   });
 
+  const defaultSelector = '.js-yxt-AnimatedReverse';
+  const searchSelector = '.js-yxt-AnimatedForward';
+  const defaultSVGWrapperSelector = '.Icon--yext_animated_reverse';
+  const searchSVGWrapperSelector = '.Icon--yext_animated_forward';
+  const iconInactiveSelector = 'yxt-SearchBar-Icon--inactive';
+  const defaultStaticSelector = 'yxt-SearchBar-Yext--static';
+  const searchStaticSelector = 'yxt-SearchBar-MagnifyingGlass--static';
+
   it('Transition between default icon (Yext) and search icon (Magnifying Glass)', () => {
     const component = COMPONENT_MANAGER.create('SearchBar', defaultConfig);
     const wrapper = mount(component);
     const controller = component.searchBarIconController;
 
-    const defaultIcon = wrapper.find('.js-yxt-AnimatedReverse');
-    const searchIcon = wrapper.find('.js-yxt-AnimatedForward');
-    const defaultSVGWrapper = wrapper.find('.Icon--yext_animated_reverse');
-    const searchSVGWrapper = wrapper.find('.Icon--yext_animated_forward');
+    const defaultIcon = wrapper.find(defaultSelector);
+    const searchIcon = wrapper.find(searchSelector);
+    const defaultSVGWrapper = wrapper.find(defaultSVGWrapperSelector);
+    const searchSVGWrapper = wrapper.find(searchSVGWrapperSelector);
 
-    expect(defaultSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-Yext--static')).toBeTruthy();
-    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+    expect(defaultSVGWrapper.getDOMNode().classList.contains(defaultStaticSelector)).toBeTruthy();
+    expect(defaultIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeFalsy();
 
     controller.handleEvent('FOCUS');
-    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
-    expect(searchIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
-    expect(searchSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-MagnifyingGlass--static')).toBeFalsy();
+    expect(defaultIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeTruthy();
+    expect(searchIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeFalsy();
+    expect(searchSVGWrapper.getDOMNode().classList.contains(searchStaticSelector)).toBeFalsy();
 
     controller.handleEvent('FOCUS_OUT');
-    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
-    expect(searchIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
-    expect(defaultSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-MagnifyingGlass--static')).toBeFalsy();
-    expect(searchSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-MagnifyingGlass--static')).toBeFalsy();
+    expect(defaultIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeFalsy();
+    expect(searchIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeTruthy();
+    expect(defaultSVGWrapper.getDOMNode().classList.contains(searchStaticSelector)).toBeFalsy();
+    expect(searchSVGWrapper.getDOMNode().classList.contains(searchStaticSelector)).toBeFalsy();
   });
 
   it('transition between default icon (Yext) and loading icon', () => {
@@ -64,21 +72,21 @@ describe('Search bar icon controller', () => {
     const wrapper = mount(component);
     const controller = component.searchBarIconController;
 
-    const defaultIcon = wrapper.find('.js-yxt-AnimatedReverse');
+    const defaultIcon = wrapper.find(defaultSelector);
     const loadingIcon = wrapper.find('.js-yxt-SearchBar-LoadingIndicator');
-    const defaultSVGWrapper = wrapper.find('.Icon--yext_animated_reverse');
+    const defaultSVGWrapper = wrapper.find(defaultSVGWrapperSelector);
 
-    expect(defaultSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-Yext--static')).toBeTruthy();
-    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+    expect(defaultSVGWrapper.getDOMNode().classList.contains(defaultStaticSelector)).toBeTruthy();
+    expect(defaultIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeFalsy();
 
     controller.handleEvent('SUBMIT');
-    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
-    expect(loadingIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+    expect(defaultIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeTruthy();
+    expect(loadingIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeFalsy();
 
     controller.handleEvent('SEARCH_COMPLETE');
-    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
-    expect(loadingIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
-    expect(defaultSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-Yext--static')).toBeTruthy();
+    expect(defaultIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeFalsy();
+    expect(loadingIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeTruthy();
+    expect(defaultSVGWrapper.getDOMNode().classList.contains(defaultStaticSelector)).toBeTruthy();
   });
 
   it('transition between search icon (Magnifying Glass) and loading icon', () => {
@@ -86,25 +94,25 @@ describe('Search bar icon controller', () => {
     const wrapper = mount(component);
     const controller = component.searchBarIconController;
 
-    const searchIcon = wrapper.find('.js-yxt-AnimatedForward');
-    const defaultIcon = wrapper.find('.js-yxt-AnimatedReverse');
+    const searchIcon = wrapper.find(searchSelector);
+    const defaultIcon = wrapper.find(defaultSelector);
     const loadingIcon = wrapper.find('.js-yxt-SearchBar-LoadingIndicator');
-    const searchSVGWrapper = wrapper.find('.Icon--yext_animated_forward');
-    const defaultSVGWrapper = wrapper.find('.Icon--yext_animated_reverse');
+    const searchSVGWrapper = wrapper.find(searchSVGWrapperSelector);
+    const defaultSVGWrapper = wrapper.find(defaultSVGWrapperSelector);
 
-    expect(searchSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-MagnifyingGlass--static')).toBeTruthy();
-    expect(searchIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+    expect(searchSVGWrapper.getDOMNode().classList.contains(searchStaticSelector)).toBeTruthy();
+    expect(searchIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeFalsy();
 
     controller.handleEvent('SUBMIT');
-    expect(searchIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
-    expect(loadingIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+    expect(searchIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeTruthy();
+    expect(loadingIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeFalsy();
 
     controller.handleEvent('SEARCH_COMPLETE');
-    expect(searchIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
-    expect(loadingIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
-    expect(searchSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-Yext--static')).toBeFalsy();
-    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
-    expect(defaultSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-Yext--static')).toBeTruthy();
+    expect(searchIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeTruthy();
+    expect(loadingIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeTruthy();
+    expect(searchSVGWrapper.getDOMNode().classList.contains(defaultStaticSelector)).toBeFalsy();
+    expect(defaultIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeFalsy();
+    expect(defaultSVGWrapper.getDOMNode().classList.contains(defaultStaticSelector)).toBeTruthy();
   });
 
   it('transition between custom loading icon and custom default icon', () => {
@@ -115,23 +123,23 @@ describe('Search bar icon controller', () => {
     const defaultIcon = wrapper.find('.js-yxt-SearchBar-buttonImage');
     const loadingIcon = wrapper.find('.js-yxt-SearchBar-LoadingIndicator');
 
-    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+    expect(defaultIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeFalsy();
 
     controller.handleEvent('SUBMIT');
-    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
-    expect(loadingIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+    expect(defaultIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeTruthy();
+    expect(loadingIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeFalsy();
 
     controller.handleEvent('SEARCH_COMPLETE');
-    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
-    expect(loadingIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
+    expect(defaultIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeFalsy();
+    expect(loadingIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeTruthy();
 
     controller.handleEvent('FOCUS');
-    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
-    expect(loadingIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
+    expect(defaultIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeFalsy();
+    expect(loadingIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeTruthy();
 
     controller.handleEvent('FOCUS_OUT');
-    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
-    expect(loadingIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
+    expect(defaultIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeFalsy();
+    expect(loadingIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeTruthy();
   });
 
   it('check that iconIsFrozen works', () => {
@@ -139,25 +147,25 @@ describe('Search bar icon controller', () => {
     const wrapper = mount(component);
     const controller = component.searchBarIconController;
 
-    const defaultIcon = wrapper.find('.js-yxt-AnimatedReverse');
-    const searchIcon = wrapper.find('.js-yxt-AnimatedForward');
-    const defaultSVGWrapper = wrapper.find('.Icon--yext_animated_reverse');
-    const searchSVGWrapper = wrapper.find('.Icon--yext_animated_forward');
+    const defaultIcon = wrapper.find(defaultSelector);
+    const searchIcon = wrapper.find(searchSelector);
+    const defaultSVGWrapper = wrapper.find(defaultSVGWrapperSelector);
+    const searchSVGWrapper = wrapper.find(searchSVGWrapperSelector);
 
-    expect(defaultSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-Yext--static')).toBeTruthy();
-    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+    expect(defaultSVGWrapper.getDOMNode().classList.contains(defaultStaticSelector)).toBeTruthy();
+    expect(defaultIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeFalsy();
 
     controller.iconIsFrozen = true;
     controller.handleEvent('FOCUS');
-    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
-    expect(searchIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
-    expect(defaultSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-Yext--static')).toBeTruthy();
-    expect(searchSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-MagnifyingGlass--static')).toBeTruthy();
+    expect(defaultIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeFalsy();
+    expect(searchIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeTruthy();
+    expect(defaultSVGWrapper.getDOMNode().classList.contains(defaultStaticSelector)).toBeTruthy();
+    expect(searchSVGWrapper.getDOMNode().classList.contains(searchStaticSelector)).toBeTruthy();
 
     controller.iconIsFrozen = false;
     controller.handleEvent('FOCUS');
-    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
-    expect(searchIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
-    expect(searchSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-MagnifyingGlass--static')).toBeFalsy();
+    expect(defaultIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeTruthy();
+    expect(searchIcon.getDOMNode().classList.contains(iconInactiveSelector)).toBeFalsy();
+    expect(searchSVGWrapper.getDOMNode().classList.contains(searchStaticSelector)).toBeFalsy();
   });
 });

--- a/tests/ui/components/controllers/searchbariconcontroller.js
+++ b/tests/ui/components/controllers/searchbariconcontroller.js
@@ -1,0 +1,163 @@
+import DOM from '../../../../src/ui/dom/dom';
+import mockManager from '../../../setup/managermocker';
+import { mount } from 'enzyme';
+
+describe('Search bar icon controller', () => {
+  const defaultConfig = {
+    container: '#test-component',
+    verticalKey: 'verticalKey',
+    inputEl: '.js-yext-query',
+    loadingIndicator: {
+      display: true
+    }
+  };
+
+  const focusIconConfig = {
+    ...defaultConfig,
+    autoFocus: true
+  };
+
+  const customIconConfig = {
+    ...defaultConfig,
+    loadingIndicator: {
+      display: true,
+      iconUrl: 'customLoadingIcon.png'
+    },
+    customIconUrl: 'customIcon.png'
+  };
+
+  let COMPONENT_MANAGER;
+  beforeEach(() => {
+    const bodyEl = DOM.query('body');
+    DOM.empty(bodyEl);
+    DOM.append(bodyEl, DOM.createEl('div', { id: 'test-component' }));
+    COMPONENT_MANAGER = mockManager();
+  });
+
+  it('Transition between default icon (Yext) and search icon (Magnifying Glass)', () => {
+    const component = COMPONENT_MANAGER.create('SearchBar', defaultConfig);
+    const wrapper = mount(component);
+    const controller = component.searchBarIconController;
+
+    const defaultIcon = wrapper.find('.js-yxt-AnimatedReverse');
+    const searchIcon = wrapper.find('.js-yxt-AnimatedForward');
+    const defaultSVGWrapper = wrapper.find('.Icon--yext_animated_reverse');
+    const searchSVGWrapper = wrapper.find('.Icon--yext_animated_forward');
+
+    expect(defaultSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-Yext--static')).toBeTruthy();
+    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+
+    controller.handleEvent('FOCUS');
+    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
+    expect(searchIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+    expect(searchSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-MagnifyingGlass--static')).toBeFalsy();
+
+    controller.handleEvent('FOCUS_OUT');
+    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+    expect(searchIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
+    expect(defaultSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-MagnifyingGlass--static')).toBeFalsy();
+    expect(searchSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-MagnifyingGlass--static')).toBeFalsy();
+  });
+
+  it('transition between default icon (Yext) and loading icon', () => {
+    const component = COMPONENT_MANAGER.create('SearchBar', defaultConfig);
+    const wrapper = mount(component);
+    const controller = component.searchBarIconController;
+
+    const defaultIcon = wrapper.find('.js-yxt-AnimatedReverse');
+    const loadingIcon = wrapper.find('.js-yxt-SearchBar-LoadingIndicator');
+    const defaultSVGWrapper = wrapper.find('.Icon--yext_animated_reverse');
+
+    expect(defaultSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-Yext--static')).toBeTruthy();
+    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+
+    controller.handleEvent('SUBMIT');
+    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
+    expect(loadingIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+
+    controller.handleEvent('SEARCH_COMPLETE');
+    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+    expect(loadingIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
+    expect(defaultSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-Yext--static')).toBeTruthy();
+  });
+
+  it('transition between search icon (Magnifying Glass) and loading icon', () => {
+    const component = COMPONENT_MANAGER.create('SearchBar', focusIconConfig);
+    const wrapper = mount(component);
+    const controller = component.searchBarIconController;
+
+    const searchIcon = wrapper.find('.js-yxt-AnimatedForward');
+    const defaultIcon = wrapper.find('.js-yxt-AnimatedReverse');
+    const loadingIcon = wrapper.find('.js-yxt-SearchBar-LoadingIndicator');
+    const searchSVGWrapper = wrapper.find('.Icon--yext_animated_forward');
+    const defaultSVGWrapper = wrapper.find('.Icon--yext_animated_reverse');
+
+    expect(searchSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-MagnifyingGlass--static')).toBeTruthy();
+    expect(searchIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+
+    controller.handleEvent('SUBMIT');
+    expect(searchIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
+    expect(loadingIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+
+    controller.handleEvent('SEARCH_COMPLETE');
+    expect(searchIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
+    expect(loadingIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
+    expect(searchSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-Yext--static')).toBeFalsy();
+    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+    expect(defaultSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-Yext--static')).toBeTruthy();
+  });
+
+  it('transition between custom loading icon and custom default icon', () => {
+    const component = COMPONENT_MANAGER.create('SearchBar', customIconConfig);
+    const wrapper = mount(component);
+    const controller = component.searchBarIconController;
+
+    const defaultIcon = wrapper.find('.js-yxt-SearchBar-buttonImage');
+    const loadingIcon = wrapper.find('.js-yxt-SearchBar-LoadingIndicator');
+
+    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+
+    controller.handleEvent('SUBMIT');
+    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
+    expect(loadingIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+
+    controller.handleEvent('SEARCH_COMPLETE');
+    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+    expect(loadingIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
+
+    controller.handleEvent('FOCUS');
+    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+    expect(loadingIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
+
+    controller.handleEvent('FOCUS_OUT');
+    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+    expect(loadingIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
+  });
+
+  it('check that iconIsFrozen works', () => {
+    const component = COMPONENT_MANAGER.create('SearchBar', defaultConfig);
+    const wrapper = mount(component);
+    const controller = component.searchBarIconController;
+
+    const defaultIcon = wrapper.find('.js-yxt-AnimatedReverse');
+    const searchIcon = wrapper.find('.js-yxt-AnimatedForward');
+    const defaultSVGWrapper = wrapper.find('.Icon--yext_animated_reverse');
+    const searchSVGWrapper = wrapper.find('.Icon--yext_animated_forward');
+
+    expect(defaultSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-Yext--static')).toBeTruthy();
+    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+
+    controller.iconIsFrozen = true;
+    controller.handleEvent('FOCUS');
+    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+    expect(searchIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
+    expect(defaultSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-Yext--static')).toBeTruthy();
+    expect(searchSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-MagnifyingGlass--static')).toBeTruthy();
+
+    controller.iconIsFrozen = false;
+    controller.handleEvent('FOCUS');
+    expect(defaultIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeTruthy();
+    expect(searchIcon.getDOMNode().classList.contains('yxt-SearchBar-Icon--inactive')).toBeFalsy();
+    expect(searchSVGWrapper.getDOMNode().classList.contains('yxt-SearchBar-MagnifyingGlass--static')).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Move logic around searchBar icons to a state machine system

- Added a general state machine model and state class
- Added a searchBarIconController that holds a state machine and manages all events and behavior surrounding the search bar icons.
- Added 3 states for different behavior in search bar icon (loading, search, and default)
- Removed related search bar icon code from searchBarComponent
- Removed RequestAnimationFrame calls since we are relying on CSS animations

J=SLAP-1437
TEST=manual & auto

- serve page from sdk dist/ and verified icon changes during search, click outside of search bar, type query, and click submit. Verified that custom icons for default and loading states work.
- Added Jest tests for the controller