### PR TITLE
RTL language support in map

### DIFF
--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -33,7 +33,11 @@ export default class MapBoxMapProvider extends MapProvider {
       onload: () => {
         this._isLoaded = true;
         mapboxgl.accessToken = this._apiKey;
-
+        mapboxgl.setRTLTextPlugin(
+          'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js',
+          null,
+          true // Lazy load the plugin
+        );
         if (typeof onLoad === 'function') {
           onLoad();
         }


### PR DESCRIPTION
- add mapbox-gl-rtl-text plugin to support right to left languages

J=SLAP-1459
TEST=manual

from feature/arabic-i18n branch, built ar-* bundle and use it in theme to spin up ar map page (locations.html), and see that arabic is displayed properly. see that en and es is displayed as normal.