### PR TITLE
Display email validation error in QuestionSubmission

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -18,7 +18,7 @@ import DirectAnswer from './models/directanswer';
 import AutoCompleteResponseTransformer from './search/autocompleteresponsetransformer';
 
 import { PRODUCTION, ENDPOINTS, LIB_VERSION } from './constants';
-import { getCachedLiveApiUrl, getLiveApiUrl, getKnowledgeApiUrl } from './utils/urlutils';
+import { getCachedLiveApiUrl, getLiveApiUrl } from './utils/urlutils';
 import { SearchParams } from '../ui';
 import SearchStates from './storage/searchstates';
 
@@ -149,7 +149,7 @@ export default class Core {
     return {
       universalSearch: getLiveApiUrl(this._environment) + ENDPOINTS.UNIVERSAL_SEARCH,
       verticalSearch: getLiveApiUrl(this._environment) + ENDPOINTS.VERTICAL_SEARCH,
-      questionSubmission: getKnowledgeApiUrl(this._environment) + ENDPOINTS.QUESTION_SUBMISSION,
+      questionSubmission: getLiveApiUrl(this._environment) + ENDPOINTS.QUESTION_SUBMISSION,
       universalAutocomplete: getCachedLiveApiUrl(this._environment) + ENDPOINTS.UNIVERSAL_AUTOCOMPLETE,
       verticalAutocomplete: getCachedLiveApiUrl(this._environment) + ENDPOINTS.VERTICAL_AUTOCOMPLETE,
       filterSearch: getCachedLiveApiUrl(this._environment) + ENDPOINTS.FILTER_SEARCH

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -20,14 +20,6 @@ export function getCachedLiveApiUrl (env = PRODUCTION) {
 }
 
 /**
- * Returns the base url for the knowledge api backend in the desired environment.
- * @param {string} env The desired environment.
- */
-export function getKnowledgeApiUrl (env = PRODUCTION) {
-  return env === SANDBOX ? 'https://api-sandbox.yext.com' : 'https://api.yext.com';
-}
-
-/**
  * Returns the base url for the analytics backend in the desired environment.
  * @param {string} env The desired environment.
  * @param {boolean} conversionTrackingEnabled If conversion tracking has been opted into.

--- a/src/ui/components/questions/questionsubmissioncomponent.js
+++ b/src/ui/components/questions/questionsubmissioncomponent.js
@@ -169,6 +169,15 @@ const DEFAULT_CONFIG = {
   }),
 
   /**
+   * The default email error text, shown when there is an email is invalid with the QA Submission
+   * request.
+   * @type {string}
+   */
+  emailInvalidErrorText: TranslationFlagger.flag({
+    phrase: 'Your email address was not valid. Please refresh the page and try submitting your question again.'
+  }),
+
+  /**
    * Whether or not this component is expanded by default.
    * @type {boolean}
    */
@@ -293,7 +302,7 @@ export default class QuestionSubmissionComponent extends Component {
 
     const questionText = DOM.query(formEl, '.js-question-text');
     DOM.on(questionText, 'focus', () => {
-      this.analyticsReporter.report(this.getAnalyticsEvent('QUESTION_FOCUS'));
+      this.analyticsReporter?.report(this.getAnalyticsEvent('QUESTION_FOCUS'));
     });
   }
 
@@ -305,7 +314,7 @@ export default class QuestionSubmissionComponent extends Component {
   bindFormSubmit (formEl) {
     DOM.on(formEl, 'submit', (e) => {
       e.preventDefault();
-      this.analyticsReporter.report(this.getAnalyticsEvent('QUESTION_SUBMIT'));
+      this.analyticsReporter?.report(this.getAnalyticsEvent('QUESTION_SUBMIT'));
 
       // TODO(billy) we probably want to disable the form from being submitted twice
       const errors = this.validate(formEl);
@@ -323,10 +332,12 @@ export default class QuestionSubmissionComponent extends Component {
         questionDescription: formData.questionDescription
       })
         .catch(error => {
+          let errorMessage = this._config.networkErrorText;
+          if (error.code === 22) {
+            errorMessage = this._config.emailInvalidErrorText;
+          }
           this.setState(
-            new QuestionSubmission(formData, {
-              network: 'We\'re sorry, an error occurred.'
-            })
+            new QuestionSubmission(formData, { network: errorMessage })
           );
           throw error;
         });

--- a/src/ui/components/questions/questionsubmissioncomponent.js
+++ b/src/ui/components/questions/questionsubmissioncomponent.js
@@ -160,11 +160,11 @@ const DEFAULT_CONFIG = {
   }),
 
   /**
-   * The default network error text, shown when there is an issue with the QA Submission
+   * The default error text, shown when there is an issue with the QA Submission
    * request.
    * @type {string}
    */
-  networkErrorText: TranslationFlagger.flag({
+  defaultErrorText: TranslationFlagger.flag({
     phrase: 'We\'re sorry, an error occurred.'
   }),
 
@@ -174,7 +174,7 @@ const DEFAULT_CONFIG = {
    * @type {string}
    */
   emailInvalidErrorText: TranslationFlagger.flag({
-    phrase: 'Your email address was not valid. Please refresh the page and try submitting your question again.'
+    phrase: 'Invalid email address. Please refresh the page and try submitting your question again.'
   }),
 
   /**
@@ -332,7 +332,7 @@ export default class QuestionSubmissionComponent extends Component {
         questionDescription: formData.questionDescription
       })
         .catch(error => {
-          let errorMessage = this._config.networkErrorText;
+          let errorMessage = this._config.defaultErrorText;
           if (error.code === 22) {
             errorMessage = this._config.emailInvalidErrorText;
           }

--- a/src/ui/templates/questions/questionsubmission.hbs
+++ b/src/ui/templates/questions/questionsubmission.hbs
@@ -38,7 +38,7 @@
         {{#if errors.network}}
           <div class="yxt-QuestionSubmission-formRow">
             <div class="yxt-QuestionSubmission-formError" role="alert">
-              {{_config.networkErrorText}}
+              {{errors.network}}
             </div>
           </div>
         {{else}}


### PR DESCRIPTION

- surface email error from backend with code 22 and display corresponding error message in hbs template
- update questionSubmission URLs to use liveapi version
- minor fix: added optional chaining in case analyticsReporter is not set

J=SLAP-1020
TEST=manual

- serve page from dist folder with QASubmission component, submit with invalid email domain and see that the error message is displayed.