### PR TITLE
Don't deploy major version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,8 +115,6 @@ jobs:
             echo "export MAJOR_VERSION="$(echo "${CIRCLE_TAG}" | cut -d '.' -f 1)"" >> $BASH_ENV
       - deploy-to-aws:
           subdirectory: '/${MINOR_VERSION}'
-      - deploy-to-aws:
-          subdirectory: '/${MAJOR_VERSION}'
 workflows:
   version: 2
   build_and_deploy:


### PR DESCRIPTION
Since this is a support branch, we don't want it to override the assets for v1 when deployed

J=none
TEST=none