### PR TITLE
Gracefully handle LiveAPI failures

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -303,6 +303,8 @@ export default class Core {
         }
         this.updateHistoryAfterSearch(queryTrigger);
         window.performance.mark('yext.answers.verticalQueryResponseRendered');
+      }).catch(error => {
+        console.error('Vertical search failed with the following error: ' + error);
       });
   }
 
@@ -389,6 +391,8 @@ export default class Core {
         }
         this.updateHistoryAfterSearch(queryTrigger);
         window.performance.mark('yext.answers.universalQueryResponseRendered');
+      }).catch(error => {
+        console.error('Universal search failed with the following error: ' + error);
       });
   }
 
@@ -436,6 +440,8 @@ export default class Core {
       .then(data => {
         this.storage.set(`${StorageKeys.AUTOCOMPLETE}.${namespace}`, data);
         return data;
+      }).catch(error => {
+        console.error('Universal autocomplete failed with the following error: ' + error);
       });
   }
 
@@ -458,6 +464,8 @@ export default class Core {
       .then(data => {
         this.storage.set(`${StorageKeys.AUTOCOMPLETE}.${namespace}`, data);
         return data;
+      }).catch(error => {
+        console.error('Vertical autocomplete failed with the following error: ' + error);
       });
   }
 
@@ -487,6 +495,8 @@ export default class Core {
       .then(response => AutoCompleteResponseTransformer.transformFilterSearchResponse(response))
       .then(data => {
         this.storage.set(`${StorageKeys.AUTOCOMPLETE}.${config.namespace}`, data);
+      }).catch(error => {
+        console.error('Filter search failed with the following error: ' + error);
       });
   }
 
@@ -510,6 +520,9 @@ export default class Core {
         this.storage.set(
           StorageKeys.QUESTION_SUBMISSION,
           QuestionSubmission.submitted());
+      }).catch(error => {
+        console.error('Question submission failed with the following error: ' + error);
+        throw error;
       });
   }
 

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -626,7 +626,7 @@ export default class SearchComponent extends Component {
           this._autoCompleteName,
           this._verticalKey)
         : this.core.autoCompleteUniversal(query, this._autoCompleteName);
-      return autocompleteRequest.then(data => data.inputIntents);
+      return autocompleteRequest.then(data => data?.inputIntents ?? []);
     } else {
       // There are two alternatives to consider here. The user could have selected the query
       // as an autocomplete option or manually input it themselves. If the former, use the intents

--- a/tests/ui/components/search/searchcomponent.js
+++ b/tests/ui/components/search/searchcomponent.js
@@ -126,6 +126,20 @@ describe('SearchBar component', () => {
     return expect(wasSearchRanPromise).resolves.toBeTruthy();
   });
 
+  it('An undefined universalAutocomplete response results in empty query intents', async () => {
+    expect.assertions(1);
+    const component = COMPONENT_MANAGER.create('SearchBar', {
+      ...defaultConfig,
+      verticalKey: null,
+      allowEmptySearch: true
+    });
+    component.core.autoCompleteUniversal = () => {
+      return Promise.resolve(undefined);
+    };
+
+    return expect(component.fetchQueryIntents()).resolves.toStrictEqual([]);
+  });
+
   it('searching with the search bar sets QUERY_TRIGGER to SEARCH_BAR', () => {
     storage.setWithPersist(StorageKeys.QUERY, 'what does yext do?');
     const component = COMPONENT_MANAGER.create('SearchBar', defaultConfig);


### PR DESCRIPTION
Update the code to prevent live api failures from causing unhandled promise rejections resulting in a broken search experience

Promise chains needs a `.catch`, or a rejected handler or else an unhandled promise rejection event will be sent to the window. Adding a catch will prevent that issue. I added the caches to our requests in core.js. Note: If someone adds a `.then` to one of our network requests, the `.then` will execute even if the rejection handler in the catch block was called. In this case, the data passed to the `.then` handler will be undefined. That is why I added null checking to the search component after checking for the near me intent.

The question submission component was built to read the live API error code so that it could display the proper error message. Because of that, I made the questionSubmission function throw the error in the catch block so that the Question submission component could read the error.

J=SLAP-1884
TEST=manual

Mock the core library's universalAutocomplete function to return a rejected promise. Use a local theme test site and point it to this SDK version. See that after this code change, the experience doesn't break and regular search queries can be fired and the results will update. Test the question submission and see that the error message shows up properly and doesn't break the experience.
