### PR TITLE
update pin label to ensure correct ordering with card ordinal

### DIFF
--- a/src/core/models/section.js
+++ b/src/core/models/section.js
@@ -25,8 +25,8 @@ export default class Section {
 
     let centerCoordinates = {};
 
-    for (let j = 0; j < results.length; j++) {
-      const result = results[j]._raw;
+    for (let resultIndex = 0; resultIndex < results.length; resultIndex++) {
+      const result = results[resultIndex]._raw;
       if (result && result.yextDisplayCoordinate) {
         if (!centerCoordinates.latitude) {
           centerCoordinates = {
@@ -36,7 +36,7 @@ export default class Section {
         }
         mapMarkers.push({
           item: result,
-          label: j + 1,
+          label: resultIndex + 1,
           latitude: result.yextDisplayCoordinate.latitude,
           longitude: result.yextDisplayCoordinate.longitude
         });

--- a/src/core/models/section.js
+++ b/src/core/models/section.js
@@ -36,7 +36,7 @@ export default class Section {
         }
         mapMarkers.push({
           item: result,
-          label: mapMarkers.length + 1,
+          label: j + 1,
           latitude: result.yextDisplayCoordinate.latitude,
           longitude: result.yextDisplayCoordinate.longitude
         });


### PR DESCRIPTION
Since we plan on having locator support for job entity in Theme/SDK, there may be cards constructed from entities without location field (e.g. without map markers). As such, the pin numbers may not correspond to the right card's ordinal number. This pr updates the pin's label based on the result's index instead of the mapMarker array's length

J=SLAP-1768
TEST=manual

Use local SDK changes in theme's test site with job entities in `location` (Mapbox provider) and `location_google` (Google provider) and see that the pins now correctly map to the right cards