### PR TITLE
Add support for Auth Token to SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Add the Javascript library and placeholder elements for [Answers components](#co
 <div id="UniversalResultsContainer"></div>
 ```
 
-Add an initialization script with an apiKey, experienceKey and onReady function. In the example below, we've initialized two
-basic components: [SearchBar](#searchbar-component) and [UniversalResults](#universal-results-component).
+Add an initialization script with an apiKey or token, experienceKey and onReady function. In the example below, we've initialized two
+basic components with apiKey: [SearchBar](#searchbar-component) and [UniversalResults](#universal-results-component).
 ```js
 function initAnswers() {
   ANSWERS.init({
@@ -125,8 +125,10 @@ The configuration provided here is configuration that is shared across component
 ```js
 function initAnswers() {
   ANSWERS.init({
-    // Required, your Yext Answers API key
+    // Required*, your Yext Answers API key. *Do NOT provide apiKey if token is used.
     apiKey: '<API_KEY_HERE>',
+    //Required*, custom auth token. *Do NOT provide token if apiKey is used.
+    token: '<TOKEN_HERE>',
     // Required, the key used for your Answers experience
     experienceKey: '<EXPERIENCE_KEY_HERE>',
     // Optional, initialize components here, invoked when the Answers component library is loaded/ready.

--- a/src/answers-search-bar.js
+++ b/src/answers-search-bar.js
@@ -182,6 +182,7 @@ class AnswersSearchBar {
     }
 
     this.core = new Core({
+      token: parsedConfig.token,
       apiKey: parsedConfig.apiKey,
       storage: storage,
       experienceKey: parsedConfig.experienceKey,
@@ -247,11 +248,12 @@ class AnswersSearchBar {
     }
     parsedConfig.sessionTrackingEnabled = sessionTrackingEnabled;
 
+    const authIdKey = parsedConfig.apiKey ? 'apiKey' : 'token';
     const sandboxPrefix = `${SANDBOX}-`;
-    parsedConfig.apiKey.includes(sandboxPrefix)
+    parsedConfig[authIdKey].includes(sandboxPrefix)
       ? parsedConfig.environment = SANDBOX
       : parsedConfig.environment = PRODUCTION;
-    parsedConfig.apiKey = parsedConfig.apiKey.replace(sandboxPrefix, '');
+    parsedConfig[authIdKey] = parsedConfig[authIdKey].replace(sandboxPrefix, '');
 
     return parsedConfig;
   }

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -272,6 +272,7 @@ class Answers {
     }
 
     this.core = new Core({
+      token: parsedConfig.token,
       apiKey: parsedConfig.apiKey,
       storage: storage,
       experienceKey: parsedConfig.experienceKey,
@@ -402,11 +403,12 @@ class Answers {
     }
     parsedConfig.sessionTrackingEnabled = sessionTrackingEnabled;
 
+    const authIdKey = parsedConfig.apiKey ? 'apiKey' : 'token';
     const sandboxPrefix = `${SANDBOX}-`;
-    parsedConfig.apiKey.includes(sandboxPrefix)
+    parsedConfig[authIdKey].includes(sandboxPrefix)
       ? parsedConfig.environment = SANDBOX
       : parsedConfig.environment = PRODUCTION;
-    parsedConfig.apiKey = parsedConfig.apiKey.replace(sandboxPrefix, '');
+    parsedConfig[authIdKey] = parsedConfig[authIdKey].replace(sandboxPrefix, '');
 
     return parsedConfig;
   }
@@ -419,8 +421,12 @@ class Answers {
   validateConfig (config) {
     // TODO (tmeyer): Extract this method into it's own class. Investigate the use of JSON schema
     // to validate these configs.
-    if (typeof config.apiKey !== 'string') {
-      throw new Error('Missing required `apiKey`. Type must be {string}');
+    if (typeof config.apiKey !== 'string' && typeof config.token !== 'string') {
+      throw new Error('Missing required `apiKey` or `token`. Type must be {string}');
+    }
+
+    if (typeof config.apiKey === 'string' && typeof config.token === 'string') {
+      throw new Error('Both apiKey and token are present. Only one authentication method should be provided');
     }
 
     if (typeof config.experienceKey !== 'string') {

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -32,6 +32,13 @@ import SearchStates from './storage/searchstates';
 export default class Core {
   constructor (config = {}) {
     /**
+     * A reference to the auth token used for all requests
+     * @type {string}
+     * @private
+     */
+    this._token = config.token;
+
+    /**
      * A reference to the client API Key used for all requests
      * @type {string}
      * @private
@@ -129,6 +136,7 @@ export default class Core {
    */
   init () {
     const params = {
+      token: this._token,
       apiKey: this._apiKey,
       experienceKey: this._experienceKey,
       locale: this._locale,


### PR DESCRIPTION
- update Answers (answers-umd and answers-search-bar)and Core class to support token field pass in from config.
- update readme

J=SLAP-1627
TEST=manual & auto

see that token is in header when making a request