### PR TITLE
Search Rate Event Name Fix

### DIFF
--- a/src/core/analytics/createimpressionevent.js
+++ b/src/core/analytics/createimpressionevent.js
@@ -1,7 +1,7 @@
 import AnalyticsEvent from './analyticsevent';
 
 /**
- * Creates an ANSWERS_IMPRESSION analytics event
+ * Creates an SEARCH_BAR_IMPRESSION analytics event
  * @param {Object} options
  * @param {string} options.verticalKey Optional, indicates the vertical associated with the impression
  * @param {boolean} options.standAlone Indicates whether or not the impression came
@@ -13,7 +13,7 @@ export default function createImpressionEvent ({
   standAlone = false
 }) {
   return AnalyticsEvent.fromData({
-    type: 'ANSWERS_IMPRESSION',
+    type: 'SEARCH_BAR_IMPRESSION',
     searcher: verticalKey ? 'VERTICAL' : 'UNIVERSAL',
     ...verticalKey && { verticalConfigId: verticalKey },
     standAlone

--- a/tests/answers-search-bar.js
+++ b/tests/answers-search-bar.js
@@ -24,7 +24,7 @@ describe('ANSWERS search bar instance integration testing', () => {
     });
     await initAnswers(ANSWERS);
     const expectedEvent = {
-      eventType: 'ANSWERS_IMPRESSION',
+      eventType: 'SEARCH_BAR_IMPRESSION',
       searcher: 'UNIVERSAL',
       standAlone: true
     };

--- a/tests/answers-umd.js
+++ b/tests/answers-umd.js
@@ -40,7 +40,7 @@ describe('ANSWERS instance integration testing', () => {
       onReady: () => ANSWERS.addComponent('SearchBar')
     });
     const expectedEvent = {
-      eventType: 'ANSWERS_IMPRESSION',
+      eventType: 'SEARCH_BAR_IMPRESSION',
       searcher: 'UNIVERSAL',
       standAlone: true
     };


### PR DESCRIPTION
Fix the analytics event name for the search impression event

The spec references both `ANSWERS_IMPRESSION` and `SEARCH_BAR_IMPRESSION`, however the backend only accepts `SEARCH_BAR_IMPRESSION`, so we should update it

J=none
TEST=manual

Load the page and see that the SEARCH_BAR_IMPRESSION is being fired and see that the server returns an http 200