### PR TITLE
send cookies in GET requests (#1489)

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -304,7 +304,7 @@ MIT License
 
 The following NPM packages may be included in this product:
 
- - @yext/answers-core@1.1.0
+ - @yext/answers-core@1.3.0-beta.3
 
 These packages each contain the following license and notice below:
 
@@ -343,7 +343,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The following NPM packages may be included in this product:
 
  - @yext/answers-search-ui@1.8.0
- - @yext/answers-storage@1.0.0-beta.0
+ - @yext/answers-storage@1.1.1
 
 These packages each contain the following license and notice below:
 
@@ -2007,7 +2007,7 @@ SOFTWARE.
 
 The following NPM packages may be included in this product:
 
- - cross-fetch@3.0.6
+ - cross-fetch@3.1.4
 
 These packages each contain the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5341,18 +5341,18 @@
       }
     },
     "@yext/answers-core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.1.0.tgz",
-      "integrity": "sha512-H5ec+TE9pvGzcD7QZXUSLo9xXoSRJlrFQFVsGo2rlf3RC98rru+V2oEswjJAIf6Mfay4bFm2X//iQ0+LDEFjQg==",
+      "version": "1.3.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.3.0-beta.3.tgz",
+      "integrity": "sha512-AMPP0nnvb03xy+rQpbGEJ++yawUJ3/3KBxdhSSFNVm1aQqv5lakWMWupD5I8/0fcwSR9Mce4RiJu41Q4cmT37g==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
-        "cross-fetch": "^3.0.6"
+        "cross-fetch": "^3.1.4"
       }
     },
     "@yext/answers-storage": {
-      "version": "1.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@yext/answers-storage/-/answers-storage-1.0.0-beta.0.tgz",
-      "integrity": "sha512-WdNPXN5nwvZEa97EgtagW3Ub7doFZeV0XokoyMLWKdwooWe51nwSXSSzto6u4gb3c4JK7ufAKWH/dwnHHEqc8Q=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@yext/answers-storage/-/answers-storage-1.1.1.tgz",
+      "integrity": "sha512-xA21FoDJkl+QFpH8cCz877h+xUCdY/ENZDst+tyV/phaR8ZT63vLFWTSxHJTI/FUQm+bXHw8QWxcv3kKze37Lg=="
     },
     "@yext/rtf-converter": {
       "version": "1.5.0",
@@ -8351,9 +8351,9 @@
       }
     },
     "cross-fetch": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
-      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
       "requires": {
         "node-fetch": "2.6.1"
       }
@@ -19769,9 +19769,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
       "dev": true
     },
     "regenerator-transform": {

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   ],
   "dependencies": {
     "@mapbox/mapbox-gl-language": "^0.10.1",
-    "@yext/answers-core": "^1.1.0",
-    "@yext/answers-storage": "^1.0.0-beta.0",
+    "@yext/answers-core": "^1.3.0-beta.3",
+    "@yext/answers-storage": "^1.1.0",
     "@yext/rtf-converter": "^1.5.0",
-    "cross-fetch": "^3.0.6",
+    "cross-fetch": "^3.1.4",
     "css-vars-ponyfill": "^2.4.3",
     "gulp-sourcemaps": "^2.6.5",
     "handlebars": "^4.7.7",


### PR DESCRIPTION
This commit bumps the answers-core version, so that all GET
requests use credentials: 'include', which allow cookies to be
sent across origins.

This fixes an issue with the session-id cookie not being sent,
and therefore a new session-id being generated by the backend after
every search.

Will cherry pick this (and then test) on support/v1.8 and develop

T=TECHOPS-1384
TEST=manual

see that the session-id cookie is sent in search requests