### PR TITLE
catch errors in promptLocation then chain

### DIFF
--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -579,7 +579,7 @@ export default class SearchComponent extends Component {
   promptForLocation (query) {
     if (this._promptForLocation) {
       return this.fetchQueryIntents(query)
-        .then(queryIntents => queryIntents.includes('NEAR_ME'))
+        .then(queryIntents => queryIntents?.includes('NEAR_ME'))
         .then(queryHasNearMeIntent => {
           if (queryHasNearMeIntent && !this.core.storage.get(StorageKeys.GEOLOCATION)) {
             return new Promise((resolve, reject) =>
@@ -602,7 +602,8 @@ export default class SearchComponent extends Component {
                 this._geolocationOptions)
             );
           }
-        });
+        })
+        .catch(error => console.warn('Unable to determine user\'s location.', error));
     } else {
       return Promise.resolve();
     }


### PR DESCRIPTION
this pr update the middleware function `promptForLocation` to gracefully handle rejected promises related to fetching near me intents or getting user location. 

If fails, a search request should still get executed. Added catch in the then() call chain to handle rejected promise cases and provide a console warn message. Since the handler function doesn't return anything, the promise returned by then gets resolved with an undefined value.

this pr (https://github.com/yext/answers-search-ui/pull/1669) already handle fail requests from fetchQueryIntents

J=SLAP-1885
TEST=manual

return a rejected promise in the second then() call to mock a failed request from navigation geolocation API. See that a console warn message appear indicating the error, but the search is still executed and see that results for the query is shown on page.