### PR TITLE
Add GitHub Action deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,39 +215,39 @@ jobs:
           cache-control: 'max-age=43200'
 workflows:
   version: 2
-  build_and_deploy:
-    jobs:
-      - build:
-          filters:
-            branches:
-              ignore:
-                - develop
-                - master
-                - /^support\/.*/
-                - /^hotfix\/.*/
-                - /^feature\/.*-i18n/
-                - /^release\/.*/
-      - unit_test:
-          requires:
-            - build
-      - headless_acceptance_test:
-          requires:
-            - build
-      - browserstack_acceptance_test:
-          requires:
-            - build
-      - useragent_acceptance_test:
-          requires:
-            - build
-      - translation_test:
-          requires:
-            - build
-      - deploy_branch:
-          requires:
-            - unit_test
-            - browserstack_acceptance_test
-            - useragent_acceptance_test
-            - headless_acceptance_test
+  # build_and_deploy:
+  #   jobs:
+  #     - build:
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - develop
+  #               - master
+  #               - /^support\/.*/
+  #               - /^hotfix\/.*/
+  #               - /^feature\/.*-i18n/
+  #               - /^release\/.*/
+  #     - unit_test:
+  #         requires:
+  #           - build
+  #     - headless_acceptance_test:
+  #         requires:
+  #           - build
+  #     - browserstack_acceptance_test:
+  #         requires:
+  #           - build
+  #     - useragent_acceptance_test:
+  #         requires:
+  #           - build
+  #     - translation_test:
+  #         requires:
+  #           - build
+  #     - deploy_branch:
+  #         requires:
+  #           - unit_test
+  #           - browserstack_acceptance_test
+  #           - useragent_acceptance_test
+  #           - headless_acceptance_test
   build_and_deploy_i18n:
     jobs:
       - build_i18n:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
       - image: circleci/node:14.5
     working_directory: ~/answers
     steps:
-      # - setup-workspace
+      - setup-workspace
       - run:
           name: Echo AWS Region
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,11 +51,11 @@ jobs:
       - image: circleci/node:14.5
     working_directory: ~/answers
     steps:
-      - setup-workspace
+      # - setup-workspace
       - run:
           name: Echo AWS Region
           command: |
-            echo $AWS_REGION > dist/env_var.txt
+            mkdir dist && touch dist/env_var.txt && echo $AWS_REGION > dist/env_var.txt
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,10 @@ jobs:
     working_directory: ~/answers
     steps:
       - setup-workspace
-      - run: npm run build
+      - run:
+          name: Echo AWS Region
+          command: |
+            echo $AWS_REGION
       - persist_to_workspace:
           root: .
           paths:
@@ -215,18 +218,18 @@ jobs:
           cache-control: 'max-age=43200'
 workflows:
   version: 2
-  # build_and_deploy:
-  #   jobs:
-  #     - build:
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - develop
-  #               - master
-  #               - /^support\/.*/
-  #               - /^hotfix\/.*/
-  #               - /^feature\/.*-i18n/
-  #               - /^release\/.*/
+  build_and_deploy:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore:
+                - develop
+                - master
+                - /^support\/.*/
+                - /^hotfix\/.*/
+                - /^feature\/.*-i18n/
+                - /^release\/.*/
   #     - unit_test:
   #         requires:
   #           - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - run:
           name: Echo AWS Region
           command: |
-            echo $AWS_REGION
+            echo $AWS_REGION > env_var.txt && cat env_var.txt
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - run:
           name: Echo AWS Region
           command: |
-            echo $AWS_REGION > env_var.txt && cat env_var.txt
+            echo $AWS_REGION > dist/env_var.txt
       - persist_to_workspace:
           root: .
           paths:
@@ -230,27 +230,27 @@ workflows:
                 - /^hotfix\/.*/
                 - /^feature\/.*-i18n/
                 - /^release\/.*/
-  #     - unit_test:
-  #         requires:
-  #           - build
-  #     - headless_acceptance_test:
-  #         requires:
-  #           - build
-  #     - browserstack_acceptance_test:
-  #         requires:
-  #           - build
-  #     - useragent_acceptance_test:
-  #         requires:
-  #           - build
-  #     - translation_test:
-  #         requires:
-  #           - build
-  #     - deploy_branch:
-  #         requires:
-  #           - unit_test
-  #           - browserstack_acceptance_test
-  #           - useragent_acceptance_test
-  #           - headless_acceptance_test
+      - unit_test:
+          requires:
+            - build
+      - headless_acceptance_test:
+          requires:
+            - build
+      - browserstack_acceptance_test:
+          requires:
+            - build
+      - useragent_acceptance_test:
+          requires:
+            - build
+      - translation_test:
+          requires:
+            - build
+      - deploy_branch:
+          requires:
+            - build
+            # - browserstack_acceptance_test
+            # - useragent_acceptance_test
+            # - headless_acceptance_test
   build_and_deploy_i18n:
     jobs:
       - build_i18n:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,10 +52,7 @@ jobs:
     working_directory: ~/answers
     steps:
       - setup-workspace
-      - run:
-          name: Echo AWS Region
-          command: |
-            mkdir dist && touch dist/env_var.txt && echo $AWS_REGION > dist/env_var.txt
+      - run: npm run build
       - persist_to_workspace:
           root: .
           paths:
@@ -218,39 +215,39 @@ jobs:
           cache-control: 'max-age=43200'
 workflows:
   version: 2
-  build_and_deploy:
-    jobs:
-      - build:
-          filters:
-            branches:
-              ignore:
-                - develop
-                - master
-                - /^support\/.*/
-                - /^hotfix\/.*/
-                - /^feature\/.*-i18n/
-                - /^release\/.*/
-      - unit_test:
-          requires:
-            - build
-      - headless_acceptance_test:
-          requires:
-            - build
-      - browserstack_acceptance_test:
-          requires:
-            - build
-      - useragent_acceptance_test:
-          requires:
-            - build
-      - translation_test:
-          requires:
-            - build
-      - deploy_branch:
-          requires:
-            - build
-            # - browserstack_acceptance_test
-            # - useragent_acceptance_test
-            # - headless_acceptance_test
+  # build_and_deploy:
+  #   jobs:
+  #     - build:
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - develop
+  #               - master
+  #               - /^support\/.*/
+  #               - /^hotfix\/.*/
+  #               - /^feature\/.*-i18n/
+  #               - /^release\/.*/
+  #     - unit_test:
+  #         requires:
+  #           - build
+  #     - headless_acceptance_test:
+  #         requires:
+  #           - build
+  #     - browserstack_acceptance_test:
+  #         requires:
+  #           - build
+  #     - useragent_acceptance_test:
+  #         requires:
+  #           - build
+  #     - translation_test:
+  #         requires:
+  #           - build
+  #     - deploy_branch:
+  #         requires:
+  #           - unit_test
+  #           - browserstack_acceptance_test
+  #           - useragent_acceptance_test
+  #           - headless_acceptance_test
   build_and_deploy_i18n:
     jobs:
       - build_i18n:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -18,31 +18,24 @@ jobs:
     uses: yext/answers-search-ui/.github/workflows/unit_test.yml@feature/gh-action-migration
     needs: call_build
 
-  format_branch_name:
+  call_deploy:
     runs-on: ubuntu-latest
+    #needs: call_unit_test
     steps:
       - name: Format branch name # replace '/' with '-'
         id: vars
         run: |
           FORMATTED_BRANCH="$(echo ${GITHUB_REF_NAME} | sed "s/\//-/g")" 
-          echo $FORMATTED_BRANCH
           echo ::set-output name=formatted_branch::${FORMATTED_BRANCH}
-  print_formatted_branch_name:
-    runs-on: ubuntu-latest
-    needs: format_branch_name
-    steps:
       - name: Print formatted branch name
         run: |
           echo "${{ steps.vars.outputs.formatted_branch }}"
-
-  # call_deploy:
-  #   uses: yext/answers-search-ui/.github/workflows/deploy.yml@dev/gh-s3-deploy
-  #   needs: call_unit_test
-  #   with:
-  #     directory: ${{ github.ref_name }}
-  #   secrets:
-  #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      # - uses: yext/answers-search-ui/.github/workflows/deploy.yml@dev/gh-s3-deploy
+      #   with:
+      #     directory: ${{ github.ref_name }}
+      #   secrets:
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 concurrency:
   group: ci-build-and-deploy-${{ github.ref }}-1

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -18,9 +18,10 @@ jobs:
     uses: yext/answers-search-ui/.github/workflows/unit_test.yml@feature/gh-action-migration
     needs: call_build
 
-  call_deploy:
+  format_branch_name:
     runs-on: ubuntu-latest
-    needs: call_unit_test
+    outputs:
+      formatted_branch: ${{ steps.vars.outputs.formatted_branch }}
     steps:
       - name: Format branch name # replace '/' with '-'
         id: vars
@@ -28,9 +29,14 @@ jobs:
           FORMATTED_BRANCH="$(echo ${GITHUB_REF_NAME} | sed "s/\//-/g")" 
           echo $FORMATTED_BRANCH
           echo ::set-output name=formatted_branch::${FORMATTED_BRANCH}
+
+  call_deploy:
+    needs: 
+      - call_unit_test
+      - format_branch_name
     uses: yext/answers-search-ui/.github/workflows/deploy.yml@dev/gh-s3-deploy
     with:
-      directory: dev/test-test/${{ steps.vars.outputs.formatted_branch }}
+      directory: dev/test-test/${{ needs.format_branch_name.outputs.formatted_branch }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -29,6 +29,7 @@ jobs:
           echo ::set-output name=formatted_branch::${FORMATTED_BRANCH}
   print_formatted_branch_name:
     runs-on: ubuntu-latest
+    needs: format_branch_name
     steps:
       - name: Print formatted branch name
         run: |

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -36,7 +36,7 @@ jobs:
       - format_branch_name
     uses: yext/answers-search-ui/.github/workflows/deploy.yml@dev/gh-s3-deploy
     with:
-      directory: dev/test-test/${{ needs.format_branch_name.outputs.formatted_branch }}
+      directory: dev/${{ needs.format_branch_name.outputs.formatted_branch }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -27,6 +27,12 @@ jobs:
           FORMATTED_BRANCH="$(echo ${GITHUB_REF_NAME} | sed "s/\//-/g")" 
           echo $FORMATTED_BRANCH
           echo ::set-output name=formatted_branch::${FORMATTED_BRANCH}
+  print_formatted_branch_name:
+    runs_on: ubuntu-latest
+    steps:
+      - name: Print formatted branch name
+        run: |
+          echo "${{ steps.vars.outputs.formatted_branch }}"
 
   # call_deploy:
   #   uses: yext/answers-search-ui/.github/workflows/deploy.yml@dev/gh-s3-deploy

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -17,16 +17,25 @@ jobs:
   call_unit_test:
     uses: yext/answers-search-ui/.github/workflows/unit_test.yml@feature/gh-action-migration
     needs: call_build
-  
-  call_deploy:
-    uses: yext/answers-search-ui/.github/workflows/deploy.yml@dev/gh-s3-deploy
-    needs: call_unit_test
-    with:
-      directory: dev/gh-s3-deploy
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+  format_branch_name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Format branch name # replace '/' with '-'
+        id: vars
+        run: |
+          FORMATTED_BRANCH="$(echo ${GITHUB_REF_NAME} | sed "s/\//-/g")" 
+          echo $FORMATTED_BRANCH
+          echo ::set-output name=formatted_branch::${FORMATTED_BRANCH}
+
+  # call_deploy:
+  #   uses: yext/answers-search-ui/.github/workflows/deploy.yml@dev/gh-s3-deploy
+  #   needs: call_unit_test
+  #   with:
+  #     directory: ${{ github.ref_name }}
+  #   secrets:
+  #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 concurrency:
   group: ci-build-and-deploy-${{ github.ref }}-1

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -28,7 +28,7 @@ jobs:
           echo $FORMATTED_BRANCH
           echo ::set-output name=formatted_branch::${FORMATTED_BRANCH}
   print_formatted_branch_name:
-    runs_on: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Print formatted branch name
         run: |

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -29,11 +29,11 @@ jobs:
           echo $FORMATTED_BRANCH
           echo ::set-output name=formatted_branch::${FORMATTED_BRANCH}
     uses: yext/answers-search-ui/.github/workflows/deploy.yml@dev/gh-s3-deploy
-      with:
-        directory: dev/test-test/${{ steps.vars.outputs.formatted_branch }}
-      secrets:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    with:
+      directory: dev/test-test/${{ steps.vars.outputs.formatted_branch }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 concurrency:
   group: ci-build-and-deploy-${{ github.ref }}-1

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -12,10 +12,10 @@ on:
 
 jobs:
   call_build:
-    uses: .github/workflows/build.yml
+    uses: ./.github/workflows/build.yml
 
   call_unit_test:
-    uses: .github/workflows/unit_test.yml
+    uses: ./.github/workflows/unit_test.yml
     needs: call_build
 
   format_branch_name:
@@ -34,7 +34,7 @@ jobs:
     needs: 
       - call_unit_test
       - format_branch_name
-    uses: .github/workflows/deploy.yml
+    uses: ./.github/workflows/deploy.yml
     with:
       directory: dev/${{ needs.format_branch_name.outputs.formatted_branch }}
     secrets:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -12,11 +12,17 @@ on:
 
 jobs:
   call_build:
-    uses: yext/answers-search-ui/.github/workflows/build.yml@dev/build-workflow
+    uses: yext/answers-search-ui/.github/workflows/build.yml@feature/gh-action-migration
 
   call_unit_test:
-    uses: yext/answers-search-ui/.github/workflows/unit_test.yml@dev/build-workflow
+    uses: yext/answers-search-ui/.github/workflows/unit_test.yml@feature/gh-action-migration
     needs: call_build
+  
+  call_deploy:
+    uses: yext/answers-search-ui/.github/workflows/deploy.yml@dev/gh-s3-deploy
+    needs: call_unit_test
+    with:
+      directory: dev/gh-s3-deploy
 
 concurrency:
   group: ci-build-and-deploy-${{ github.ref }}-1

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -23,6 +23,10 @@ jobs:
     needs: call_unit_test
     with:
       directory: dev/gh-s3-deploy
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
 
 concurrency:
   group: ci-build-and-deploy-${{ github.ref }}-1

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -12,10 +12,10 @@ on:
 
 jobs:
   call_build:
-    uses: yext/answers-search-ui/.github/workflows/build.yml@feature/gh-action-migration
+    uses: .github/workflows/build.yml
 
   call_unit_test:
-    uses: yext/answers-search-ui/.github/workflows/unit_test.yml@feature/gh-action-migration
+    uses: .github/workflows/unit_test.yml
     needs: call_build
 
   format_branch_name:
@@ -34,7 +34,7 @@ jobs:
     needs: 
       - call_unit_test
       - format_branch_name
-    uses: yext/answers-search-ui/.github/workflows/deploy.yml@dev/gh-s3-deploy
+    uses: .github/workflows/deploy.yml
     with:
       directory: dev/${{ needs.format_branch_name.outputs.formatted_branch }}
     secrets:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -20,22 +20,20 @@ jobs:
 
   call_deploy:
     runs-on: ubuntu-latest
-    #needs: call_unit_test
+    needs: call_unit_test
     steps:
       - name: Format branch name # replace '/' with '-'
         id: vars
         run: |
           FORMATTED_BRANCH="$(echo ${GITHUB_REF_NAME} | sed "s/\//-/g")" 
+          echo $FORMATTED_BRANCH
           echo ::set-output name=formatted_branch::${FORMATTED_BRANCH}
-      - name: Print formatted branch name
-        run: |
-          echo "${{ steps.vars.outputs.formatted_branch }}"
-      # - uses: yext/answers-search-ui/.github/workflows/deploy.yml@dev/gh-s3-deploy
-      #   with:
-      #     directory: ${{ github.ref_name }}
-      #   secrets:
-      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - uses: yext/answers-search-ui/.github/workflows/deploy.yml@dev/gh-s3-deploy
+        with:
+          directory: dev/test-test/${{ steps.vars.outputs.formatted_branch }}
+        secrets:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 concurrency:
   group: ci-build-and-deploy-${{ github.ref }}-1

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -28,12 +28,12 @@ jobs:
           FORMATTED_BRANCH="$(echo ${GITHUB_REF_NAME} | sed "s/\//-/g")" 
           echo $FORMATTED_BRANCH
           echo ::set-output name=formatted_branch::${FORMATTED_BRANCH}
-      - uses: yext/answers-search-ui/.github/workflows/deploy.yml@dev/gh-s3-deploy
-        with:
-          directory: dev/test-test/${{ steps.vars.outputs.formatted_branch }}
-        secrets:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    uses: yext/answers-search-ui/.github/workflows/deploy.yml@dev/gh-s3-deploy
+      with:
+        directory: dev/test-test/${{ steps.vars.outputs.formatted_branch }}
+      secrets:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 concurrency:
   group: ci-build-and-deploy-${{ github.ref }}-1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v2
       - name: Download build-output artifact
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy assets to AWS S3
+
+on:
+  workflow_call:
+    inputs:
+      bucket:
+        required: false
+        type: string
+        default: answers
+      directory:
+        required: true
+        type: string
+      cache-control:
+        required: false
+        type: string
+        default: no-cache
+
+jobs:
+  unit_tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download build-output artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: build-output
+          path: dist/
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Deploy to S3
+        run: aws s3 sync ./dist/ s3://assets.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }} \
+          --acl public-read \
+          --cache-control ${{ inputs.cache-control }} \
+          --profile production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ on:
         default: no-cache
 
 jobs:
-  unit_tests:
+  deploy:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,8 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Deploy to S3
-        run: aws s3 sync ./dist/ s3://assets.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }} \
+        run: |
+          aws s3 sync ./dist/ s3://assets.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }} \
           --acl public-read \
           --cache-control ${{ inputs.cache-control }} \
           --profile production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,7 @@ jobs:
           aws-region: us-east-1
       - name: Deploy to S3
         run: |
-          aws s3 sync ./dist/ s3://assets.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }} \
+          aws s3 cp ./dist/ s3://assets.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }} \
           --acl public-read \
+          --recursive \
           --cache-control ${{ inputs.cache-control }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: string
         default: no-cache
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,5 +41,4 @@ jobs:
         run: |
           aws s3 sync ./dist/ s3://assets.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }} \
           --acl public-read \
-          --cache-control ${{ inputs.cache-control }} \
-          --profile production
+          --cache-control ${{ inputs.cache-control }}


### PR DESCRIPTION
Add GitHub Action deployment

Add a deploy.yml file and connect it to the build_and_deploy workflow. Comment out the corresponding build_and_deploy from CircleCI. When the migration is complete, we can delete the commented out portions from the CircleCI config. I added the AWS credentials to the repo's secrets. I also set up branch name formatting where any '/' is replaced with '-' in order to match the CircleCI behavior.

J=SLAP-1816
TEST=manual

Observe the build and deploy in the Github Actions panel. Point the theme test site to the assets and see the page work correctly.


