### PR TITLE
Fix loading indicator in safari and ie11

### DIFF
--- a/src/ui/sass/modules/_SearchBar.scss
+++ b/src/ui/sass/modules/_SearchBar.scss
@@ -213,13 +213,21 @@ $searchbar-button-text-color-active: var(--yxt-searchbar-button-text-color-base)
   &-LoadingIndicator-AnimatedIcon 
   {
     stroke-dasharray: 208;
+    /* IE11 specific styling */  
+    _:-ms-fullscreen, :root & { 
+      /**
+       * IE11 does not support stroke-* properties in animation, so use smaller stroke
+       * length to simulate a fixed gap instead of using stroke-dashoffset in animation.
+       */
+      stroke-dasharray: 150;
+   }
     transform-origin: 50% 50%;
     animation: dash 1.4s ease-in-out infinite;
   }
 
   &-Icon--inactive &-LoadingIndicator-AnimatedIcon 
   {
-    display: none;
+    animation: none;
   }
   
   @keyframes dash 


### PR DESCRIPTION
- animation in the loading indicator's svg tag fail to restart in safari after display is set to none. Since the display was used to stop the animation, and doesn't affect what is display, changing it to `animation: none;` fixed it.
- EI11 does not support `stroke-dashoffset` property in css animation.  Added a workaround for ie11 by setting a smaller length for the loading circle's stroke to simulate a fixed gap on rotation instead of a dynamic shrink/expand animation with `stroke-dashoffset`

J=SLAP-1755
TEST=manual

load page and perform search in EI11, safari, chrome, and firefox. See that loading indicator behave as expected.