### PR TITLE
Update icon size

### DIFF
--- a/src/ui/sass/answers-search-bar.scss
+++ b/src/ui/sass/answers-search-bar.scss
@@ -9,6 +9,6 @@
 @import "base";
 
 // Component Styling
-@import "modules/SearchBar";
 @import "modules/Icon";
+@import "modules/SearchBar";
 @import "modules/AutoComplete";

--- a/src/ui/sass/answers.scss
+++ b/src/ui/sass/answers.scss
@@ -9,8 +9,8 @@
 @import "base";
 
 // Component Styling
-@import "modules/SearchBar";
 @import "modules/Icon";
+@import "modules/SearchBar";
 @import "modules/Nav";
 @import "modules/DirectAnswer";
 @import "modules/Results";

--- a/src/ui/sass/modules/_SearchBar.scss
+++ b/src/ui/sass/modules/_SearchBar.scss
@@ -270,7 +270,7 @@ $searchbar-button-text-color-active: var(--yxt-searchbar-button-text-color-base)
     }
   }
 
-  &-buttonImage .Icon svg, .Icon-image
+  &-AnimatedIcon svg, &-buttonImage .Icon svg, .Icon-image
   {
     width: 1.5em;
     height: 1.5em;

--- a/src/ui/sass/modules/_SearchBar.scss
+++ b/src/ui/sass/modules/_SearchBar.scss
@@ -272,8 +272,8 @@ $searchbar-button-text-color-active: var(--yxt-searchbar-button-text-color-base)
 
   &-buttonImage .Icon svg, .Icon-image
   {
-    width: 2em;
-    height: 2em;
+    width: 1.5em;
+    height: 1.5em;
   }
 
   &-instructions {

--- a/src/ui/templates/icons/searchBarIcon.hbs
+++ b/src/ui/templates/icons/searchBarIcon.hbs
@@ -5,7 +5,7 @@
     </div>
   {{else}}
     <div class="yxt-SearchBar-AnimatedIcon js-yxt-SearchBar-LoadingIndicator yxt-SearchBar-LoadingIndicator js-yxt-SearchBar-Icon 
-      yxt-SearchBar-Icon--inactive Icon--lg">
+      yxt-SearchBar-Icon--inactive">
       <svg class= "yxt-SearchBar-LoadingIndicator-AnimatedIcon" viewBox="0 0 72 72">
         <circle class="yxt-SearchBar-LoadingIndicator-Circle" cx="36" cy="36" r="33" stroke="black" stroke-width="3" fill="none"/>
       </svg>
@@ -26,7 +26,7 @@
     {{#unless autoFocus}} yxt-SearchBar-Icon--inactive{{/unless}}">
     {{> icons/builtInIcon
       iconName='yext_animated_forward'
-      classNames='yxt-SearchBar-MagnifyingGlass--static Icon--lg'
+      classNames='yxt-SearchBar-MagnifyingGlass--static'
       complexContentsParams=forwardIconOpts.complexContentsParams
     }}
   </div>
@@ -34,7 +34,7 @@
     {{#if autoFocus}} yxt-SearchBar-Icon--inactive{{/if}}">
     {{> icons/builtInIcon
       iconName='yext_animated_reverse'
-      classNames='yxt-SearchBar-Yext--static Icon--lg'
+      classNames='yxt-SearchBar-Yext--static'
       complexContentsParams=forwardIconOpts.complexContentsParams
     }}
   </div>

--- a/src/ui/templates/icons/voiceSearchIcon.hbs
+++ b/src/ui/templates/icons/voiceSearchIcon.hbs
@@ -1,16 +1,22 @@
-<div class="yxt-SearchBar-voiceIconWrapper Icon--lg">
+<div class="yxt-SearchBar-voiceIconWrapper">
   <div class="yxt-SearchBar-micIconWrapper {{#if customMicIconUrl}}yxt-SearchBar-CustomMicIcon{{/if}}">
     {{#if customMicIconUrl}}
       {{> icons/iconPartial iconUrl=customMicIconUrl}}
     {{else}}
-      {{> icons/builtInIcon iconName='voice_search_mic'}}
+      {{> icons/builtInIcon 
+        classNames='yxt-SearchBar-AnimatedIcon'
+        iconName='voice_search_mic'
+      }}
     {{/if}}
   </div>
   <div class="yxt-SearchBar-listeningIconWrapper {{#if customListeningIconUrl}}yxt-SearchBar-CustomListeningIcon{{/if}}">
     {{#if customListeningIconUrl}}
       {{> icons/iconPartial iconUrl=customListeningIconUrl}}
     {{else}}
-      {{> icons/builtInIcon iconName='voice_search_dots'}}
+      {{> icons/builtInIcon
+        classNames='yxt-SearchBar-AnimatedIcon'
+        iconName='voice_search_dots'
+      }}
     {{/if}}
   </div>
   <span class="yxt-SearchBar-voiceSearchText sr-only"></span>


### PR DESCRIPTION
- searchbar icon reduce from 2em to 1.5em
- update other searchbar icons to use searchbar styling instead of default _Icon.scss. moved the scss module for Icon above searchbar scss module since it make sense that specific component's styling should have precedent over the generic icon styling, like in this case with searchbar

J=SLAP-1697
TEST=manual

serve page from SDK with magnifying_glass submitIcon. launch test site from theme with a custom submitIcon. See that both pages have smaller icon size from before