### PR TITLE
Revert "allow search to occur if "near me" request fails"

### DIFF
--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -581,10 +581,7 @@ export default class SearchComponent extends Component {
   promptForLocation (query) {
     if (this._promptForLocation) {
       return this.fetchQueryIntents(query)
-        .then(
-          queryIntents => queryIntents.includes('NEAR_ME'),
-          error => Promise.reject(new Error('Failed to fetch query intents.', { cause: error }))
-        )
+        .then(queryIntents => queryIntents.includes('NEAR_ME'))
         .then(queryHasNearMeIntent => {
           if (queryHasNearMeIntent && !this.core.storage.get(StorageKeys.GEOLOCATION)) {
             return new Promise((resolve, reject) =>
@@ -607,8 +604,7 @@ export default class SearchComponent extends Component {
                 this._geolocationOptions)
             );
           }
-        })
-        .catch(error => console.warn('Unable to determine user\'s location.', error));
+        });
     } else {
       return Promise.resolve();
     }


### PR DESCRIPTION
Reverts yext/answers-search-ui#1668

will be merge in hotfix branch 1.12.2 instead. Will be removing the first onReject handler function since this pr (https://github.com/yext/answers-search-ui/pull/1669) already handle it.