### PR TITLE
Improve autocomplete screen reader support 

### DIFF
--- a/conf/i18n/translations/messages.pot
+++ b/conf/i18n/translations/messages.pot
@@ -8,9 +8,15 @@ msgid_plural "([[resultsCount]] results)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/templates/search/autocomplete.hbs:6
+#: src/ui/templates/search/autocomplete.hbs:7
 msgid "[[resultsCount]] [[label]] autocomplete option found."
 msgid_plural "[[resultsCount]] [[label]] autocomplete options found."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/ui/templates/search/autocomplete.hbs:15
+msgid "[[resultsCount]] autocomplete option found."
+msgid_plural "[[resultsCount]] autocomplete options found."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -31,7 +37,7 @@ msgstr ""
 msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
 msgstr ""
 
-#: src/ui/templates/search/autocomplete.hbs:15
+#: src/ui/templates/search/autocomplete.hbs:24
 msgid "0 autocomplete options found."
 msgstr ""
 

--- a/conf/i18n/translations/messages.pot
+++ b/conf/i18n/translations/messages.pot
@@ -15,7 +15,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/ui/templates/search/autocomplete.hbs:14
-#: src/ui/templates/search/autocomplete.hbs:24
+#: src/ui/templates/search/autocomplete.hbs:23
 msgid "[[resultsCount]] autocomplete option found."
 msgid_plural "[[resultsCount]] autocomplete options found."
 msgstr[0] ""

--- a/conf/i18n/translations/messages.pot
+++ b/conf/i18n/translations/messages.pot
@@ -8,13 +8,14 @@ msgid_plural "([[resultsCount]] results)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/templates/search/autocomplete.hbs:7
+#: src/ui/templates/search/autocomplete.hbs:6
 msgid "[[resultsCount]] [[label]] autocomplete option found."
 msgid_plural "[[resultsCount]] [[label]] autocomplete options found."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/templates/search/autocomplete.hbs:15
+#: src/ui/templates/search/autocomplete.hbs:14
+#: src/ui/templates/search/autocomplete.hbs:24
 msgid "[[resultsCount]] autocomplete option found."
 msgid_plural "[[resultsCount]] autocomplete options found."
 msgstr[0] ""
@@ -35,10 +36,6 @@ msgstr ""
 
 #: src/ui/templates/results/alternativeverticals.hbs:3
 msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
-msgstr ""
-
-#: src/ui/templates/search/autocomplete.hbs:24
-msgid "0 autocomplete options found."
 msgstr ""
 
 #: src/ui/templates/results/alternativeverticals.hbs:40

--- a/conf/i18n/translations/messages.pot
+++ b/conf/i18n/translations/messages.pot
@@ -8,9 +8,9 @@ msgid_plural "([[resultsCount]] results)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/templates/search/autocomplete.hbs:14
-msgid "[[resultsCount]] autocomplete option found"
-msgid_plural "[[resultsCount]] autocomplete options found"
+#: src/ui/templates/search/autocomplete.hbs:6
+msgid "[[resultsCount]] [[label]] autocomplete option found."
+msgid_plural "[[resultsCount]] [[label]] autocomplete options found."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -29,6 +29,10 @@ msgstr ""
 
 #: src/ui/templates/results/alternativeverticals.hbs:3
 msgid "<em class=\"yxt-AlternativeVerticals-noResultsInfo--emphasized\">No results found</em> in [[currentVerticalLabel]]."
+msgstr ""
+
+#: src/ui/templates/search/autocomplete.hbs:15
+msgid "0 autocomplete options found."
 msgstr ""
 
 #: src/ui/templates/results/alternativeverticals.hbs:40
@@ -190,6 +194,11 @@ msgstr ""
 
 #: src/ui/components/questions/questionsubmissioncomponent.js:167
 msgid "We're sorry, an error occurred."
+msgstr ""
+
+#: src/ui/templates/search/filtersearch.hbs:12
+#: src/ui/templates/search/search.hbs:29
+msgid "When autocomplete results are available, use up and down arrows to review and enter to select."
 msgstr ""
 
 #: src/ui/templates/results/noresults.hbs:7

--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -143,11 +143,6 @@ export default class AutoCompleteComponent extends Component {
      * @type {boolean}
      */
     this._isVoiceSearchActive = false;
-
-    /**
-     * Indicates that the user hasn't typed anything in the autocomplete input yet
-     */
-    this._beforeSearch = true;
   }
 
   /**
@@ -184,20 +179,18 @@ export default class AutoCompleteComponent extends Component {
       this._isOpen = true;
     }
 
+    let _onOpen = false;
+
     if (wasOpen && !this._isOpen) {
       this._onClose();
-      this._beforeSearch = true;
     } else if (!wasOpen && this._isOpen) {
       this._onOpen();
-    }
-
-    if (queryInputEl.value && this.isQueryInputFocused()) {
-      this._beforeSearch = false;
+      _onOpen = true;
     }
 
     super.setState(Object.assign({}, data, {
       hasResults: this.hasResults(data),
-      beforeSearch: this._beforeSearch,
+      isAlreadyOpen: this._isOpen && !_onOpen,
       sectionIndex: this._sectionIndex,
       resultIndex: this._resultIndex,
       promptHeader: this._originalQuery.length === 0 ? this.promptHeader : null,
@@ -248,7 +241,8 @@ export default class AutoCompleteComponent extends Component {
     // When a user focuses the input, we should populate the autocomplete based
     // on the current value
     DOM.on(queryInput, 'focus', () => {
-      this.reset();
+      this._sectionIndex = 0;
+      this._resultIndex = -1;
       this.autoComplete(queryInput.value);
     });
 

--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -179,18 +179,18 @@ export default class AutoCompleteComponent extends Component {
       this._isOpen = true;
     }
 
-    let _onOpen = false;
+    // let _onOpen = false;
 
     if (wasOpen && !this._isOpen) {
       this._onClose();
     } else if (!wasOpen && this._isOpen) {
       this._onOpen();
-      _onOpen = true;
+      // _onOpen = true;
     }
 
     super.setState(Object.assign({}, data, {
       hasResults: this.hasResults(data),
-      isAlreadyOpen: this._isOpen && !_onOpen,
+      isAlreadyOpen: this._isOpen && wasOpen,
       sectionIndex: this._sectionIndex,
       resultIndex: this._resultIndex,
       promptHeader: this._originalQuery.length === 0 ? this.promptHeader : null,

--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -143,6 +143,11 @@ export default class AutoCompleteComponent extends Component {
      * @type {boolean}
      */
     this._isVoiceSearchActive = false;
+
+    /**
+     * Indicates that the user hasn't typed anything in the autocomplete input yet
+     */
+    this._beforeSearch = true;
   }
 
   /**
@@ -181,12 +186,18 @@ export default class AutoCompleteComponent extends Component {
 
     if (wasOpen && !this._isOpen) {
       this._onClose();
+      this._beforeSearch = true;
     } else if (!wasOpen && this._isOpen) {
       this._onOpen();
     }
 
+    if (queryInputEl.value && this.isQueryInputFocused()) {
+      this._beforeSearch = false;
+    }
+
     super.setState(Object.assign({}, data, {
       hasResults: this.hasResults(data),
+      beforeSearch: this._beforeSearch,
       sectionIndex: this._sectionIndex,
       resultIndex: this._resultIndex,
       promptHeader: this._originalQuery.length === 0 ? this.promptHeader : null,

--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -179,13 +179,10 @@ export default class AutoCompleteComponent extends Component {
       this._isOpen = true;
     }
 
-    // let _onOpen = false;
-
     if (wasOpen && !this._isOpen) {
       this._onClose();
     } else if (!wasOpen && this._isOpen) {
       this._onOpen();
-      // _onOpen = true;
     }
 
     super.setState(Object.assign({}, data, {

--- a/src/ui/sass/modules/_SearchBar.scss
+++ b/src/ui/sass/modules/_SearchBar.scss
@@ -275,6 +275,10 @@ $searchbar-button-text-color-active: var(--yxt-searchbar-button-text-color-base)
     width: 2em;
     height: 2em;
   }
+
+  &-instructions {
+    display: none;
+  }
 }
 
 // If custom icons are supplied, the SVGs simply alternate opacity

--- a/src/ui/templates/search/autocomplete.hbs
+++ b/src/ui/templates/search/autocomplete.hbs
@@ -19,15 +19,13 @@
           }}
         {{/if}}
       {{/each}}
-    {{else}}
-      {{#if isAlreadyOpen}}
-        {{translate
-          phrase='[[resultsCount]] autocomplete option found.'
-          pluralForm='[[resultsCount]] autocomplete options found.'
-          resultsCount=0
-          count=0
-        }}
-      {{/if}}
+    {{else if isAlreadyOpen}}
+      {{translate
+        phrase='[[resultsCount]] autocomplete option found.'
+        pluralForm='[[resultsCount]] autocomplete options found.'
+        resultsCount=0
+        count=0
+      }}
     {{/if}}
   </span>
   {{#if hasResults}}

--- a/src/ui/templates/search/autocomplete.hbs
+++ b/src/ui/templates/search/autocomplete.hbs
@@ -1,29 +1,34 @@
 <div class="yxt-AutoComplete-wrapper js-yxt-AutoComplete-wrapper" aria-expanded="{{hasResults}}">
   <span class="yxt-AutoComplete-resultsCount sr-only" aria-live="assertive">
-    {{#unless beforeSearch}}
-      {{#if hasResults}}
-        {{#each sections}}
-          {{#if label}}
-            {{translate
-              phrase='[[resultsCount]] [[label]] autocomplete option found.'
-              pluralForm='[[resultsCount]] [[label]] autocomplete options found.'
-              resultsCount=resultsCount
-              label=label
-              count=resultsCount
-            }}
-          {{else}}
-            {{translate
-              phrase='[[resultsCount]] autocomplete option found.'
-              pluralForm='[[resultsCount]] autocomplete options found.'
-              resultsCount=resultsCount
-              count=resultsCount
-            }}
-          {{/if}}
-        {{/each}}
-      {{else}}
-        {{translate phrase='0 autocomplete options found.'}}
+    {{#if hasResults}}
+      {{#each sections}}
+        {{#if label}}
+          {{translate
+            phrase='[[resultsCount]] [[label]] autocomplete option found.'
+            pluralForm='[[resultsCount]] [[label]] autocomplete options found.'
+            resultsCount=resultsCount
+            label=label
+            count=resultsCount
+          }}
+        {{else}}
+          {{translate
+            phrase='[[resultsCount]] autocomplete option found.'
+            pluralForm='[[resultsCount]] autocomplete options found.'
+            resultsCount=resultsCount
+            count=resultsCount
+          }}
+        {{/if}}
+      {{/each}}
+    {{else}}
+      {{#if isAlreadyOpen}}
+        {{translate
+          phrase='[[resultsCount]] autocomplete option found.'
+          pluralForm='[[resultsCount]] autocomplete options found.'
+          resultsCount=0
+          count=0
+        }}
       {{/if}}
-    {{/unless}}
+    {{/if}}
   </span>
   {{#if hasResults}}
     <div class="yxt-AutoComplete">

--- a/src/ui/templates/search/autocomplete.hbs
+++ b/src/ui/templates/search/autocomplete.hbs
@@ -3,13 +3,22 @@
     {{#unless beforeSearch}}
       {{#if hasResults}}
         {{#each sections}}
-          {{translate
-            phrase='[[resultsCount]] [[label]] autocomplete option found.'
-            pluralForm='[[resultsCount]] [[label]] autocomplete options found.'
-            resultsCount=resultsCount
-            label=label
-            count=resultsCount
-          }}
+          {{#if label}}
+            {{translate
+              phrase='[[resultsCount]] [[label]] autocomplete option found.'
+              pluralForm='[[resultsCount]] [[label]] autocomplete options found.'
+              resultsCount=resultsCount
+              label=label
+              count=resultsCount
+            }}
+          {{else}}
+            {{translate
+              phrase='[[resultsCount]] autocomplete option found.'
+              pluralForm='[[resultsCount]] autocomplete options found.'
+              resultsCount=resultsCount
+              count=resultsCount
+            }}
+          {{/if}}
         {{/each}}
       {{else}}
         {{translate phrase='0 autocomplete options found.'}}

--- a/src/ui/templates/search/autocomplete.hbs
+++ b/src/ui/templates/search/autocomplete.hbs
@@ -1,4 +1,21 @@
 <div class="yxt-AutoComplete-wrapper js-yxt-AutoComplete-wrapper" aria-expanded="{{hasResults}}">
+  <span class="yxt-AutoComplete-resultsCount sr-only" aria-live="assertive">
+    {{#unless beforeSearch}}
+      {{#if hasResults}}
+        {{#each sections}}
+          {{translate
+            phrase='[[resultsCount]] [[label]] autocomplete option found.'
+            pluralForm='[[resultsCount]] [[label]] autocomplete options found.'
+            resultsCount=resultsCount
+            label=label
+            count=resultsCount
+          }}
+        {{/each}}
+      {{else}}
+        {{translate phrase='0 autocomplete options found.'}}
+      {{/if}}
+    {{/unless}}
+  </span>
   {{#if hasResults}}
     <div class="yxt-AutoComplete">
       {{assign 'currentSelected' sectionIndex resultIndex}}
@@ -10,14 +27,6 @@
         </ul>
       {{/if}}
       {{#each sections}}
-        <span class="yxt-AutoComplete-resultsCount sr-only" aria-live="assertive">
-          {{translate
-            phrase='[[resultsCount]] autocomplete option found'
-            pluralForm='[[resultsCount]] autocomplete options found'
-            resultsCount=resultsCount
-            count=resultsCount
-          }}
-        </span>
         <ul role="listbox"
             class="yxt-AutoComplete-results"
             aria-labelledby="{{../listLabelIdName}}"

--- a/src/ui/templates/search/filtersearch.hbs
+++ b/src/ui/templates/search/filtersearch.hbs
@@ -5,7 +5,13 @@
          type="text"
          name="query"
          value="{{query}}"
-         {{#if _config.placeholderText}}placeholder="{{_config.placeholderText}}"{{/if}}>
+         {{#if _config.placeholderText}}placeholder="{{_config.placeholderText}}"{{/if}}
+         aria-describedby="instructions">
   </input>
+  <div id="instructions" class="yxt-SearchBar-instructions sr-only">
+    {{translate
+      phrase='When autocomplete results are available, use up and down arrows to review and enter to select.'
+    }}
+  </div>
   <div class="yxt-SearchBar-autocomplete"></div>
 </div>

--- a/src/ui/templates/search/search.hbs
+++ b/src/ui/templates/search/search.hbs
@@ -22,8 +22,14 @@
           aria-label="{{labelText}}"
           aria-autocomplete="list"
           aria-controls="{{autocompleteContainerIdName}}"
+          aria-describedby="instructions"
           aria-haspopup="listbox"
         >
+        <div id="instructions" class="yxt-SearchBar-instructions sr-only">
+          {{translate
+            phrase='When autocomplete results are available, use up and down arrows to review and enter to select.'
+          }}
+        </div>
         <button type="button"
                 class="js-yxt-SearchBar-clear yxt-SearchBar-clear yxt-SearchBar--hidden"
                 data-eventtype="SEARCH_CLEAR_BUTTON"


### PR DESCRIPTION
Move `span` with `aria-live` label to be top-level for the autocomplete component so that it is present on page-load, even with empty content. Add instructions for navigating autocomplete to the search bar. Update the autocomplete component to correctly announce number of autocomplete options found for no results and for sectioned filter search.

Note: there should be no screen reader text for number of options found or autocomplete instructions when the search bar is not active. Also, there should be no announcement for number of options found when user focuses on the search bar and there are no default autocomplete options shown.

J=SLAP-1653, 1402
TEST=manual

Smoke testing with theme test-site to check that screen reader correctly announces instructions and number of autocomplete options found.