### PR TITLE
add FOLLOW_UP_QUERY analytics event

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -21,6 +21,7 @@ import { PRODUCTION, ENDPOINTS, LIB_VERSION } from './constants';
 import { getCachedLiveApiUrl, getLiveApiUrl } from './utils/urlutils';
 import { SearchParams } from '../ui';
 import SearchStates from './storage/searchstates';
+import Searcher from './models/searcher';
 
 /** @typedef {import('./storage/storage').default} Storage */
 
@@ -234,6 +235,12 @@ export default class Core {
     const queryTrigger = this.storage.get(StorageKeys.QUERY_TRIGGER);
     const queryTriggerForApi = this.getQueryTriggerForSearchApi(queryTrigger);
 
+    const queryId = this.storage.get(StorageKeys.QUERY_ID);
+    if (queryId) {
+      const event = new AnalyticsEvent('FOLLOW_UP_QUERY').addOptions({ searcher: Searcher.VERTICAL });
+      this._analyticsReporter.report(event);
+    }
+
     return this._coreLibrary
       .verticalSearch({
         verticalKey: verticalKey || searchConfig.verticalKey,
@@ -261,7 +268,6 @@ export default class Core {
         this._persistFacets();
         this._persistFilters();
         this._persistLocationRadius();
-
         this.storage.set(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
         this.storage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
         this.storage.set(StorageKeys.ALTERNATIVE_VERTICALS, data[StorageKeys.ALTERNATIVE_VERTICALS]);
@@ -355,6 +361,13 @@ export default class Core {
 
     const queryTrigger = this.storage.get(StorageKeys.QUERY_TRIGGER);
     const queryTriggerForApi = this.getQueryTriggerForSearchApi(queryTrigger);
+
+    const queryId = this.storage.get(StorageKeys.QUERY_ID);
+    if (queryId) {
+      const event = new AnalyticsEvent('FOLLOW_UP_QUERY').addOptions({ searcher: Searcher.UNIVERSAL });
+      this._analyticsReporter.report(event);
+    }
+
     return this._coreLibrary
       .universalSearch({
         query: queryString,

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -235,12 +235,6 @@ export default class Core {
     const queryTrigger = this.storage.get(StorageKeys.QUERY_TRIGGER);
     const queryTriggerForApi = this.getQueryTriggerForSearchApi(queryTrigger);
 
-    const queryId = this.storage.get(StorageKeys.QUERY_ID);
-    if (queryId) {
-      const event = new AnalyticsEvent('FOLLOW_UP_QUERY').addOptions({ searcher: Searcher.VERTICAL });
-      this._analyticsReporter.report(event);
-    }
-
     return this._coreLibrary
       .verticalSearch({
         verticalKey: verticalKey || searchConfig.verticalKey,
@@ -268,6 +262,12 @@ export default class Core {
         this._persistFacets();
         this._persistFilters();
         this._persistLocationRadius();
+        const previousQueryId = this.storage.get(StorageKeys.QUERY_ID);
+        const newQueryId = data[StorageKeys.QUERY_ID];
+        if (previousQueryId && previousQueryId !== newQueryId) {
+          const event = new AnalyticsEvent('FOLLOW_UP_QUERY').addOptions({ searcher: Searcher.VERTICAL });
+          this._analyticsReporter.report(event);
+        }
         this.storage.set(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
         this.storage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
         this.storage.set(StorageKeys.ALTERNATIVE_VERTICALS, data[StorageKeys.ALTERNATIVE_VERTICALS]);
@@ -362,12 +362,6 @@ export default class Core {
     const queryTrigger = this.storage.get(StorageKeys.QUERY_TRIGGER);
     const queryTriggerForApi = this.getQueryTriggerForSearchApi(queryTrigger);
 
-    const queryId = this.storage.get(StorageKeys.QUERY_ID);
-    if (queryId) {
-      const event = new AnalyticsEvent('FOLLOW_UP_QUERY').addOptions({ searcher: Searcher.UNIVERSAL });
-      this._analyticsReporter.report(event);
-    }
-
     return this._coreLibrary
       .universalSearch({
         query: queryString,
@@ -383,6 +377,13 @@ export default class Core {
       })
       .then(response => SearchDataTransformer.transformUniversal(response, urls, this._fieldFormatters))
       .then(data => {
+        const previousQueryId = this.storage.get(StorageKeys.QUERY_ID);
+        const newQueryId = data[StorageKeys.QUERY_ID];
+        if (previousQueryId && previousQueryId !== newQueryId) {
+          const event = new AnalyticsEvent('FOLLOW_UP_QUERY').addOptions({ searcher: Searcher.UNIVERSAL });
+          this._analyticsReporter.report(event);
+        }
+
         this.storage.set(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
         this.storage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
         this.storage.set(StorageKeys.DIRECT_ANSWER, data[StorageKeys.DIRECT_ANSWER]);


### PR DESCRIPTION
Update core.js' search and verticalsearch function to send a FOLLOW_UP_QUERY analytics event for subsequent searches from the initial search. The previous queryId is used in the analytics event instead.

J=SLAP-1916
TEST=manual

See that initial query did not fire a FOLLOW_UP_QUERY analytics event.
See that the second query did fire a FOLLOW_UP_QUERY analytics event containing the previous queryId and correct searcher type.
See that analytic event did fire from a new search due to a filter change (new queryId generated).
See that analytic event did not fire from a new search due to pagination (no new queryId generated)