### PR TITLE
Update map controls

### DIFF
--- a/src/core/utils/i18nutils.js
+++ b/src/core/utils/i18nutils.js
@@ -52,6 +52,19 @@ export function parseLocale (localeCode) {
 }
 
 /**
+ * Checks if the specified language is RTL.
+ *
+ * @param {string} language
+ * @returns Whether or not the given language is written from right to left (requires rtl css)
+ */
+export function isRTL (language) {
+  if (language === 'ar') {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Object containing imperial units
  */
 const IMPERIAL = {

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -128,8 +128,8 @@ export default class GoogleMapProvider extends MapProvider {
       const container = DOM.query(el);
 
       const zoomControlPosition = isRTL(this._language)
-        ? google.maps.ControlPosition.LEFT_BOTTOM
-        : google.maps.ControlPosition.RIGHT_BOTTOM;
+        ? google.maps.ControlPosition.LEFT_TOP
+        : google.maps.ControlPosition.RIGHT_TOP;
 
       this.map = new google.maps.Map(container, {
         zoom: this._zoom,

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -2,7 +2,7 @@
 
 import MapProvider from './mapprovider';
 import DOM from '../../../dom/dom';
-import { parseLocale } from '../../../../core/utils/i18nutils';
+import { parseLocale, isRTL } from '../../../../core/utils/i18nutils';
 
 /* global google */
 
@@ -126,9 +126,22 @@ export default class GoogleMapProvider extends MapProvider {
     // Only here for demo purposes, so we'll fix later.
     setTimeout(() => {
       const container = DOM.query(el);
+
+      const zoomControlPosition = isRTL(this._language)
+        ? google.maps.ControlPosition.LEFT_BOTTOM
+        : google.maps.ControlPosition.RIGHT_BOTTOM;
+
       this.map = new google.maps.Map(container, {
         zoom: this._zoom,
         center: this.getCenterMarker(mapData),
+        fullscreenControl: false,
+        mapTypeControl: false,
+        rotateControl: false,
+        scaleControl: false,
+        streetViewControl: false,
+        zoomControlOptions: {
+          position: zoomControlPosition
+        },
         ...this._providerOptions
       });
 

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -4,7 +4,7 @@ import MapboxLanguage from '@mapbox/mapbox-gl-language';
 
 import MapProvider from './mapprovider';
 import DOM from '../../../dom/dom';
-import { parseLocale } from '../../../../core/utils/i18nutils';
+import { parseLocale, isRTL } from '../../../../core/utils/i18nutils';
 
 /* global mapboxgl */
 
@@ -81,6 +81,11 @@ export default class MapBoxMapProvider extends MapProvider {
     this._map.addControl(new MapboxLanguage({
       defaultLanguage: this._language
     }));
+
+    const zoomControl = new mapboxgl.NavigationControl({ showCompass: false });
+    isRTL(this._language)
+      ? this._map.addControl(zoomControl, 'bottom-left')
+      : this._map.addControl(zoomControl, 'bottom-right');
 
     if (mapData && mapData.mapMarkers.length) {
       const collapsedMarkers = this._collapsePins

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -84,8 +84,8 @@ export default class MapBoxMapProvider extends MapProvider {
 
     const zoomControl = new mapboxgl.NavigationControl({ showCompass: false });
     isRTL(this._language)
-      ? this._map.addControl(zoomControl, 'bottom-left')
-      : this._map.addControl(zoomControl, 'bottom-right');
+      ? this._map.addControl(zoomControl, 'top-left')
+      : this._map.addControl(zoomControl);
 
     if (mapData && mapData.mapMarkers.length) {
       const collapsedMarkers = this._collapsePins


### PR DESCRIPTION
Add zoom control buttons to MapBox maps. Remove controls except for zoom control buttons from Google map to match the Theme map. These can be added back if specified in the config. Switch the zoom buttons position for RTL, as in the theme.

J=SLAP-1765
TEST=manual

Check that only zoom buttons now appear on all maps and switch position for RTL pages.