### PR TITLE
Update the `LANGUAGES_TO_LOCALES` map with new language/locale pairs

### DIFF
--- a/conf/i18n/constants.js
+++ b/conf/i18n/constants.js
@@ -102,6 +102,47 @@ const LANGUAGES_TO_LOCALES = {
   ],
   ja: [
     'ja_JP'
+  ],
+  ar: [
+    'ar_AE',
+    'ar_BH',
+    'ar_DZ',
+    'ar_IQ',
+    'ar_KW',
+    'ar_LY',
+    'ar_OM',
+    'ar_PS',
+    'ar_QA',
+    'ar_SA'
+  ],
+  hi: [],
+  ko: [],
+  nl: [
+    'nl_BE',
+    'nl_NL',
+    'nl_SX'
+  ],
+  pl: [],
+  pt: [
+    'pt_BR',
+    'pt_CV',
+    'pt_PT'
+  ],
+  ru: [
+    'ru_UA'
+  ],
+  sv: [
+    'sv_SE'
+  ],
+  'zh-CN': [
+    'zh-CN_CN',
+    'zh_CN_HK',
+    'zh_CN_SG'
+  ],
+  'zh-TW': [
+    'zh-TW_HK',
+    'zh-TW_MO',
+    'zh-TW_TW'
   ]
 };
 exports.LANGUAGES_TO_LOCALES = LANGUAGES_TO_LOCALES;


### PR DESCRIPTION
Rose provided these new pairs directly from Knowledge Graph.

TEST=manual

I ran `build-locales` and saw assets generated for the new pairs and languages.