### PR TITLE
Update core config

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -136,8 +136,8 @@ export default class Core {
    */
   init (config) {
     const params = {
-      token: this._token,
-      apiKey: this._apiKey,
+      ...(this._token && { token: this._token }),
+      ...(this._apiKey && { apiKey: this._apiKey }),
       experienceKey: this._experienceKey,
       locale: this._locale,
       experienceVersion: this._experienceVersion,


### PR DESCRIPTION
- only pass a token or apiKey field if it is defined

TEST=manual

see error without it, see local page work after the change