### PR TITLE
Additional Language Map Support

### DIFF
--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -41,7 +41,7 @@ export default class GoogleMapProvider extends MapProvider {
    */
   getLanguage (localeStr) {
     const googleMapsCustomLanguages =
-      ['zh-CN', 'zn-HK', 'zh-TW', 'en-AU', 'en-GB', 'fr-CA', 'pt-BR', 'pt-PT', 'es-419'];
+      ['zh-CN', 'zh-HK', 'zh-TW', 'en-AU', 'en-GB', 'fr-CA', 'pt-BR', 'pt-PT', 'es-419'];
     const locale = localeStr.replace('_', '-');
 
     if (googleMapsCustomLanguages.includes(locale)) {

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -48,12 +48,18 @@ export default class GoogleMapProvider extends MapProvider {
       return locale;
     }
 
-    const { language, modifier } = parseLocale(localeStr);
+    const { language, modifier, region } = parseLocale(localeStr);
 
+    if (language === 'zh' && region === 'HK') {
+      return 'zh-HK';
+    }
+
+    // Google maps uses the 'CN' region code to indicate Simplified Chinese
     if (language === 'zh' && modifier === 'Hans') {
       return 'zh-CN';
     }
 
+    // Google maps uses the 'TW' region code to indicate Traditionalls Chinese
     if (language === 'zh' && modifier === 'Hant') {
       return 'zh-TW';
     }

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -59,7 +59,7 @@ export default class GoogleMapProvider extends MapProvider {
       return 'zh-CN';
     }
 
-    // Google maps uses the 'TW' region code to indicate Traditionalls Chinese
+    // Google maps uses the 'TW' region code to indicate Traditional Chinese
     if (language === 'zh' && modifier === 'Hant') {
       return 'zh-TW';
     }

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -2,6 +2,7 @@
 
 import MapProvider from './mapprovider';
 import DOM from '../../../dom/dom';
+import { parseLocale } from '../../../../core/utils/i18nutils';
 
 /* global google */
 
@@ -33,7 +34,8 @@ export default class GoogleMapProvider extends MapProvider {
 
   /**
    * Google Maps supports some language codes that are longer than two characters. If the
-   * locale matches one of these edge cases, use it. Otherwise, fallback on the first two
+   * locale matches one of these edge cases, use it. If a chinese script code is used, map
+   * it to the corresponding locale supported by Google. Otherwise, fallback on the first two
    * characters of the locale.
    * @param {string} localeStr Unicode locale
    */
@@ -46,7 +48,16 @@ export default class GoogleMapProvider extends MapProvider {
       return locale;
     }
 
-    const language = locale.substring(0, 2);
+    const { language, modifier } = parseLocale(localeStr);
+
+    if (language === 'zh' && modifier === 'Hans') {
+      return 'zh-CN';
+    }
+
+    if (language === 'zh' && modifier === 'Hant') {
+      return 'zh-TW';
+    }
+
     return language;
   }
 

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -4,6 +4,7 @@ import MapboxLanguage from '@mapbox/mapbox-gl-language';
 
 import MapProvider from './mapprovider';
 import DOM from '../../../dom/dom';
+import { parseLocale } from '../../../../core/utils/i18nutils';
 
 /* global mapboxgl */
 
@@ -16,11 +17,12 @@ export default class MapBoxMapProvider extends MapProvider {
   constructor (opts = {}, systemOpts = {}) {
     super(opts, systemOpts);
 
+    const { language, modifier } = parseLocale(this._locale);
     /**
      * Language of the map.
      * @type {string}
      */
-    this._language = this._locale.substring(0, 2);
+    this._language = modifier ? `${language}-${modifier}` : language;
   }
 
   /**

--- a/tests/ui/components/map/providers/googlemapprovider.js
+++ b/tests/ui/components/map/providers/googlemapprovider.js
@@ -1,4 +1,5 @@
-import { GoogleMapMarkerConfig } from '../../../../../src/ui/components/map/providers/googlemapprovider';
+// eslint-disable-next-line import/no-named-default
+import { default as GoogleMapProvider, GoogleMapMarkerConfig } from '../../../../../src/ui/components/map/providers/googlemapprovider';
 
 window.google = {};
 window.google.maps = {
@@ -195,5 +196,32 @@ describe('converts array of markers into GoogleAPIMarkers', () => {
     const actual = GoogleMapMarkerConfig.from(markers, pinConfigFunc, map);
 
     expect(actual).toEqual(expected);
+  });
+});
+
+describe('google map provider properly handles locales', () => {
+  it('en locale is set correctly', () => {
+    const map = new GoogleMapProvider({ locale: 'en', apiKey: '123' });
+    expect(map._language).toEqual('en');
+  });
+
+  it('extended custom locales supported by google work', () => {
+    const map = new GoogleMapProvider({ locale: 'fr-CA', apiKey: '123' });
+    expect(map._language).toEqual('fr-CA');
+  });
+
+  it('locales with a HK region fallback to zh-HK', () => {
+    const map = new GoogleMapProvider({ locale: 'zh-Hant-HK', apiKey: '123' });
+    expect(map._language).toEqual('zh-HK');
+  });
+
+  it('zh-Hans falls back to zh-CN', () => {
+    const map = new GoogleMapProvider({ locale: 'zh-Hans', apiKey: '123' });
+    expect(map._language).toEqual('zh-CN');
+  });
+
+  it('zh-Hant falls back to zh-TW', () => {
+    const map = new GoogleMapProvider({ locale: 'zh-Hant', apiKey: '123' });
+    expect(map._language).toEqual('zh-TW');
   });
 });

--- a/tests/ui/components/map/providers/mapboxmapprovider.js
+++ b/tests/ui/components/map/providers/mapboxmapprovider.js
@@ -1,4 +1,5 @@
-import { MapBoxMarkerConfig } from '../../../../../src/ui/components/map/providers/mapboxmapprovider';
+// eslint-disable-next-line import/no-named-default
+import { default as MapboxMapProvider, MapBoxMarkerConfig } from '../../../../../src/ui/components/map/providers/mapboxmapprovider';
 
 const map = { tmp: 'test value' };
 const wrapper = '<button>this is the pin</button>';
@@ -161,5 +162,27 @@ describe('converts array of markers into MapboxMarkers', () => {
     const actual = MapBoxMarkerConfig.from(markers, pinConfigFunc, map);
 
     expect(actual).toEqual(expected);
+  });
+});
+
+describe('mapbox map provider properly handles locales', () => {
+  it('en locale is set correctly', () => {
+    const map = new MapboxMapProvider({ locale: 'en' });
+    expect(map._language).toEqual('en');
+  });
+
+  it('locales with regions fall back to the language code', () => {
+    const map = new MapboxMapProvider({ locale: 'fr-CA' });
+    expect(map._language).toEqual('fr');
+  });
+
+  it('zh-Hans is supported', () => {
+    const map = new MapboxMapProvider({ locale: 'zh-Hans' });
+    expect(map._language).toEqual('zh-Hans');
+  });
+
+  it('zh-Hant is supported', () => {
+    const map = new MapboxMapProvider({ locale: 'zh-Hant' });
+    expect(map._language).toEqual('zh-Hant');
   });
 });


### PR DESCRIPTION
Add support for additional languages and language scripts

Most notably, this adds support for Simplified and Traditional Chinese for the maps

J=1534
TEST=manual

Load a test site with traditional and simplifed Chinese for mapbox and google maps