### PR TITLE
Fix useragent acceptance test

### DIFF
--- a/.circleci/testcafe.json
+++ b/.circleci/testcafe.json
@@ -1,5 +1,6 @@
 {
   "src": ["tests/acceptance/acceptancesuites/*.js", "!tests/acceptance/acceptancesuites/searchbaronlysuite.js"],
   "appCommand": "npx serve -l tcp://0.0.0.0:9999",
-  "appInitDelay": 4000
+  "appInitDelay": 4000,
+  "skipJsErrors": true
 }


### PR DESCRIPTION
Fix the failing useragent acceptance tests

The useragent acceptance tests have been failing due to the error: `undefined is not an object (evaluating 'za.objectHasOwnProperty.call(s,"writable")')`, and the callstack shows that testcafe code, not our code, is causing the issue. The error message suggests enabling "skipJsErrors` so that the test doesn't fail. The error is only thrown when ran through testcafe, which further suggests that the issue is on testcafe's side. Therefore, by setting this option we can get the test passing again.

This means that JS errors on the page won't cause the test to fail, however I think that's okay for this test since we have other acceptance tests which would fail if there were JS errors on the page.

J=none
TEST=none

Confirm that the tests now pass.