### PR TITLE
Add the translations for the new invalid email errors.

### DIFF
--- a/conf/i18n/translations/ar.po
+++ b/conf/i18n/translations/ar.po
@@ -105,6 +105,10 @@ msgstr "انتقل إلى الصفحة التالية من النتائج"
 msgid "Image for [[title]]"
 msgstr "صورة لـ [[title]]"
 
+#: src/ui/components/questions/questionsubmissioncomponent.js:176
+msgid "Invalid email address. Please refresh the page and try submitting your question again."
+msgstr "عنوان بريد إلكتروني غير صالح. يرجى تحديث الصفحة ومحاولة إرسال سؤالك مرة أخرى."
+
 #: src/ui/components/filters/geolocationcomponent.js:285
 #: src/ui/components/filters/geolocationcomponent.js:39
 #: src/ui/components/filters/geolocationcomponent.js:47

--- a/conf/i18n/translations/de.po
+++ b/conf/i18n/translations/de.po
@@ -97,6 +97,10 @@ msgstr "Zur nächsten Ergebnisseite wechseln"
 msgid "Image for [[title]]"
 msgstr "Bild für [[title]]"
 
+#: src/ui/components/questions/questionsubmissioncomponent.js:176
+msgid "Invalid email address. Please refresh the page and try submitting your question again."
+msgstr "E-Mail-Adresse ungültig. Bitte aktualisieren Sie die Seite und versuchen Sie erneut, Ihre Frage einzureichen."
+
 #: src/ui/components/filters/geolocationcomponent.js:280
 #: src/ui/components/filters/geolocationcomponent.js:38
 #: src/ui/components/filters/geolocationcomponent.js:46

--- a/conf/i18n/translations/es.po
+++ b/conf/i18n/translations/es.po
@@ -166,6 +166,10 @@ msgstr "Vaya a la página siguiente de los resultados"
 msgid "Image for [[title]]"
 msgstr "imagen para [[title]]"
 
+#: src/ui/components/questions/questionsubmissioncomponent.js:176
+msgid "Invalid email address. Please refresh the page and try submitting your question again."
+msgstr "Dirección de correo electrónico no válida. Actualiza la página e intenta enviar tu pregunta de nuevo."
+
 #: src/ui/templates/results/noresults.hbs:31
 msgid "Make sure all words are spelled correctly."
 msgstr "Verifique que todas las palabras estén escritas correctamente."

--- a/conf/i18n/translations/fr.po
+++ b/conf/i18n/translations/fr.po
@@ -160,6 +160,10 @@ msgstr "Aller à la prochaine page de résultats"
 msgid "Image for [[title]]"
 msgstr "Image pour [[title]]"
 
+#: src/ui/components/questions/questionsubmissioncomponent.js:176
+msgid "Invalid email address. Please refresh the page and try submitting your question again."
+msgstr "Adresse e-mail non valide. Veuillez actualiser la page et essayer d'envoyer votre question à nouveau."
+
 #: src/ui/templates/results/noresults.hbs:31
 msgid "Make sure all words are spelled correctly."
 msgstr "Assurez vous que les mots sont épelés correctement"

--- a/conf/i18n/translations/hi.po
+++ b/conf/i18n/translations/hi.po
@@ -97,6 +97,10 @@ msgstr "परिणामों के अगले पेज पर जाए�
 msgid "Image for [[title]]"
 msgstr "[[title]] के लिए इमेज"
 
+#: src/ui/components/questions/questionsubmissioncomponent.js:176
+msgid "Invalid email address. Please refresh the page and try submitting your question again."
+msgstr "अमान्य ईमेल पता. कृपया अपना पेज रिफ़्रेश करें और अपना सवाल दोबारा डालने की कोशिश करें."
+
 #: src/ui/components/filters/geolocationcomponent.js:285
 #: src/ui/components/filters/geolocationcomponent.js:39
 #: src/ui/components/filters/geolocationcomponent.js:47

--- a/conf/i18n/translations/it.po
+++ b/conf/i18n/translations/it.po
@@ -166,6 +166,10 @@ msgstr "Vada alla pagina successiva dei risultati"
 msgid "Image for [[title]]"
 msgstr "Imagine per [[title]]"
 
+#: src/ui/components/questions/questionsubmissioncomponent.js:176
+msgid "Invalid email address. Please refresh the page and try submitting your question again."
+msgstr "Indirizzo e-mail non valido. Aggiorna la pagina e riprova a inviare la domanda."
+
 #: src/ui/templates/results/noresults.hbs:31
 msgid "Make sure all words are spelled correctly."
 msgstr "Controlli che le parole siano scritte correttamente"

--- a/conf/i18n/translations/ja.po
+++ b/conf/i18n/translations/ja.po
@@ -133,6 +133,10 @@ msgstr "検索結果の次のページへ移動する"
 msgid "Image for [[title]]"
 msgstr "[[title]]の画像"
 
+#: src/ui/components/questions/questionsubmissioncomponent.js:176
+msgid "Invalid email address. Please refresh the page and try submitting your question again."
+msgstr "メールアドレスが無効です。ページを更新し、質問を再度送信してみてください。"
+
 #: src/ui/templates/results/noresults.hbs:31
 msgid "Make sure all words are spelled correctly."
 msgstr "すべての単語の綴りが正しいことを確認してください。"

--- a/conf/i18n/translations/ko.po
+++ b/conf/i18n/translations/ko.po
@@ -95,6 +95,10 @@ msgstr "결과의 다음 페이지로 이동"
 msgid "Image for [[title]]"
 msgstr "[[title]] 이미지"
 
+#: src/ui/components/questions/questionsubmissioncomponent.js:176
+msgid "Invalid email address. Please refresh the page and try submitting your question again."
+msgstr "올바르지 않은 이메일 주소. 페이지를 새로 고침하고 질문을 다시 제출해 보세요."
+
 #: src/ui/components/filters/geolocationcomponent.js:285
 #: src/ui/components/filters/geolocationcomponent.js:39
 #: src/ui/components/filters/geolocationcomponent.js:47

--- a/conf/i18n/translations/nl.po
+++ b/conf/i18n/translations/nl.po
@@ -97,6 +97,10 @@ msgstr "Ga naar de volgende pagina met resultaten"
 msgid "Image for [[title]]"
 msgstr "Afbeelding voor [[title]]"
 
+#: src/ui/components/questions/questionsubmissioncomponent.js:176
+msgid "Invalid email address. Please refresh the page and try submitting your question again."
+msgstr "Ongeldig e-mailadres. Vernieuw de pagina en probeer uw vraag opnieuw te verzenden."
+
 #: src/ui/components/filters/geolocationcomponent.js:285
 #: src/ui/components/filters/geolocationcomponent.js:39
 #: src/ui/components/filters/geolocationcomponent.js:47

--- a/conf/i18n/translations/pl.po
+++ b/conf/i18n/translations/pl.po
@@ -99,6 +99,10 @@ msgstr "Przejdź do następnej strony wyników"
 msgid "Image for [[title]]"
 msgstr "Obraz dla [[tytuł]]"
 
+#: src/ui/components/questions/questionsubmissioncomponent.js:176
+msgid "Invalid email address. Please refresh the page and try submitting your question again."
+msgstr "Nieprawidłowy adres e-mail. Odśwież stronę i spróbuj ponownie przesłać pytanie."
+
 #: src/ui/components/filters/geolocationcomponent.js:285
 #: src/ui/components/filters/geolocationcomponent.js:39
 #: src/ui/components/filters/geolocationcomponent.js:47

--- a/conf/i18n/translations/pt.po
+++ b/conf/i18n/translations/pt.po
@@ -97,6 +97,10 @@ msgstr "Vá para a próxima página de resultados"
 msgid "Image for [[title]]"
 msgstr "Imagem de [[title]]"
 
+#: src/ui/components/questions/questionsubmissioncomponent.js:176
+msgid "Invalid email address. Please refresh the page and try submitting your question again."
+msgstr "Endereço de e-mail inválido. Atualize a página e experimente submeter novamente a sua pergunta."
+
 #: src/ui/components/filters/geolocationcomponent.js:285
 #: src/ui/components/filters/geolocationcomponent.js:39
 #: src/ui/components/filters/geolocationcomponent.js:47

--- a/conf/i18n/translations/ru.po
+++ b/conf/i18n/translations/ru.po
@@ -99,6 +99,10 @@ msgstr "Перейти на следующую страницу с резуль�
 msgid "Image for [[title]]"
 msgstr "Изображение для [[title]]"
 
+#: src/ui/components/questions/questionsubmissioncomponent.js:176
+msgid "Invalid email address. Please refresh the page and try submitting your question again."
+msgstr "Недействительный адрес эл. почты. Обновите страницу и попробуйте отправить вопрос еще раз."
+
 #: src/ui/components/filters/geolocationcomponent.js:285
 #: src/ui/components/filters/geolocationcomponent.js:39
 #: src/ui/components/filters/geolocationcomponent.js:47

--- a/conf/i18n/translations/sv.po
+++ b/conf/i18n/translations/sv.po
@@ -97,6 +97,10 @@ msgstr "Gå till nästa sida i resultaten"
 msgid "Image for [[title]]"
 msgstr "Bild för [[title]]"
 
+#: src/ui/components/questions/questionsubmissioncomponent.js:176
+msgid "Invalid email address. Please refresh the page and try submitting your question again."
+msgstr "Ogiltig e-postadress. Uppdatera sidan och försök skicka din fråga igen."
+
 #: src/ui/components/filters/geolocationcomponent.js:285
 #: src/ui/components/filters/geolocationcomponent.js:39
 #: src/ui/components/filters/geolocationcomponent.js:47

--- a/conf/i18n/translations/zh-CN.po
+++ b/conf/i18n/translations/zh-CN.po
@@ -95,6 +95,10 @@ msgstr "转到下一页结果"
 msgid "Image for [[title]]"
 msgstr "[[title]] 的图像"
 
+#: src/ui/components/questions/questionsubmissioncomponent.js:176
+msgid "Invalid email address. Please refresh the page and try submitting your question again."
+msgstr "电子邮件地址无效。请刷新页面，然后尝试重新提交问题。"
+
 #: src/ui/components/filters/geolocationcomponent.js:285
 #: src/ui/components/filters/geolocationcomponent.js:39
 #: src/ui/components/filters/geolocationcomponent.js:47

--- a/conf/i18n/translations/zh-TW.po
+++ b/conf/i18n/translations/zh-TW.po
@@ -95,6 +95,10 @@ msgstr "前往下一頁的結果"
 msgid "Image for [[title]]"
 msgstr "[[title]]的影像"
 
+#: src/ui/components/questions/questionsubmissioncomponent.js:176
+msgid "Invalid email address. Please refresh the page and try submitting your question again."
+msgstr "電子郵件地址無效。請重新整理頁面，並再次提交您的問題。"
+
 #: src/ui/components/filters/geolocationcomponent.js:285
 #: src/ui/components/filters/geolocationcomponent.js:39
 #: src/ui/components/filters/geolocationcomponent.js:47


### PR DESCRIPTION
The `QuestionSubmission` component was recently updated to display a detailed
error message about invalid emails. This PR provides all the necessary translations
for that error message.

J=SLAP-1487
TEST=none