### PR TITLE
Set fixed custom icon size

### DIFF
--- a/src/ui/sass/modules/_SearchBar.scss
+++ b/src/ui/sass/modules/_SearchBar.scss
@@ -264,6 +264,12 @@ $searchbar-button-text-color-active: var(--yxt-searchbar-button-text-color-base)
       position: relative;
     }
   }
+
+  &-buttonImage .Icon svg, .Icon-image
+  {
+    width: 2em;
+    height: 2em;
+  }
 }
 
 // If custom icons are supplied, the SVGs simply alternate opacity


### PR DESCRIPTION
Set an explicit custom icon width so that the voice and clear button don't shift around when the loading indicator appears

J=SLAP-1473
TEST=manual

Enable the loading indicator and set a custom icon. See that the voice icon and the clear button stay in the same spot