### PR TITLE
allow search to occur if "near me" request fails

### DIFF
--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -579,30 +579,35 @@ export default class SearchComponent extends Component {
   promptForLocation (query) {
     if (this._promptForLocation) {
       return this.fetchQueryIntents(query)
-        .then(queryIntents => queryIntents.includes('NEAR_ME'))
-        .then(queryHasNearMeIntent => {
-          if (queryHasNearMeIntent && !this.core.storage.get(StorageKeys.GEOLOCATION)) {
-            return new Promise((resolve, reject) =>
-              navigator.geolocation.getCurrentPosition(
-                position => {
-                  this.core.storage.set(StorageKeys.GEOLOCATION, {
-                    lat: position.coords.latitude,
-                    lng: position.coords.longitude,
-                    radius: position.coords.accuracy
-                  });
-                  resolve();
-                },
-                () => {
-                  resolve();
-                  const { enabled, message } = this._geolocationTimeoutAlert;
-                  if (enabled) {
-                    alert(message);
-                  }
-                },
-                this._geolocationOptions)
-            );
-          }
-        });
+        .then(
+          queryIntents => queryIntents.includes('NEAR_ME'),
+          error => console.warn('Unable to determine user\'s location. Error occured fetching query intents.', error)
+        ).then(
+          queryHasNearMeIntent => {
+            if (queryHasNearMeIntent && !this.core.storage.get(StorageKeys.GEOLOCATION)) {
+              return new Promise((resolve, reject) =>
+                navigator.geolocation.getCurrentPosition(
+                  position => {
+                    this.core.storage.set(StorageKeys.GEOLOCATION, {
+                      lat: position.coords.latitude,
+                      lng: position.coords.longitude,
+                      radius: position.coords.accuracy
+                    });
+                    resolve();
+                  },
+                  () => {
+                    resolve();
+                    const { enabled, message } = this._geolocationTimeoutAlert;
+                    if (enabled) {
+                      alert(message);
+                    }
+                  },
+                  this._geolocationOptions)
+              );
+            }
+          },
+          error => console.warn('Unable to determine user\'s location. Error occured using geolocation API.', error)
+        );
     } else {
       return Promise.resolve();
     }

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -579,35 +579,31 @@ export default class SearchComponent extends Component {
   promptForLocation (query) {
     if (this._promptForLocation) {
       return this.fetchQueryIntents(query)
-        .then(
-          queryIntents => queryIntents.includes('NEAR_ME'),
-          error => console.warn('Unable to determine user\'s location. Error occured fetching query intents.', error)
-        ).then(
-          queryHasNearMeIntent => {
-            if (queryHasNearMeIntent && !this.core.storage.get(StorageKeys.GEOLOCATION)) {
-              return new Promise((resolve, reject) =>
-                navigator.geolocation.getCurrentPosition(
-                  position => {
-                    this.core.storage.set(StorageKeys.GEOLOCATION, {
-                      lat: position.coords.latitude,
-                      lng: position.coords.longitude,
-                      radius: position.coords.accuracy
-                    });
-                    resolve();
-                  },
-                  () => {
-                    resolve();
-                    const { enabled, message } = this._geolocationTimeoutAlert;
-                    if (enabled) {
-                      alert(message);
-                    }
-                  },
-                  this._geolocationOptions)
-              );
-            }
-          },
-          error => console.warn('Unable to determine user\'s location. Error occured using geolocation API.', error)
-        );
+        .then(queryIntents => queryIntents.includes('NEAR_ME'))
+        .then(queryHasNearMeIntent => {
+          if (queryHasNearMeIntent && !this.core.storage.get(StorageKeys.GEOLOCATION)) {
+            return new Promise((resolve, reject) =>
+              navigator.geolocation.getCurrentPosition(
+                position => {
+                  this.core.storage.set(StorageKeys.GEOLOCATION, {
+                    lat: position.coords.latitude,
+                    lng: position.coords.longitude,
+                    radius: position.coords.accuracy
+                  });
+                  resolve();
+                },
+                () => {
+                  resolve();
+                  const { enabled, message } = this._geolocationTimeoutAlert;
+                  if (enabled) {
+                    alert(message);
+                  }
+                },
+                this._geolocationOptions)
+            );
+          }
+        })
+        .catch(error => console.warn('Unable to determine user\'s location.', error));
     } else {
       return Promise.resolve();
     }

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -579,7 +579,10 @@ export default class SearchComponent extends Component {
   promptForLocation (query) {
     if (this._promptForLocation) {
       return this.fetchQueryIntents(query)
-        .then(queryIntents => queryIntents.includes('NEAR_ME'))
+        .then(
+          queryIntents => queryIntents.includes('NEAR_ME'),
+          error => Promise.reject(new Error('Failed to fetch query intents.', { cause: error }))
+        )
         .then(queryHasNearMeIntent => {
           if (queryHasNearMeIntent && !this.core.storage.get(StorageKeys.GEOLOCATION)) {
             return new Promise((resolve, reject) =>


### PR DESCRIPTION
this pr update the middleware function `promptForLocation` to gracefully handle rejected promises related to fetching near me intents or getting user location. 

If fails, a search request should still get executed. To do so, catch in the then() call chain to handle rejected promise cases and provide a console warn message. Since the handler function doesn't return anything, the promise returned by then gets resolved with an undefined value.


J=SLAP-1885
TEST=manual

return a rejected promise for `fetchQueryIntents` function to mock a failed autocomplete request to compute near me intents. See that a console warn message appear indicating the error, but the search is still executed and see that results for the query is shown on page.