### PR TITLE
Voice search async fix

### DIFF
--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -370,8 +370,8 @@ export default class SearchComponent extends Component {
       this._voiceSearchController =
         new VoiceSearchController(this._container, this._voiceSearchConfig, this);
       const voiceSearchElement = DOM.query(this._container, '.js-yxt-SearchBar-voiceSearch');
-      DOM.on(voiceSearchElement, 'click', async () => {
-        await this._voiceSearchController.handleIconClick();
+      DOM.on(voiceSearchElement, 'click', () => {
+        this._voiceSearchController.handleIconClick();
       });
     }
 


### PR DESCRIPTION
Fix a bug that caused voice search to break due to the async keyword

The keyword is not necessary, and it causes a 'regeneratorRuntime' error in browsers. Removing it fixes the issue

J=none
TEST=manual

Smoke test voice search