### PR TITLE
send cookies in GET requests

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -304,7 +304,7 @@ MIT License
 
 The following NPM packages may be included in this product:
 
- - @yext/answers-core@1.2.0
+ - @yext/answers-core@1.3.0-beta.3
 
 These packages each contain the following license and notice below:
 
@@ -342,7 +342,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM packages may be included in this product:
 
- - @yext/answers-search-ui@1.9.1
+ - @yext/answers-search-ui@1.9.2
  - @yext/answers-storage@1.1.0
 
 These packages each contain the following license and notice below:
@@ -2007,7 +2007,7 @@ SOFTWARE.
 
 The following NPM packages may be included in this product:
 
- - cross-fetch@3.0.6
+ - cross-fetch@3.1.4
 
 These packages each contain the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5412,12 +5412,12 @@
       }
     },
     "@yext/answers-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.2.0.tgz",
-      "integrity": "sha512-s2jg5OwhwOMY7sh/dlkF2aIOxOSOKhIzny8O+Jn0/yjxBpHcZ++RvZDCt3xcYGSwKVQIyQ6RTo2K2e9f6yj1iA==",
+      "version": "1.3.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.3.0-beta.3.tgz",
+      "integrity": "sha512-AMPP0nnvb03xy+rQpbGEJ++yawUJ3/3KBxdhSSFNVm1aQqv5lakWMWupD5I8/0fcwSR9Mce4RiJu41Q4cmT37g==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
-        "cross-fetch": "^3.0.6"
+        "cross-fetch": "^3.1.4"
       }
     },
     "@yext/answers-storage": {
@@ -8429,9 +8429,9 @@
       }
     },
     "cross-fetch": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
-      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
       "requires": {
         "node-fetch": "2.6.1"
       }
@@ -19831,9 +19831,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
       "dev": true
     },
     "regenerator-transform": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Javascript Answers Programming Interface",
   "main": "dist/answers-umd.js",
   "repository": {
@@ -24,10 +24,10 @@
   ],
   "dependencies": {
     "@mapbox/mapbox-gl-language": "^0.10.1",
-    "@yext/answers-core": "^1.2.0",
+    "@yext/answers-core": "^1.3.0-beta.3",
     "@yext/answers-storage": "^1.1.0",
     "@yext/rtf-converter": "^1.5.0",
-    "cross-fetch": "^3.0.6",
+    "cross-fetch": "^3.1.4",
     "css-vars-ponyfill": "^2.4.3",
     "gulp-sourcemaps": "^2.6.5",
     "handlebars": "^4.7.7",


### PR DESCRIPTION
This commit bumps the answers-core version, so that all GET
requests use credentials: 'include', which allow cookies to be
sent across origins.

This fixes an issue with the session-id cookie not being sent,
and therefore a new session-id being generated by the backend after
every search.

Will cherry pick this (and then test) on support/v1.8 and develop

T=TECHOPS-1384
TEST=manual

see that the session-id cookie is sent in search requests