### PR TITLE
fix defaultInitialSearch

### DIFF
--- a/src/answers-search-bar.js
+++ b/src/answers-search-bar.js
@@ -215,11 +215,13 @@ class AnswersSearchBar {
     this._handlePonyfillCssVariables(parsedConfig.disableCssVariablesPonyfill)
       .finally(() => {
         this._onReady();
-        const impressionEvent = createImpressionEvent({
-          verticalKey: parsedConfig.search?.verticalKey,
-          standAlone: true
-        });
-        this._analyticsReporterService.report(impressionEvent, { includeQueryId: false });
+        if (this._analyticsReporterService) {
+          const impressionEvent = createImpressionEvent({
+            verticalKey: parsedConfig.search?.verticalKey,
+            standAlone: true
+          });
+          this._analyticsReporterService.report(impressionEvent, { includeQueryId: false });
+        }
       });
   }
 

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -351,7 +351,6 @@ class Answers {
   _searchOnLoad () {
     const searchComponents = this.components._activeComponents
       .filter(c => c.constructor.type === SearchComponent.type);
-    console.log('search on load?', searchComponents, this.core.storage)
     if (searchComponents.length) {
       searchComponents.forEach(c => c.searchAfterAnswersOnReady && c.searchAfterAnswersOnReady());
     } else if (this.core.storage.has(StorageKeys.QUERY)) {

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -305,7 +305,7 @@ class Answers {
     return asyncDeps.finally(() => {
       this._onReady();
 
-      const searchBarIsActive = this.components.getActiveComponent(SearchComponent.type);
+      const searchBarIsActive = !!this.components.getActiveComponent(SearchComponent.type);
       if (searchBarIsActive && this._analyticsReporterService) {
         const numActiveComponents = this.components.getNumActiveComponents();
         const impressionEvent = createImpressionEvent({

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -306,8 +306,7 @@ class Answers {
       this._onReady();
 
       const searchBarIsActive = this.components.getActiveComponent(SearchComponent.type);
-      // if (searchBarIsActive && this._analyticsReporterService) {
-      if (searchBarIsActive) {
+      if (searchBarIsActive && this._analyticsReporterService) {
         const numActiveComponents = this.components.getNumActiveComponents();
         const impressionEvent = createImpressionEvent({
           verticalKey: parsedConfig.search?.verticalKey,

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -306,8 +306,8 @@ class Answers {
       this._onReady();
 
       const searchBarIsActive = this.components.getActiveComponent(SearchComponent.type);
-
-      if (searchBarIsActive && this._analyticsReporterService) {
+      // if (searchBarIsActive && this._analyticsReporterService) {
+      if (searchBarIsActive) {
         const numActiveComponents = this.components.getNumActiveComponents();
         const impressionEvent = createImpressionEvent({
           verticalKey: parsedConfig.search?.verticalKey,

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -305,10 +305,10 @@ class Answers {
     return asyncDeps.finally(() => {
       this._onReady();
 
-      const isSearchBarActive = this.components.getActiveComponent(SearchComponent.type);
-      const numActiveComponents = this.components.getNumActiveComponents();
+      const searchBarIsActive = this.components.getActiveComponent(SearchComponent.type);
 
-      if (isSearchBarActive) {
+      if (searchBarIsActive && this._analyticsReporterService) {
+        const numActiveComponents = this.components.getNumActiveComponents();
         const impressionEvent = createImpressionEvent({
           verticalKey: parsedConfig.search?.verticalKey,
           // check that 1 or 2 components are active because the
@@ -316,7 +316,9 @@ class Answers {
           standAlone: numActiveComponents >= 1 && numActiveComponents <= 2
         });
         this._analyticsReporterService.report(impressionEvent, { includeQueryId: false });
-      } else {
+      }
+
+      if (!searchBarIsActive) {
         this._initQueryUpdateListener(parsedConfig.search);
       }
 
@@ -350,6 +352,7 @@ class Answers {
   _searchOnLoad () {
     const searchComponents = this.components._activeComponents
       .filter(c => c.constructor.type === SearchComponent.type);
+    console.log('search on load?', searchComponents, this.core.storage)
     if (searchComponents.length) {
       searchComponents.forEach(c => c.searchAfterAnswersOnReady && c.searchAfterAnswersOnReady());
     } else if (this.core.storage.has(StorageKeys.QUERY)) {

--- a/tests/acceptance/fixtures/html/universalinitialsearch.html
+++ b/tests/acceptance/fixtures/html/universalinitialsearch.html
@@ -19,7 +19,6 @@
     ANSWERS.init({
       apiKey: 'df4b24f4075800e5e9705090c54c6c13',
       experienceKey: 'sdkacceptancetests',
-      businessId: '3350634',
       experienceVersion: 'PRODUCTION',
       templateBundle: TemplateBundle.default,
       search: {


### PR DESCRIPTION
Prior to this change, if you didn't have a businessId, searches on page load
would error out because a search impression analytics event would try to be fired
using a null analytics reporter service.

J=SLAP-1616
TEST=manual,auto

I can run default initial searches, and searches using the query url param again, in my local
SDK test site and also the theme's test-site

tweaked the universalinitialsearch acceptance suite to not have a business id