### PR TITLE
close autocomplete when click outside of iframe

### DIFF
--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -245,7 +245,7 @@ export default class AutoCompleteComponent extends Component {
       }
       this.close();
     });
-    if (document !== window.parent.document) {
+    if (window.parent?.document && document !== window.parent.document) {
       window.parent.document.addEventListener('click', () => {
         this.close();
       });

--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -245,6 +245,11 @@ export default class AutoCompleteComponent extends Component {
       }
       this.close();
     });
+    if (document !== window.parent.document) {
+      window.parent.document.addEventListener('click', () => {
+        this.close();
+      });
+    }
 
     // When a user focuses the input, we should populate the autocomplete based
     // on the current value


### PR DESCRIPTION

add an additional click event listener for parent window to close autocomplete when click outside of iframe page

J=SLAP-1182
TEST=manual

use local SDK with theme test-site. In iframe_test page and normal pages, see autocomplete closes as expected when click outside of the autocomplete container, inside and outside of iframe.