### PR TITLE
Update DOM.once to work with ie11

### DIFF
--- a/src/ui/controllers/searchbariconcontroller.js
+++ b/src/ui/controllers/searchbariconcontroller.js
@@ -33,7 +33,6 @@ export default class SearchBarIconController {
     this.iconIsFrozen = false;
     this.inputEl = config.inputEl;
     this.searchBarContainer = config.searchBarContainer;
-    this.onMouseUp = this.oneTimeMouseUpListener.bind(this);
 
     const stateMap = {
       [IconState.LOADING_ICON]: new LoadingIconState(this, IconState.LOADING_ICON),
@@ -82,7 +81,9 @@ export default class SearchBarIconController {
       if (clickableEl) {
         DOM.on(clickableEl, 'mousedown', () => {
           this.iconIsFrozen = true;
-          DOM.on(document, 'mouseup', this.onMouseUp);
+          DOM.once(document, 'mouseup', () => {
+            this.iconIsFrozen = false;
+          });
         });
       }
     }
@@ -93,10 +94,5 @@ export default class SearchBarIconController {
     DOM.on(this.searchBarContainer, 'focusout', e => {
       this.handleEvent(IconEvent.FOCUS_OUT, e);
     });
-  }
-
-  oneTimeMouseUpListener () {
-    document.removeEventListener('mouseup', this.onMouseUp);
-    this.iconIsFrozen = false;
   }
 }

--- a/src/ui/dom/dom.js
+++ b/src/ui/dom/dom.js
@@ -202,7 +202,11 @@ export default class DOM {
   }
 
   static once (selector, evt, handler) {
-    DOM.query(selector).addEventListener(evt, handler, { once: true });
+    const oneTimeHandler = () => {
+      handler();
+      DOM.off(selector, evt, oneTimeHandler);
+    };
+    DOM.query(selector).addEventListener(evt, oneTimeHandler);
   }
 
   static off (selector, evt, handler) {


### PR DESCRIPTION
- Update DOM.once to create a one time handler that would remove itself after the event is trigger once.
- remove the self-destructing listener in searchbariconController and use DOM.once instead

J=SLAP-1432
TEST=manual

Put console log in the handler for 'mouseup' event on document in searchbar icon and passed to DOM.once. Click on document multiple times and see that console log is called once. Repeat process for DOM.once call in autocomplete component and see that console log is called once.