### PR TITLE
Search Rate Tracking

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,7 +1,7 @@
 module.exports = [
   {
     path: 'dist/answers.min.js',
-    limit: '168 KB'
+    limit: '170 KB'
   },
   {
     path: 'dist/answers-modern.min.js',

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
       "**/tests/core/**/*.js",
       "**/tests/ui/**/*.js",
       "**/tests/conf/**/*.js",
-      "**/tests/answers-umd.js"
+      "**/tests/answers-*.js"
     ],
     "transform": {
       ".+\\.js$": "babel-jest",

--- a/src/answers-search-bar.js
+++ b/src/answers-search-bar.js
@@ -12,6 +12,7 @@ import {
 import ErrorReporter from './core/errors/errorreporter';
 import { AnalyticsReporter } from './core';
 import Storage from './core/storage/storage';
+import AnalyticsEvent from './core/analytics/analyticsevent';
 import { AnswersComponentError } from './core/errors/errors';
 import StorageKeys from './core/storage/storagekeys';
 import QueryTriggers from './core/models/querytriggers';
@@ -174,6 +175,13 @@ class AnswersSearchBar {
         parsedConfig.businessId,
         parsedConfig.analyticsOptions,
         parsedConfig.environment);
+
+      const impressionEvent = AnalyticsEvent.fromData({
+        type: 'ANSWERS_IMPRESSION',
+        searcher: parsedConfig.search.verticalKey ? 'VERTICAL' : 'UNIVERSAL',
+        standalone: true
+      });
+      this._analyticsReporterService.report(impressionEvent);
 
       this.components.setAnalyticsReporter(this._analyticsReporterService);
     }

--- a/src/answers-search-bar.js
+++ b/src/answers-search-bar.js
@@ -178,10 +178,6 @@ class AnswersSearchBar {
         parsedConfig.analyticsOptions,
         parsedConfig.environment);
 
-      const verticalKey = parsedConfig.search?.verticalKey;
-      const impressionEvent = createImpressionEvent({ verticalKey, standAlone: true });
-      this._analyticsReporterService.report(impressionEvent, { includeQueryId: false });
-
       this.components.setAnalyticsReporter(this._analyticsReporterService);
     }
 
@@ -217,7 +213,14 @@ class AnswersSearchBar {
 
     this.renderer.init(parsedConfig.templateBundle, this._getInitLocale());
     this._handlePonyfillCssVariables(parsedConfig.disableCssVariablesPonyfill)
-      .finally(() => this._onReady());
+      .finally(() => {
+        this._onReady();
+        const impressionEvent = createImpressionEvent({
+          verticalKey: parsedConfig.search?.verticalKey,
+          standAlone: true
+        });
+        this._analyticsReporterService.report(impressionEvent, { includeQueryId: false });
+      });
   }
 
   domReady (cb) {

--- a/src/answers-search-bar.js
+++ b/src/answers-search-bar.js
@@ -12,7 +12,6 @@ import {
 import ErrorReporter from './core/errors/errorreporter';
 import { AnalyticsReporter } from './core';
 import Storage from './core/storage/storage';
-import AnalyticsEvent from './core/analytics/analyticsevent';
 import { AnswersComponentError } from './core/errors/errors';
 import StorageKeys from './core/storage/storagekeys';
 import QueryTriggers from './core/models/querytriggers';
@@ -23,6 +22,7 @@ import { isValidContext } from './core/utils/apicontext';
 import { urlWithoutQueryParamsAndHash } from './core/utils/urlutils';
 import Filter from './core/models/filter';
 import { SEARCH_BAR_COMPONENTS_REGISTRY } from './ui/components/search-bar-only-registry';
+import createImpressionEvent from './core/analytics/createimpressionevent';
 
 /** @typedef {import('./core/services/errorreporterservice').default} ErrorReporterService */
 /** @typedef {import('./core/services/analyticsreporterservice').default} AnalyticsReporterService */
@@ -178,12 +178,9 @@ class AnswersSearchBar {
         parsedConfig.analyticsOptions,
         parsedConfig.environment);
 
-      const impressionEvent = AnalyticsEvent.fromData({
-        type: 'ANSWERS_IMPRESSION',
-        searcher: parsedConfig.search.verticalKey ? 'VERTICAL' : 'UNIVERSAL',
-        standalone: true
-      });
-      this._analyticsReporterService.report(impressionEvent);
+      const verticalKey = parsedConfig.search?.verticalKey;
+      const impressionEvent = createImpressionEvent({ verticalKey, standAlone: true });
+      this._analyticsReporterService.report(impressionEvent, { includeQueryId: false });
 
       this.components.setAnalyticsReporter(this._analyticsReporterService);
     }

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -305,15 +305,19 @@ class Answers {
     return asyncDeps.finally(() => {
       this._onReady();
 
-      if (!this.components.getActiveComponent(SearchComponent.type)) {
+      const isSearchBarActive = this.components.getActiveComponent(SearchComponent.type);
+      const numActiveComponents = this.components.getNumActiveComponents();
+
+      if (isSearchBarActive) {
+        const impressionEvent = createImpressionEvent({
+          verticalKey: parsedConfig.search?.verticalKey,
+          // check that 1 or 2 components are active because the search bar also creates the autocomplete component
+          standAlone: numActiveComponents >= 1 && numActiveComponents <= 2
+        });
+        this._analyticsReporterService.report(impressionEvent, { includeQueryId: false });
+      } else {
         this._initQueryUpdateListener(parsedConfig.search);
       }
-
-      const impressionEvent = createImpressionEvent({
-        verticalKey: parsedConfig.search?.verticalKey,
-        standAlone: false
-      });
-      this._analyticsReporterService.report(impressionEvent, { includeQueryId: false });
 
       this._searchOnLoad();
     });

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -259,6 +259,13 @@ class Answers {
         parsedConfig.analyticsOptions,
         parsedConfig.environment);
 
+      const impressionEvent = AnalyticsEvent.fromData({
+        type: 'ANSWERS_IMPRESSION',
+        searcher: parsedConfig.search.verticalKey ? 'VERTICAL' : 'UNIVERSAL',
+        standalone: false
+      });
+      this._analyticsReporterService.report(impressionEvent);
+
       // listen to query id updates
       storage.registerListener({
         eventType: 'update',

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -31,6 +31,7 @@ import SearchComponent from './ui/components/search/searchcomponent';
 import QueryUpdateListener from './core/statelisteners/queryupdatelistener';
 import { COMPONENT_REGISTRY } from './ui/components/registry';
 import { localizedDistance, parseLocale } from './core/utils/i18nutils';
+import createImpressionEvent from './core/analytics/createimpressionevent';
 
 /** @typedef {import('./core/services/errorreporterservice').default} ErrorReporterService */
 /** @typedef {import('./core/services/analyticsreporterservice').default} AnalyticsReporterService */
@@ -259,12 +260,9 @@ class Answers {
         parsedConfig.analyticsOptions,
         parsedConfig.environment);
 
-      const impressionEvent = AnalyticsEvent.fromData({
-        type: 'ANSWERS_IMPRESSION',
-        searcher: parsedConfig.search.verticalKey ? 'VERTICAL' : 'UNIVERSAL',
-        standalone: false
-      });
-      this._analyticsReporterService.report(impressionEvent);
+      const verticalKey = parsedConfig.search?.verticalKey;
+      const impressionEvent = createImpressionEvent({ verticalKey, standAlone: false });
+      this._analyticsReporterService.report(impressionEvent, { includeQueryId: false });
 
       // listen to query id updates
       storage.registerListener({

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -260,10 +260,6 @@ class Answers {
         parsedConfig.analyticsOptions,
         parsedConfig.environment);
 
-      const verticalKey = parsedConfig.search?.verticalKey;
-      const impressionEvent = createImpressionEvent({ verticalKey, standAlone: false });
-      this._analyticsReporterService.report(impressionEvent, { includeQueryId: false });
-
       // listen to query id updates
       storage.registerListener({
         eventType: 'update',
@@ -308,9 +304,17 @@ class Answers {
     const asyncDeps = this._loadAsyncDependencies(parsedConfig);
     return asyncDeps.finally(() => {
       this._onReady();
+
       if (!this.components.getActiveComponent(SearchComponent.type)) {
         this._initQueryUpdateListener(parsedConfig.search);
       }
+
+      const impressionEvent = createImpressionEvent({
+        verticalKey: parsedConfig.search?.verticalKey,
+        standAlone: false
+      });
+      this._analyticsReporterService.report(impressionEvent, { includeQueryId: false });
+
       this._searchOnLoad();
     });
   }

--- a/src/core/analytics/analyticsreporter.js
+++ b/src/core/analytics/analyticsreporter.js
@@ -38,7 +38,7 @@ export default class AnalyticsReporter {
      * @type {object}
      * @private
      */
-    this._globalOptions = Object.assign({}, globalOptions, { experienceKey, experienceVersion });
+    this._globalOptions = Object.assign({}, globalOptions, { experienceKey });
 
     /**
      * The environment of the Answers experience

--- a/src/core/analytics/analyticsreporter.js
+++ b/src/core/analytics/analyticsreporter.js
@@ -38,7 +38,7 @@ export default class AnalyticsReporter {
      * @type {object}
      * @private
      */
-    this._globalOptions = Object.assign({}, globalOptions, { experienceKey });
+    this._globalOptions = Object.assign({}, globalOptions, { experienceKey, experienceVersion });
 
     /**
      * The environment of the Answers experience

--- a/src/core/analytics/createimpressionevent.js
+++ b/src/core/analytics/createimpressionevent.js
@@ -1,0 +1,20 @@
+import AnalyticsEvent from './analyticsevent';
+
+/**
+ * Creates an ANSWERS_IMPRESSION analytics event
+ * @param {*} options
+ * @param {string} options.verticalKey Optional, indicates the vertical associated with the impression
+ * @param {boolean} options.standAlone Indicates whether or not the impression came from the standalone search bar
+ * @returns AnalyticsEvent
+ */
+export default function createImpressionEvent ({
+  verticalKey = undefined,
+  standAlone = false
+}) {
+  return AnalyticsEvent.fromData({
+    type: 'ANSWERS_IMPRESSION',
+    searcher: verticalKey ? 'VERTICAL' : 'UNIVERSAL',
+    ...verticalKey && { verticalConfigId: verticalKey },
+    standAlone
+  });
+}

--- a/src/core/analytics/createimpressionevent.js
+++ b/src/core/analytics/createimpressionevent.js
@@ -2,7 +2,7 @@ import AnalyticsEvent from './analyticsevent';
 
 /**
  * Creates an ANSWERS_IMPRESSION analytics event
- * @param {*} options
+ * @param {Object} options
  * @param {string} options.verticalKey Optional, indicates the vertical associated with the impression
  * @param {boolean} options.standAlone Indicates whether or not the impression came from the standalone search bar
  * @returns AnalyticsEvent

--- a/src/ui/components/componentmanager.js
+++ b/src/ui/components/componentmanager.js
@@ -210,4 +210,12 @@ export default class ComponentManager {
       return names.concat(this._componentTypeToComponentNames[type] || []);
     }, []);
   }
+
+  /**
+   * Returns the number of active components
+   * @returns {number} The number of active componets
+   */
+  getNumActiveComponents () {
+    return this._activeComponents.length;
+  }
 }

--- a/tests/answers-search-bar.js
+++ b/tests/answers-search-bar.js
@@ -1,33 +1,19 @@
-import ANSWERS from '../src/answers-umd';
+import ANSWERS from '../src/answers-search-bar';
 import mockWindow from './setup/mockwindow';
 import initAnswers from './setup/initanswers';
 
 jest.mock('../src/core/analytics/analyticsreporter');
+jest.mock('../src/ui/rendering/handlebarsrenderer');
 
 let windowSpy;
 
-describe('ANSWERS instance integration testing', () => {
+describe('ANSWERS search bar instance integration testing', () => {
   beforeEach(() => {
     windowSpy = jest.spyOn(window, 'window', 'get');
   });
 
   afterEach(() => {
     windowSpy.mockRestore();
-  });
-
-  it('Spellcheck query params in the URL trigger a spellcheck search during ANSWERS initialization', async () => {
-    mockWindow(windowSpy, {
-      location: {
-        search: '?query=office+space&queryTrigger=suggest&skipSpellCheck=true'
-      }
-    });
-    await initAnswers(ANSWERS);
-    const expectedParams = expect.objectContaining({
-      query: 'office space',
-      queryTrigger: 'suggest',
-      skipSpellCheck: 'true'
-    });
-    expect(ANSWERS.core._coreLibrary.universalSearch).toHaveBeenCalledWith(expectedParams);
   });
 
   it('An ANSWERS impression event is reported during ANSWERS.init', async () => {
@@ -40,7 +26,7 @@ describe('ANSWERS instance integration testing', () => {
     const expectedEvent = {
       eventType: 'ANSWERS_IMPRESSION',
       searcher: 'UNIVERSAL',
-      standAlone: false
+      standAlone: true
     };
     expect(ANSWERS._analyticsReporterService.report).toHaveBeenCalledWith(expectedEvent, expect.anything());
   });

--- a/tests/answers-umd.js
+++ b/tests/answers-umd.js
@@ -30,17 +30,19 @@ describe('ANSWERS instance integration testing', () => {
     expect(ANSWERS.core._coreLibrary.universalSearch).toHaveBeenCalledWith(expectedParams);
   });
 
-  it('An ANSWERS impression event is reported during ANSWERS.init', async () => {
+  it('An ANSWERS impression event is reported during ANSWERS.init if the search bar component is active', async () => {
     mockWindow(windowSpy, {
       location: {
         search: '?query=test'
       }
     });
-    await initAnswers(ANSWERS);
+    await initAnswers(ANSWERS, {
+      onReady: () => ANSWERS.addComponent('SearchBar')
+    });
     const expectedEvent = {
       eventType: 'ANSWERS_IMPRESSION',
       searcher: 'UNIVERSAL',
-      standAlone: false
+      standAlone: true
     };
     expect(ANSWERS._analyticsReporterService.report).toHaveBeenCalledWith(expectedEvent, expect.anything());
   });

--- a/tests/setup/initanswers.js
+++ b/tests/setup/initanswers.js
@@ -1,0 +1,17 @@
+/**
+ * Initializes ANSWERS for jest testing with some functionality disabled
+ * @param ANSWERS - The answers instance to initialize
+ * @param config Config to add during initialization
+ */
+export default async function initAnswers (ANSWERS, config = {}) {
+  // Don't load the templates during testing
+  ANSWERS._loadTemplates = () => Promise.resolve();
+  await ANSWERS.init({
+    apiKey: 'test',
+    experienceKey: 'test',
+    // Don't load this polyfill during testing
+    disableCssVariablesPonyfill: 'true',
+    businessId: '123',
+    ...config
+  });
+}

--- a/tests/setup/mockwindow.js
+++ b/tests/setup/mockwindow.js
@@ -1,0 +1,24 @@
+/**
+ * Mocks the window for jest testing while putting the provided data on the window
+ * @param {jest.SpyInstance} windowSpy A jest spy instance tracking calls to the window's get function
+ * @param {Object} data Data added to the mocked window
+ */
+export default function mockWindow (windowSpy, data = {}) {
+  windowSpy.mockImplementation(() => ({
+    performance: {
+      mark: jest.fn()
+    },
+    sessionStorage: {
+      getItem: jest.fn(),
+      setItem: jest.fn()
+    },
+    addEventListener: jest.fn(),
+    history: {
+      replaceState: jest.fn()
+    },
+    location: {
+      search: jest.fn()
+    },
+    ...data
+  }));
+}


### PR DESCRIPTION
Allow search rate tracking by sending impression analytics events when the experience loads

J=SLAP-1600
TEST=manual, integration

View the network tab and see that the answers impression event is fired on load. For the search bar only assets, see that 'standAlone' is true. Also confirm the other fields are included such as experienceKey, experienceVersion, searcher, and verticalConfigId. Add integration test which confirms that the report function is called properly for both the standard integration and the search bar integration