### PR TITLE
Support providerOptions on the map

### DIFF
--- a/README.md
+++ b/README.md
@@ -2055,6 +2055,11 @@ ANSWERS.addComponent('Map', {
       labelType: 'numeric'
     };
   },
+  // Optional, an object which contains options which are passed directly to the specified mapProvider.
+  // Refer to the map option api reference for the specified map provider
+  providerOptions: {
+    style: 'mapbox://styles/mapbox/light-v9' // Specifies a custom style for mapbox
+  }
 };
 ```
 

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -111,7 +111,8 @@ export default class GoogleMapProvider extends MapProvider {
       const container = DOM.query(el);
       this.map = new google.maps.Map(container, {
         zoom: this._zoom,
-        center: this.getCenterMarker(mapData)
+        center: this.getCenterMarker(mapData),
+        ...this._providerOptions
       });
 
       // Apply our search data to our GoogleMap

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -67,7 +67,8 @@ export default class MapBoxMapProvider extends MapProvider {
       container: container,
       zoom: this._zoom,
       style: 'mapbox://styles/mapbox/streets-v9',
-      center: this.getCenterMarker(mapData)
+      center: this.getCenterMarker(mapData),
+      ...this._providerOptions
     });
 
     this._map.addControl(new MapboxLanguage({

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -97,6 +97,12 @@ export default class MapProvider {
      * @type {string}
      */
     this._locale = this._getValidatedLocale(config.locale);
+
+    /**
+     * Map options to be passed directly to the Map Provider
+     * @type {Object}
+     */
+    this._providerOptions = config.providerOptions || {};
   }
 
   /**


### PR DESCRIPTION
Support map options specific to the map provider

This can be used for things such as styling the mapbox map

J=SLAP-1449
TEST=manual

Use the hitchhikers theme to build a site and see that the provider options on the map vertical also affects the universal map. Test a custom style for Mapbox, and test a custom background color for Google.