### PR TITLE
change sessionStorage console.error to warning instead

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -764,8 +764,8 @@ export default class Core {
           window.sessionStorage.setItem('sessionId', sessionId);
         }
         return sessionId;
-      } catch (e) {
-        console.error(e);
+      } catch (err) {
+        console.warn('Unable to use browser sessionStorage for sessionId.\n', err);
       }
     }
     return null;


### PR DESCRIPTION
If sessionStorage doesn't exist or usage is blocked by the browser
we still default to using the old session-id cookie, but an error
would still be printed even though nothing is "going wrong".

Rose said we can change to a warning. I also added a little extra context.

J=SLAP-1518
TEST=manual

ran `delete window.sessionStorage` in browser dev tools, and then try running searches