### PR TITLE
Update SDK to allow DA on vertical search (#1438)

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -304,7 +304,7 @@ MIT License
 
 The following NPM packages may be included in this product:
 
- - @yext/answers-core@1.2.0-alpha.0
+ - @yext/answers-core@1.3.0-alpha.0
 
 These packages each contain the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5389,9 +5389,9 @@
       }
     },
     "@yext/answers-core": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-bQbFanG+OyRR3P4CmvenRZWEC8q5dAk0rIZIjakXU57xf3iOPVPHXns7Yv3ru+yAET/rAqn1UlEXiQK7ZeYCAQ==",
+      "version": "1.3.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.3.0-alpha.0.tgz",
+      "integrity": "sha512-a/EWnGrdUt39+8X+laAPEZWXdSqJizd84j4Fj7WmZIFhFUGo5SHGqGoI/0Dsgx2WOgFTUN9gHh5Lzxek0ZIHXQ==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.0.6"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@mapbox/mapbox-gl-language": "^0.10.1",
-    "@yext/answers-core": "^1.2.0-alpha.0",
+    "@yext/answers-core": "^1.3.0-alpha.0",
     "@yext/answers-storage": "^1.1.0",
     "@yext/rtf-converter": "^1.5.0",
     "cross-fetch": "^3.0.6",

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -184,6 +184,7 @@ export default class Core {
       if (!verticalResults || verticalResults.searchState !== SearchStates.SEARCH_LOADING) {
         this.storage.set(StorageKeys.VERTICAL_RESULTS, VerticalResults.searchLoading());
       }
+      this.storage.set(StorageKeys.DIRECT_ANSWER, {});
       this.storage.set(StorageKeys.SPELL_CHECK, {});
       this.storage.set(StorageKeys.LOCATION_BIAS, LocationBias.searchLoading());
     }
@@ -258,8 +259,12 @@ export default class Core {
           const mergedResults = this.storage.get(StorageKeys.VERTICAL_RESULTS)
             .append(data[StorageKeys.VERTICAL_RESULTS]);
           this.storage.set(StorageKeys.VERTICAL_RESULTS, mergedResults);
+          if (data[StorageKeys.DIRECT_ANSWER].answer) {
+            this.storage.set(StorageKeys.DIRECT_ANSWER, data[StorageKeys.DIRECT_ANSWER]);
+          }
         } else {
           this.storage.set(StorageKeys.VERTICAL_RESULTS, data[StorageKeys.VERTICAL_RESULTS]);
+          this.storage.set(StorageKeys.DIRECT_ANSWER, data[StorageKeys.DIRECT_ANSWER]);
         }
 
         if (data[StorageKeys.DYNAMIC_FILTERS]) {

--- a/src/core/search/searchdatatransformer.js
+++ b/src/core/search/searchdatatransformer.js
@@ -43,6 +43,7 @@ export default class SearchDataTransformer {
     return {
       [StorageKeys.QUERY_ID]: response.queryId,
       [StorageKeys.NAVIGATION]: new Navigation(), // Vertical doesn't respond with ordering, so use empty nav.
+      [StorageKeys.DIRECT_ANSWER]: DirectAnswer.fromCore(response.directAnswer, formatters),
       [StorageKeys.VERTICAL_RESULTS]: VerticalResults.fromCore(
         response.verticalResults, {}, formatters, resultsContext, verticalKey),
       [StorageKeys.DYNAMIC_FILTERS]: DynamicFilters.fromCore(response.facets, resultsContext),

--- a/src/ui/components/results/directanswercomponent.js
+++ b/src/ui/components/results/directanswercomponent.js
@@ -181,7 +181,7 @@ export default class DirectAnswerComponent extends Component {
       verticalKey: relatedItem.verticalConfigId,
       directAnswer: true,
       fieldName: this.getState('answer').fieldApiName,
-      searcher: 'UNIVERSAL',
+      searcher: this._config.isUniversal ? 'UNIVERSAL' : 'VERTICAL',
       entityId: relatedItem.data.id,
       url: event.target.href
     };
@@ -215,7 +215,7 @@ export default class DirectAnswerComponent extends Component {
     }
     return JSON.stringify({
       verticalConfigId: data.relatedItem.verticalConfigId,
-      searcher: 'UNIVERSAL',
+      searcher: this._config.isUniversal ? 'UNIVERSAL' : 'VERTICAL',
       entityId: data.relatedItem.data.id,
       ctaLabel: this._viewDetailsText.toUpperCase().replace(' ', '_')
     });

--- a/tests/core/search/searchdatatransformer.js
+++ b/tests/core/search/searchdatatransformer.js
@@ -9,6 +9,7 @@ import ResponseWithResults from '../../fixtures/responseWithResults.json';
 import ResponseWithoutResults from '../../fixtures/responseWithNoResults.json';
 import ResultsContext from '../../../src/core/storage/resultscontext';
 import AlternativeVerticals from '../../../src/core/models/alternativeverticals';
+import DirectAnswer from '../../../src/core/models/directanswer';
 
 describe('tranform vertical search response', () => {
   let response;
@@ -22,10 +23,13 @@ describe('tranform vertical search response', () => {
   it('transforms vertical response correctly with results', () => {
     const data = response;
     const result = SearchDataTransformer.transformVertical(data);
+    const formatters = {};
+
     expect(result).toEqual(
       {
         [StorageKeys.QUERY_ID]: data.queryId,
         [StorageKeys.NAVIGATION]: new Navigation(), // Vertical doesn't respond with ordering, so use empty nav.
+        [StorageKeys.DIRECT_ANSWER]: DirectAnswer.fromCore(response.directAnswer, formatters),
         [StorageKeys.VERTICAL_RESULTS]: VerticalResults.fromCore(data.verticalResults, {}, {}, ResultsContext.NORMAL),
         [StorageKeys.DYNAMIC_FILTERS]: DynamicFilters.fromCore(data.facets, ResultsContext.NORMAL),
         [StorageKeys.SPELL_CHECK]: SpellCheck.fromCore(data.spellCheck),
@@ -39,10 +43,13 @@ describe('tranform vertical search response', () => {
     const data = responseWithNoResults;
     const result = SearchDataTransformer.transformVertical(data);
     const convertedResponse = SearchDataTransformer._reshapeForNoResults(data);
+    const formatters = {};
+
     expect(result).toEqual(
       {
         [StorageKeys.QUERY_ID]: convertedResponse.queryId,
         [StorageKeys.NAVIGATION]: new Navigation(), // Vertical doesn't respond with ordering, so use empty nav.
+        [StorageKeys.DIRECT_ANSWER]: DirectAnswer.fromCore(response.directAnswer, formatters),
         [StorageKeys.VERTICAL_RESULTS]: VerticalResults.fromCore(
           convertedResponse.verticalResults, {}, {}, ResultsContext.NO_RESULTS),
         [StorageKeys.DYNAMIC_FILTERS]: DynamicFilters.fromCore(convertedResponse.facets, ResultsContext.NO_RESULTS),
@@ -100,6 +107,23 @@ describe('forming no results response', () => {
           }
         ]
       },
+      directAnswer: {
+        type: 'FEATURED_SNIPPET',
+        relatedResult: {
+          rawData: {},
+          source: 'KNOWLEDGE_MANAGER'
+        },
+        verticalKey: 'help_articles',
+        snippet: {
+          value: 'Lorem ipsum dolor sit amet.\n consectetur adipiscing elit.',
+          matchedSubstrings: [
+            {
+              offset: 0,
+              length: 10
+            }
+          ]
+        }
+      },
       appliedQueryFilters: []
     };
   });
@@ -116,6 +140,7 @@ describe('forming no results response', () => {
       results: [],
       resultsCount: 0,
       allResultsForVertical: [],
+      directAnswer: {},
       appliedQueryFilters: []
     };
     const convertedResponse = SearchDataTransformer._reshapeForNoResults(responseEmptyResults);
@@ -125,6 +150,7 @@ describe('forming no results response', () => {
       facets: undefined,
       resultsCount: 0,
       allResultsForVertical: [],
+      directAnswer: {},
       appliedQueryFilters: []
     });
   });
@@ -133,6 +159,7 @@ describe('forming no results response', () => {
     const responseEmptyResults = {
       results: [],
       resultsCount: 0,
+      directAnswer: {},
       appliedQueryFilters: []
     };
     const convertedResponse = SearchDataTransformer._reshapeForNoResults(responseEmptyResults);
@@ -141,6 +168,7 @@ describe('forming no results response', () => {
       results: [],
       facets: undefined,
       resultsCount: 0,
+      directAnswer: {},
       appliedQueryFilters: []
     });
   });


### PR DESCRIPTION
Update SDK to allow DA on vertical search

add direct answers to vertical search in sdk core data transformer layer
Note: this sdk is using core version 1.3.0-alpha to get vertical search responses with direct answer

J=SLAP-1389
TEST=auto and manual

Update and run jest tests to see that results are formatted properly.
Verify direct answer is fetched properly from answers-core with console log.
Launched theme test site using local sdk bundle, performed a vertical search on people's page and can verify that direct answer is present in network response

Co-authored-by: Yen Truong <ytruong@yext.com>