### PR TITLE
Search bar only analytics fix

### DIFF
--- a/src/answers-search-bar.js
+++ b/src/answers-search-bar.js
@@ -33,7 +33,8 @@ import { SEARCH_BAR_COMPONENTS_REGISTRY } from './ui/components/search-bar-only-
 
 const DEFAULTS = {
   locale: LOCALE,
-  querySource: QUERY_SOURCE
+  querySource: QUERY_SOURCE,
+  analyticsEventsEnabled: true
 };
 
 /**
@@ -172,6 +173,7 @@ class AnswersSearchBar {
         parsedConfig.experienceKey,
         parsedConfig.experienceVersion,
         parsedConfig.businessId,
+        parsedConfig.analyticsEventsEnabled,
         parsedConfig.analyticsOptions,
         parsedConfig.environment);
 
@@ -282,6 +284,14 @@ class AnswersSearchBar {
       throw new AnswersComponentError('Failed to add component', type, e);
     }
     return this;
+  }
+
+  /**
+   * Opt in or out of analytic events
+   * @param {boolean} analyticsEventsEnabled
+   */
+  setAnalyticsOptIn (analyticsEventsEnabled) {
+    this._analyticsReporterService.setAnalyticsOptIn(analyticsEventsEnabled);
   }
 
   /**


### PR DESCRIPTION
Fix the analytics for the search bar only assets

When analyticsEventsEnabled was added to the SDK, the parameter order of the AnalyticsReporter constructor changed and it broke analytics for the search bar only assets. This caused analytics to only be sent if `analyticsOptions` was present in the config. The data sent was also messed up.

Fix the parameter order so that it is the same as the regular SDK

J=none
TEST=manual

Build the search bar only assets and test analytics with voice search and the clear button. See that analytics are properly sent even without analyticsOptions existing, and see that the data is now correct. Test `setAnalyticsOptIn` and confirm that it can disable analytics