### PR TITLE
update SDK Mapbox to same version as Theme

### DIFF
--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -30,6 +30,7 @@ export default class MapBoxMapProvider extends MapProvider {
    * @param {function} onLoad An optional callback to invoke once the JS is loaded.
    */
   loadJS (onLoad) {
+    const version = 'v1.13.1';
     const script = DOM.createEl('script', {
       id: 'yext-map-js',
       onload: () => {
@@ -49,13 +50,13 @@ export default class MapBoxMapProvider extends MapProvider {
         }
       },
       async: true,
-      src: 'https://api.mapbox.com/mapbox-gl-js/v0.44.1/mapbox-gl.js'
+      src: `https://api.mapbox.com/mapbox-gl-js/${version}/mapbox-gl.js`
     });
 
     const css = DOM.createEl('link', {
       id: 'yext-map-css',
       rel: 'stylesheet',
-      href: 'https://api.mapbox.com/mapbox-gl-js/v0.44.1/mapbox-gl.css'
+      href: `https://api.mapbox.com/mapbox-gl-js/${version}/mapbox-gl.css`
     });
 
     DOM.append('body', css);


### PR DESCRIPTION
- updated version to v1.13.1 for Mapbox js and css api
- checked that there's no breaking change with the version update
- confirmed with product of the change in pricing model

TEST=manual
- add map to universal search component on page, serve page using locale answer bundle and see that mapbox work properly
- test that dark-v10 style works for mapbox