### PR TITLE
Disable loading icon when inactive

### DIFF
--- a/src/ui/sass/modules/_SearchBar.scss
+++ b/src/ui/sass/modules/_SearchBar.scss
@@ -216,6 +216,11 @@ $searchbar-button-text-color-active: var(--yxt-searchbar-button-text-color-base)
     transform-origin: 50% 50%;
     animation: dash 1.4s ease-in-out infinite;
   }
+
+  &-Icon--inactive &-LoadingIndicator-AnimatedIcon 
+  {
+    display: none;
+  }
   
   @keyframes dash 
   {


### PR DESCRIPTION
Disable the loading icon when it is inactive in order to prevent the icon from flashing during transitions

Note: The search bar will still sometimes flash the very first time the icon is clicked because of a long tasks associated with creating the components and waiting for the autocomplete response, but that's a separate issue

J=SLAP-1473
TEST=manual

See that when the loading indicator is enabled, the icon will no longer flash when clicking on and off the search bar.