### PR TITLE
Version Update run on Push

### DIFF
--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -1,7 +1,7 @@
 name: Update package version for release & hotfix branches
 
 on:
-  create:
+  push:
     branches: [release/*, hotfix/*]
 
 permissions:
@@ -29,13 +29,21 @@ jobs:
             echo ::set-output name=version::${PACKAGE_VERSION}
             git config user.name 'github-actions[bot]'
             git config user.email 'github-actions[bot]@users.noreply.github.com'
-            npm version ${PACKAGE_VERSION}
+            if npm version ${PACKAGE_VERSION} | tee >( grep -q 'npm ERR! Version not changed' )
+            then
+              echo "Package version is already in sync with branch name."
+              echo ::set-output name=should_create_pr::0
+              exit 0
+            fi
+            echo ::set-output name=should_create_pr::1
             git push -u origin HEAD:"dev/update-version-${PACKAGE_VERSION}"
           else
             echo "Branch name ${BRANCH_NAME} does not have the correct format with package version."
             exit 1
           fi
-      - uses: repo-sync/pull-request@v2
+      - name: create version update pr
+        if: steps.vars.outputs.should_create_pr == 1
+        uses: repo-sync/pull-request@v2
         with:
           source_branch: "dev/update-version-${{ steps.vars.outputs.version }}"
           destination_branch: "${{ steps.vars.outputs.branch }}"


### PR DESCRIPTION
- The create event does not support branch filter and tag filter so this would run on any branch creation. Update to trigger on push from release or hotfix branch. Then check if version is updated before making a new branch for pr

J=none
TEST=manual

test in dummy repo, see version update on hotfix/release branch, but not in dev branches