### PR TITLE
Deprecate the serving of the latest assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ commands:
     parameters:
       subdirectory:
         type: string
-        default: ''
       cache-control:
         type: string
         default: "no-cache"
@@ -125,13 +124,6 @@ jobs:
           command: |
             sudo apt-get install -qq gettext
             ./.circleci/run_translation_verification.sh
-  # deploy to S3 in the root folder, overwriting the existing latest version
-  deploy_latest:
-    docker:
-      - image: circleci/python:2.7
-    working_directory: ~/answers
-    steps:
-      - deploy-to-aws
   # deploys assets to an uncached folder in the S3 bucket named by branch
   deploy_branch:
     docker:
@@ -262,8 +254,7 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              only:
-                - master
+              ignore: /.*/
       - unit_test:
           filters:
             tags:
@@ -305,17 +296,9 @@ workflows:
             - useragent_acceptance_test
             - headless_acceptance_test
             - translation_test
-      - deploy_latest:
-          filters:
-            branches:
-              only: master
-          requires:
-            - hold
       - deploy_version:
           filters:
             tags:
               only: /^v.*/
-            branches:
-              ignore: /.*/
           requires:
             - hold

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -47,11 +47,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - @babel/parser@7.12.7
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (C) 2012-2014 by various contributors (see AUTHORS)
 
@@ -106,11 +106,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/mapbox-gl-language@0.10.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 BSD 3-Clause License
 
@@ -242,11 +242,11 @@ MIT License
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - @types/minimist@1.2.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 MIT License
 
@@ -272,11 +272,11 @@ MIT License
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - @types/normalize-package-data@2.4.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 MIT License
 
@@ -302,11 +302,11 @@ MIT License
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - @yext/answers-core@1.3.0-beta.3
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 BSD 3-Clause License
 
@@ -379,11 +379,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - @yext/rtf-converter@1.5.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 # rtf-converter
 Provides methods for converting Yext's flavor of Markdown into HTML or plain text
@@ -395,11 +395,11 @@ CDN
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - acorn@5.7.4
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (C) 2012-2018 by various contributors (see AUTHORS)
 
@@ -423,11 +423,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - ajv@6.12.6
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -485,11 +485,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - align-text@1.0.2
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -612,11 +612,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - argparse@2.0.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -931,11 +931,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - atob@2.1.2
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 At your option you may choose either of the following licenses:
 
@@ -1239,11 +1239,11 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - balanced-match@1.0.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 (MIT)
 
@@ -1269,11 +1269,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - brace-expansion@1.1.11
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 MIT License
 
@@ -1330,11 +1330,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - browserslist@4.15.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -1359,11 +1359,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - caniuse-lite@1.0.30001245
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Attribution 4.0 International
 
@@ -1763,11 +1763,11 @@ Creative Commons may be contacted at creativecommons.org.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - center-align@1.0.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -1841,11 +1841,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - colorette@1.2.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright © Jorge Bucaran <<https://jorgebucaran.com>>
 
@@ -1887,11 +1887,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - convert-source-map@1.7.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright 2013 Thorsten Lorenz. 
 All rights reserved.
@@ -1919,11 +1919,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - core-js-pure@3.9.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (c) 2014-2021 Denis Pushkarev
 
@@ -1947,11 +1947,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - core-util-is@1.0.2
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright Node.js contributors. All rights reserved.
 
@@ -1975,11 +1975,11 @@ IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - cosmiconfig@7.0.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -2005,11 +2005,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - cross-fetch@3.1.4
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -2035,11 +2035,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - css-vars-ponyfill@2.4.3
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 MIT License
 
@@ -2065,11 +2065,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - css@2.2.4
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 (The MIT License)
 
@@ -2141,11 +2141,11 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - debug-fabulous@1.1.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -2199,11 +2199,11 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - decamelize-keys@1.1.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -2229,11 +2229,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - decode-uri-component@0.2.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -2259,11 +2259,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - dom-serializer@0.2.2
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 License
 
@@ -2305,11 +2305,11 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - electron-to-chromium@1.3.616
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright 2018 Kilian Valkhof
 
@@ -2375,11 +2375,11 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - es6-iterator@2.0.3
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -2430,11 +2430,11 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - escalade@3.1.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 MIT License
 
@@ -2448,11 +2448,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - event-emitter@0.3.5
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (C) 2012-2015 Mariusz Nowak (www.medikoo.com)
 
@@ -2476,11 +2476,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - extend@3.0.2
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -2538,11 +2538,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - fast-json-stable-stringify@2.1.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 This software is released under the MIT license:
 
@@ -2568,11 +2568,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - fastest-levenshtein@1.0.12
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 MIT License
 
@@ -2598,11 +2598,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - fastq@1.9.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (c) 2015-2020, Matteo Collina <matteo.collina@gmail.com>
 
@@ -2683,11 +2683,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - flatted@3.1.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 ISC License
 
@@ -2741,11 +2741,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - for-own@0.1.5
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -2771,11 +2771,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - fs.realpath@1.0.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The ISC License
 
@@ -2823,11 +2823,11 @@ the licensed code:
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - function-bind@1.1.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (c) 2013 Raynos.
 
@@ -2851,11 +2851,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - gensync@1.0.0-beta.2
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright 2018 Logan Smyth <loganfsmyth@gmail.com>
 
@@ -2888,11 +2888,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - glob-parent@5.1.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The ISC License
 
@@ -2912,11 +2912,11 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - glob@7.1.6
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The ISC License
 
@@ -2975,11 +2975,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - globjoin@0.1.4
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -3005,11 +3005,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - gonzales-pe@4.3.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 # Gonzales PE @dev
 
@@ -3822,11 +3822,11 @@ line](mailto:tonyganch+gonzales@gmail.com).
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - graceful-fs@4.2.4
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The ISC License
 
@@ -3846,11 +3846,11 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - gulp-sourcemaps@2.6.5
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 ## ISC License
 
@@ -3870,11 +3870,11 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - handlebars@4.7.7
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (C) 2011-2019 by Yehuda Katz
 
@@ -3898,11 +3898,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - has@1.0.3
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (c) 2013 Thiago de Arruda
 
@@ -3929,11 +3929,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - helper-slugify@0.2.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -3982,11 +3982,11 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - htmlparser2@3.10.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright 2010, 2011, Chris Winberry <chris@winberry.net>. All rights reserved.
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -4009,11 +4009,11 @@ IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - ignore@5.1.8
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (c) 2013 Kael Zhang <i@kael.me>, contributors
 http://kael.me/
@@ -4039,11 +4039,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - imurmurhash@0.1.4
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 iMurmurHash.js
 ==============
@@ -4170,11 +4170,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - indexes-of@1.0.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (c) 2013 Dominic Tarr
 
@@ -4201,11 +4201,11 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - inflight@1.0.6
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The ISC License
 
@@ -4225,11 +4225,11 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - inherits@2.0.4
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The ISC License
 
@@ -4353,11 +4353,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - is-core-module@2.2.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -4382,11 +4382,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - is-extglob@2.1.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -4444,11 +4444,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - is-promise@2.2.2
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (c) 2014 Forbes Lindesay
 
@@ -4472,11 +4472,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - isarray@1.0.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 # isarray
 
@@ -4571,11 +4571,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - isobject@3.0.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -4601,11 +4601,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - js-levenshtein@1.1.6
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 MIT License
 
@@ -4631,11 +4631,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - js-tokens@4.0.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -4661,11 +4661,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - json-parse-even-better-errors@2.3.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright 2017 Kat Marchán
 Copyright npm, Inc.
@@ -4695,11 +4695,11 @@ distributed under the terms of the MIT license above.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - json5@2.1.3
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 MIT License
 
@@ -4727,11 +4727,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - known-css-properties@0.20.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 MIT License
 
@@ -4757,11 +4757,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - lines-and-columns@1.1.6
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -4787,11 +4787,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - linkify-it@3.0.2
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (c) 2015 Vitaly Puzrin.
 
@@ -4875,11 +4875,11 @@ terms above.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - lodash.isequal@4.5.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright JS Foundation and other contributors <https://js.foundation/>
 
@@ -4931,11 +4931,11 @@ terms above.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - lodash@4.17.21
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
 
@@ -5019,11 +5019,11 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - lru-queue@0.1.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (C) 2014 Mariusz Nowak (www.medikoo.com)
 
@@ -5047,11 +5047,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - make-iterator@0.1.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -5080,11 +5080,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - markdown-it-for-inline@0.1.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (c) 2014 Vitaly Puzrin.
 
@@ -5111,11 +5111,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - markdown-it-plugin-underline@0.0.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 ## Markdown-it plugin underline
 This plugin was created specifically to render correct underlines generated by [draft-js-export-markdown](https://www.npmjs.com/package/draft-js-export-markdown)
@@ -5164,11 +5164,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - markdown-it@12.0.4
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (c) 2014 Vitaly Puzrin, Alex Kocharin.
 
@@ -5228,11 +5228,11 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - mdurl@1.0.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (c) 2015 Vitaly Puzrin, Alex Kocharin.
 
@@ -5282,11 +5282,11 @@ IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - memoizee@0.4.14
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 ISC License
 
@@ -5306,11 +5306,11 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - merge2@1.4.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -5336,11 +5336,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - min-indent@1.0.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -5366,11 +5366,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - minimist-options@4.1.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -5396,11 +5396,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - ms@2.1.2
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -5426,11 +5426,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - neo-async@2.6.2
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 MIT License
 
@@ -5457,11 +5457,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - next-tick@1.0.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License
 
@@ -5487,11 +5487,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - next-tick@1.1.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 ISC License
 
@@ -5511,11 +5511,11 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - node-fetch@2.6.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -5541,11 +5541,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - node-releases@1.1.67
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License
 
@@ -5611,11 +5611,11 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - normalize-range@0.1.2
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -5641,11 +5641,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - normalize-selector@0.2.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 # Normalize-Selector
 
@@ -5684,11 +5684,11 @@ http://getify.mit-license.org/
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - num2fraction@1.2.2
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -5714,11 +5714,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - path-parse@1.0.6
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -5744,11 +5744,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - picomatch@2.2.2
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -5774,11 +5774,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - plural-forms@0.5.2
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 MIT License
 
@@ -5804,11 +5804,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - postcss-less@3.1.4
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -5837,11 +5837,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - postcss-media-query-parser@0.2.3
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 # postcss-media-query-parser
 
@@ -6019,11 +6019,11 @@ MIT
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - postcss-resolve-nested-selector@0.1.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -6049,11 +6049,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - postcss-sass@0.4.4
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -6078,11 +6078,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - postcss-selector-parser@6.0.4
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (c) Ben Briggs <beneb.info@gmail.com> (http://beneb.info)
 
@@ -6109,11 +6109,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - postcss-value-parser@4.1.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (c) Bogdan Chadkin <trysound@yandex.ru>
 
@@ -6140,11 +6140,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - process-nextick-args@2.0.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 # Copyright (c) 2015 Calvin Metcalf
 
@@ -6225,11 +6225,11 @@ IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - regenerator-runtime@0.13.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 # regenerator-runtime
 
@@ -6265,11 +6265,11 @@ require("regenerator-runtime/path").path
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - remark-parse@9.0.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 # remark-parse
 
@@ -6471,11 +6471,11 @@ Support this effort and give back by sponsoring on [OpenCollective][collective]!
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - remark-stringify@9.0.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 # remark-stringify
 
@@ -6697,11 +6697,11 @@ Support this effort and give back by sponsoring on [OpenCollective][collective]!
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - remark@13.0.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 # remark
 
@@ -6966,11 +6966,11 @@ Support this effort and give back by sponsoring on [OpenCollective][collective]!
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - remove-trailing-separator@1.1.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 
@@ -7009,11 +7009,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - resolve@1.19.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 MIT License
 
@@ -7039,11 +7039,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - reusify@1.0.4
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -7069,11 +7069,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - run-parallel@1.1.10
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -7098,11 +7098,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - signal-exit@3.0.3
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The ISC License
 
@@ -7123,11 +7123,11 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - slice-ansi@4.0.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 MIT License
 
@@ -7142,11 +7142,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - source-map-resolve@0.5.3
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -7173,11 +7173,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - source-map-url@0.4.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -7451,11 +7451,11 @@ Apache License
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - spdx-exceptions@2.3.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The package exports an array of strings. Each string is an identifier
 for a license exception under the [Software Package Data Exchange
@@ -7496,11 +7496,11 @@ discuss the following Supreme Court decisions with their attorneys:
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - spdx-expression-parse@3.0.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License
 
@@ -7527,11 +7527,11 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - spdx-license-ids@3.0.7
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 # spdx-license-ids
 
@@ -7588,11 +7588,11 @@ deprecatedIds.includes('GPL-3.0'); //=> true
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - specificity@0.4.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 Copyright (c) 2016 Keegan Street and others
@@ -7605,11 +7605,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - string_decoder@1.1.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Node.js is licensed for use as follows:
 
@@ -7661,11 +7661,11 @@ IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - strip-bom-string@1.0.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -7691,11 +7691,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - style-search@0.1.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (c) 2016, David Clark
 
@@ -7713,11 +7713,11 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - stylelint-scss@3.18.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -7743,11 +7743,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - stylelint@13.8.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -7772,11 +7772,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - sugarss@2.0.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -7801,11 +7801,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - svg-tags@1.0.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -7831,11 +7831,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - table@6.0.4
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (c) 2018, Gajus Kuizinas (http://gajus.com/)
 All rights reserved.
@@ -7864,11 +7864,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - through2@2.0.5
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 # The MIT License (MIT)
 
@@ -7882,11 +7882,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - titlecase@1.1.3
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright © 2008–2013 David Gouch. Licensed under the MIT License.
 
@@ -7910,11 +7910,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - to-fast-properties@2.0.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 MIT License
 
@@ -7929,11 +7929,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - trough@1.0.5
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 (The MIT License)
 
@@ -7959,11 +7959,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - type-fest@0.18.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 MIT License
 
@@ -7977,11 +7977,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - type@1.2.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 ISC License
 
@@ -8001,11 +8001,11 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - type@2.1.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 ISC License
 
@@ -8025,11 +8025,11 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - uglify-js@3.13.4
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 UglifyJS is released under the BSD license:
 
@@ -8094,11 +8094,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - uniq@1.0.1
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -8124,11 +8124,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - unist-util-is@4.0.4
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 (The MIT license)
 
@@ -8155,11 +8155,11 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - uri-js@4.4.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright 2011 Gary Court. All rights reserved.
 
@@ -8175,11 +8175,11 @@ The views and conclusions contained in the software and documentation are those 
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - util-deprecate@1.0.2
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 (The MIT License)
 
@@ -8208,11 +8208,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - uuid@8.3.2
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -8226,11 +8226,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - v8-compile-cache@2.2.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -8256,11 +8256,11 @@ SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - vfile-message@2.0.4
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 (The MIT License)
 
@@ -8287,11 +8287,11 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - write-file-atomic@3.0.3
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (c) 2015, Rebecca Turner
 
@@ -8301,11 +8301,11 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - xtend@4.0.2
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 The MIT License (MIT)
 Copyright (c) 2012-2014 Raynos.
@@ -8330,11 +8330,11 @@ THE SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - yaml@1.10.0
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright 2018 Eemeli Aro <eemeli@gmail.com>
 
@@ -8352,11 +8352,11 @@ THIS SOFTWARE.
 
 -----------
 
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - yargs-parser@20.2.4
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 Copyright (c) 2016, Contributors
 


### PR DESCRIPTION
This PR deprecates the serving of the latest assets off of the master branch

Rather than pinning to latest, developers should pin to a version of Answers.

This PR also makes the `subdirectory` param required for the `deploy-to-aws` command. In the `build_i18n` step of `build_and_deploy_hold`, now ignores all branches as only version tags should trigger it. Because we are ignoring all branches at the start of the workflow (in `build_i18n`), we no longer need to ignore all branches in the `deploy_version` step

J=SLAP-1536
TEST=none

I don't think we can fully test this until it gets merged into master. However we know the config is valid because otherwise Circle CI would throw an error