### PR TITLE
add call_misc_tests GH workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
           name: Verify translation files
           command: |
             sudo apt-get install -qq gettext
-            ./.circleci/run_translation_verification.sh
+            ./.github/run_translation_verification.sh
   # deploys assets to an uncached folder in the S3 bucket named by branch
   deploy_branch:
     docker:

--- a/.github/run_translation_verification.sh
+++ b/.github/run_translation_verification.sh
@@ -24,7 +24,8 @@ if [[ $GITHUB_REF_NAME == release/*
   || $GITHUB_REF_NAME == support/* ]]
 then
   for po_file in *.po
-    do msgcmp $po_file messages.pot
+  do
+    msgcmp $po_file messages.pot
     exit_code=$(( exit_code + $? ))
   done
 else

--- a/.github/run_translation_verification.sh
+++ b/.github/run_translation_verification.sh
@@ -25,8 +25,7 @@ if [[ $GITHUB_REF_NAME == release/*
 then
   for po_file in *.po
   do
-    msgcmp $po_file messages.pot
-    exit_code=$(( exit_code + $? ))
+    msgcmp $po_file messages.pot || exit_code=1
   done
 else
   echo "Skipping the verification that all translations are present"

--- a/.github/run_translation_verification.sh
+++ b/.github/run_translation_verification.sh
@@ -16,6 +16,8 @@ fi
 
 # Verify that translations are present for all languages
 cd conf/i18n/translations
+
+exit_code=0
 if [[ $GITHUB_REF_NAME == release/*
   || $GITHUB_REF_NAME == hotfix/*
   || $GITHUB_REF_NAME == master
@@ -23,7 +25,10 @@ if [[ $GITHUB_REF_NAME == release/*
 then
   for po_file in *.po
     do msgcmp $po_file messages.pot
+    exit_code=$(( exit_code + $? ))
   done
 else
   echo "Skipping the verification that all translations are present"
 fi
+
+exit $exit_code

--- a/.github/run_translation_verification.sh
+++ b/.github/run_translation_verification.sh
@@ -16,10 +16,10 @@ fi
 
 # Verify that translations are present for all languages
 cd conf/i18n/translations
-if [[ $CIRCLE_BRANCH == release/*
-  || $CIRCLE_BRANCH == hotfix/*
-  || $CIRCLE_BRANCH == master
-  || $CIRCLE_BRANCH == support/* ]]
+if [[ $GITHUB_REF_NAME == release/*
+  || $GITHUB_REF_NAME == hotfix/*
+  || $GITHUB_REF_NAME == master
+  || $GITHUB_REF_NAME == support/* ]]
 then
   for po_file in *.po
     do msgcmp $po_file messages.pot

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -17,10 +17,9 @@ jobs:
   call_unit_test:
     uses: ./.github/workflows/unit_test.yml
     needs: call_build
-
-  call_misc_test:
+  
+  call_misc_tests:
     uses: ./.github/workflows/miscellaneous_tests.yml
-    needs: call_build
 
   call_acceptance:
     uses: ./.github/workflows/acceptance.yml

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -18,6 +18,10 @@ jobs:
     uses: ./.github/workflows/unit_test.yml
     needs: call_build
 
+  call_misc_test:
+    uses: ./.github/workflows/miscellaneous_tests.yml
+    needs: call_build
+
   call_acceptance:
     uses: ./.github/workflows/acceptance.yml
     needs: call_build

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -36,6 +36,7 @@ jobs:
       - call_unit_test
       - call_format_branch_name
       - call_acceptance
+      - call_misc_tests
     uses: ./.github/workflows/deploy.yml
     with:
       directory: dev/${{ needs.call_format_branch_name.outputs.formatted_branch }}

--- a/.github/workflows/build_and_deploy_i18n.yml
+++ b/.github/workflows/build_and_deploy_i18n.yml
@@ -18,6 +18,9 @@ jobs:
   call_unit_test:
     uses: ./.github/workflows/unit_test.yml
     needs: call_build
+  
+  call_misc_tests:
+    uses: ./.github/workflows/miscellaneous_tests.yml
 
   call_format_branch_name:
     uses: ./.github/workflows/format_branch_name.yml
@@ -35,6 +38,7 @@ jobs:
       - call_unit_test
       - call_format_branch_name
       - call_acceptance
+      - call_misc_tests
     uses: ./.github/workflows/deploy.yml
     with:
       directory: dev/${{ needs.call_format_branch_name.outputs.formatted_branch }}
@@ -48,6 +52,7 @@ jobs:
       - call_unit_test
       - call_format_branch_name
       - call_acceptance
+      - call_misc_tests
     uses: ./.github/workflows/deploy.yml
     with:
       directory: canary/latest
@@ -61,6 +66,7 @@ jobs:
       - call_unit_test
       - call_format_branch_name
       - call_acceptance
+      - call_misc_tests
     uses: ./.github/workflows/deploy.yml
     with:
       directory: canary/${{ github.sha }}

--- a/.github/workflows/miscellaneous_tests.yml
+++ b/.github/workflows/miscellaneous_tests.yml
@@ -1,0 +1,23 @@
+name: Run miscellaneous tests
+
+on:
+  workflow_call:
+
+jobs:
+  unit_tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: 'npm'
+      - run: npm ci
+      - name: Download build-output artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: build-output
+          path: dist/
+      - run: ./.circleci/run_translation_verification.sh

--- a/.github/workflows/miscellaneous_tests.yml
+++ b/.github/workflows/miscellaneous_tests.yml
@@ -15,4 +15,5 @@ jobs:
           node-version: 14
           cache: 'npm'
       - run: npm ci
+      - run: sudo apt-get install -qq gettext
       - run: ./.github/run_translation_verification.sh

--- a/.github/workflows/miscellaneous_tests.yml
+++ b/.github/workflows/miscellaneous_tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 jobs:
-  unit_tests:
+  translation_test:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/miscellaneous_tests.yml
+++ b/.github/workflows/miscellaneous_tests.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           name: build-output
           path: dist/
-      - run: ./.circleci/run_translation_verification.sh
+      - run: ./.github/run_translation_verification.sh

--- a/.github/workflows/miscellaneous_tests.yml
+++ b/.github/workflows/miscellaneous_tests.yml
@@ -15,9 +15,4 @@ jobs:
           node-version: 14
           cache: 'npm'
       - run: npm ci
-      - name: Download build-output artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: build-output
-          path: dist/
       - run: ./.github/run_translation_verification.sh

--- a/tests/acceptance/blocks/filtersearchcomponent.js
+++ b/tests/acceptance/blocks/filtersearchcomponent.js
@@ -23,6 +23,6 @@ export default class FilterSearchComponentBlock {
       .typeText(this._input, displayValue)
       .pressKey('space')
       .wait(500)
-      .click(this._selector.find('.js-yext-autocomplete-option').withText(displayValue));
+      .click(this._selector.find('.js-yext-autocomplete-option').withExactText(displayValue));
   }
 }

--- a/tests/acceptance/blocks/filtersearchcomponent.js
+++ b/tests/acceptance/blocks/filtersearchcomponent.js
@@ -23,6 +23,6 @@ export default class FilterSearchComponentBlock {
       .typeText(this._input, displayValue)
       .pressKey('space')
       .wait(500)
-      .click(this._selector.find('.js-yext-autocomplete-option').withExactText(displayValue));
+      .click(this._selector.find('.js-yext-autocomplete-option').withText(displayValue));
   }
 }


### PR DESCRIPTION
Also fixes a bug in the translation test bash script, where a non-zero exit code would only be returned
if the LAST .po file in the for loop had a msgcmp error.

J=SLAP-1815
TEST=manual,auto

tested using https://github.com/yext/answers-search-ui/pull/1659
tests run in a support branch
tests fail if any of the translations in a pot file are missing, in either the last po file or a different one
short circuits if pot file is not up to date

