### PR TITLE
Fix google map inValidValueError

### DIFF
--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -264,7 +264,7 @@ export class GoogleMapMarkerConfig {
       }
 
       let label;
-      if (pinConfigObj.label) {
+      if (pinConfigObj.label || pinConfigObj.label === '') {
         label = pinConfigObj.label;
       } else {
         label = marker.label.toString();


### PR DESCRIPTION
- allow config to pass a pin label that is an empty string instead of defaulting to SDK built-in label got GoogleMapProvider (only use when label is not specified at all in config)

J=SLAP-655
TEST=manual

launched theme's test site, and see that theme's pin label config (empty string) is used instead of default marker label