### PR TITLE
override beforeMount in component's lifecycle

### DIFF
--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -247,7 +247,6 @@ export default class Component {
         this.onUpdate();
         this.userOnUpdate();
         this.unMount();
-        console.log(this.name + " update; before mount");
         this.mount();
       } catch (e) {
         throw new AnswersComponentError(

--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -167,21 +167,28 @@ export default class Component {
     this.transformData = config.transformData;
 
     /**
-     * The a local reference to the callback that will be invoked when a component is created.
+     * A local reference to the callback that will be invoked when a component is created.
      * @type {function}
      */
     this.onCreate = config.onCreateOverride || this.onCreate || function () {};
     this.onCreate = this.onCreate.bind(this);
 
     /**
-     * The a local reference to the callback that will be invoked when a component is Mounted.
+     * A local reference to the callback that will be invoked before a component is mounted.
+     * @type {function}
+     */
+    this.beforeMount = config.beforeMountOverride || this.beforeMount || function () {};
+    this.beforeMount = this.beforeMount.bind(this);
+
+    /**
+     * A local reference to the callback that will be invoked when a component is mounted.
      * @type {function}
      */
     this.onMount = config.onMountOverride || this.onMount || function () {};
     this.onMount = this.onMount.bind(this);
 
     /**
-     * The a local reference to the callback that will be invoked when a components state is updated.
+     * A local reference to the callback that will be invoked when a components state is updated.
      * @type {function}
      */
     this.onUpdate = config.onUpdateOverride || this.onUpdate || function () { };
@@ -240,6 +247,7 @@ export default class Component {
         this.onUpdate();
         this.userOnUpdate();
         this.unMount();
+        console.log(this.name + " update; before mount");
         this.mount();
       } catch (e) {
         throw new AnswersComponentError(


### PR DESCRIPTION
allow component to override beforeMount function by passing a beforeMountOverride function in its config. This is used to prevent component from rendering on page (e.g. [for mobile map view performance](https://github.com/yext/answers-hitchhiker-theme/pull/954)).

J=SLAP-1302

- used in theme's verticalResults config for vertical-full-page-map, and see that the provided beforeMountOverride function is called before any implementations in mount is called.