### PR TITLE
WCAG update for pagination

### DIFF
--- a/src/ui/components/results/paginationcomponent.js
+++ b/src/ui/components/results/paginationcomponent.js
@@ -184,21 +184,21 @@ export default class PaginationComponent extends Component {
     const nextPageButton = DOM.query(this._container, '.js-yxt-Pagination-next');
     const maxPage = Math.trunc((results.resultsCount - 1) / limit);
 
-    DOM.on(previousPageButton, 'click', () => this.updatePage(offset - limit));
-    DOM.on(nextPageButton, 'click', () => this.updatePage(offset + limit));
+    DOM.onClickOrEnter(previousPageButton, () => this.updatePage(offset - limit));
+    DOM.onClickOrEnter(nextPageButton, () => this.updatePage(offset + limit));
 
     if (this._firstPageButtonEnabled) {
       const firstPageButton = DOM.query(this._container, '.js-yxt-Pagination-first');
-      DOM.on(firstPageButton, 'click', () => this.updatePage(0));
+      DOM.onClickOrEnter(firstPageButton, () => this.updatePage(0));
     }
 
     if (this._lastPageButtonEnabled) {
       const lastPageButton = DOM.query(this._container, '.js-yxt-Pagination-last');
-      DOM.on(lastPageButton, 'click', () => this.updatePage(maxPage * limit));
+      DOM.onClickOrEnter(lastPageButton, () => this.updatePage(maxPage * limit));
     }
 
     DOM.queryAll('.js-yxt-Pagination-link').forEach(node => {
-      DOM.on(node, 'click', () => this.updatePage((parseInt(node.dataset.number) - 1) * limit));
+      DOM.onClickOrEnter(node, () => this.updatePage((parseInt(node.dataset.number) - 1) * limit));
     });
   }
 

--- a/src/ui/dom/dom.js
+++ b/src/ui/dom/dom.js
@@ -201,6 +201,15 @@ export default class DOM {
     DOM.query(selector).addEventListener(evt, handler);
   }
 
+  static onClickOrEnter (selector, handler) {
+    DOM.query(selector).addEventListener('click', handler);
+    DOM.query(selector).addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        handler(e);
+      }
+    });
+  }
+
   static once (selector, evt, handler) {
     const oneTimeHandler = () => {
       handler();


### PR DESCRIPTION
According to WCAG 2.1 guidelines on [Keyboard Accessible](https://www.w3.org/TR/WCAG21/#keyboard-accessible), All content's functionality should be operable through a keyboard interface. I did a quick check and it seems like most on-click events in SDK seems to already be operable by space or enter already (e.g. filter apply/reset, removable filter tag, search button, nav bar + more button).

Update pagination buttons to be operable by click or enter.

J=SLAP-576
TEST=manual

spin up theme's test site with local SDK changes, and see that pagination buttons (first, last, previous, and next) trigger listener on click or enter