### PR TITLE
Github Action for Version Update

### DIFF
--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -20,9 +20,13 @@ jobs:
           BRANCH_NAME="${GITHUB_REF#refs/heads/}"
           PACKAGE_VERSION="${GITHUB_REF##*/}"
           echo ::set-output name=branch::${BRANCH_NAME}
-          echo ::set-output name=version::${PACKAGE_VERSION}
-          if [[ $PACKAGE_VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          if [[ $PACKAGE_VERSION =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)*$ ]]
           then
+            if [[ $PACKAGE_VERSION =~ ^v[0-9]+\.[0-9]+$ ]]
+            then
+              PACKAGE_VERSION="${PACKAGE_VERSION}.0"
+            fi
+            echo ::set-output name=version::${PACKAGE_VERSION}
             git config user.name 'github-actions[bot]'
             git config user.email 'github-actions[bot]@users.noreply.github.com'
             npm version ${PACKAGE_VERSION}
@@ -36,5 +40,5 @@ jobs:
           source_branch: "dev/update-version-${{ steps.vars.outputs.version }}"
           destination_branch: "${{ steps.vars.outputs.branch }}"
           pr_title: "Update Package Version to ${{ steps.vars.outputs.version }}"
-          pr_body: "*An automated PR*"
+          pr_body: "*An automated PR which updates package version*"
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -20,7 +20,7 @@ jobs:
           BRANCH_NAME="${GITHUB_REF#refs/heads/}"
           PACKAGE_VERSION="${GITHUB_REF##*/}"
           echo ::set-output name=branch::${BRANCH_NAME}
-          if [[ $PACKAGE_VERSION =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)*$ ]]
+          if [[ $PACKAGE_VERSION =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]
           then
             if [[ $PACKAGE_VERSION =~ ^v[0-9]+\.[0-9]+$ ]]
             then

--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -40,5 +40,5 @@ jobs:
           source_branch: "dev/update-version-${{ steps.vars.outputs.version }}"
           destination_branch: "${{ steps.vars.outputs.branch }}"
           pr_title: "Update Package Version to ${{ steps.vars.outputs.version }}"
-          pr_body: "*An automated PR which updates package version*"
+          pr_body: "*An automated PR which updates the version number in package.json and package-lock.json files*"
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -1,0 +1,40 @@
+name: Update package version for release & hotfix branches
+
+on:
+  create:
+    branches: [release/*, hotfix/*]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - name: update package version
+        id: vars
+        run: |
+          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          PACKAGE_VERSION="${GITHUB_REF##*/}"
+          echo ::set-output name=branch::${BRANCH_NAME}
+          echo ::set-output name=version::${PACKAGE_VERSION}
+          if [[ $PACKAGE_VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          then
+            git config user.name 'github-actions[bot]'
+            git config user.email 'github-actions[bot]@users.noreply.github.com'
+            npm version ${PACKAGE_VERSION}
+            git push -u origin HEAD:"dev/update-version-${PACKAGE_VERSION}"
+          else
+            echo "Branch name ${BRANCH_NAME} does not have the correct format with package version."
+            exit 1
+          fi
+      - uses: repo-sync/pull-request@v2
+        with:
+          source_branch: "dev/update-version-${{ steps.vars.outputs.version }}"
+          destination_branch: "${{ steps.vars.outputs.branch }}"
+          pr_title: "Update Package Version to ${{ steps.vars.outputs.version }}"
+          pr_body: "*An automated PR*"
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- add a github action that creates a new branch from the triggered branch, add a package version update commit, and create a pr to the triggered branch. This occurs for release and hotfix branches on create.
  - if a patch number is missing (release/v1.1), github action still accepts it, add a '.0' to the end of version when commit 

J=SLAP-1356
TEST=manual

- Tested with a fake hotfix branch and see that the [github action ran](https://github.com/yext/answers-search-ui/actions/runs/1500499038) and an [automated PR is created](https://github.com/yext/answers-search-ui/pull/1619).
- Since this branch is a dev branch, see that the [github action failed](https://github.com/yext/answers-search-ui/actions/runs/1500518469) and no pr is created for it.
- Tested with release branch in a dummy repo, which successfully creates a pr. 
- Tested with a release branch in a dummy repo with incorrect format (release/some-feature), and no pr is created.
- Tested with a release branch in a dummy repo with missing patch number, see that pr is created with .0 appended.