### PR TITLE
Don't require translation verification on develop and dev branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,6 @@ workflows:
             - unit_test
             - browserstack_acceptance_test
             - headless_acceptance_test
-            - translation_test
             - third_party_notices_test
   build_and_deploy_i18n:
     jobs:
@@ -258,7 +257,6 @@ workflows:
             - unit_test
             - headless_acceptance_test
             - browserstack_acceptance_test
-            - translation_test
             - third_party_notices_test
   build_and_deploy_hold:
     jobs:


### PR DESCRIPTION
Update the config so that the translation verification is no longer required in order to deploy assets for develop and dev branches

We still run the test so that we have visibility into whether or not translations are present, but they shouldn't prevent a deploy

J=SLAP-1476
TEST=manual

See that this PR deploys despite the translation verification failing. Check the Circle CI workflow graph and see that the translation verification runs but is not required for a deploy