### PR TITLE
Pin the Google Maps API version to v3.47.

### DIFF
--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -98,7 +98,7 @@ export default class GoogleMapProvider extends MapProvider {
         onLoad();
       },
       async: true,
-      src: `https://maps.googleapis.com/maps/api/js?${self.generateCredentials()}&language=${self._language}`
+      src: `https://maps.googleapis.com/maps/api/js?${self.generateCredentials()}&language=${self._language}&v=3.47`
     });
 
     DOM.append('body', script);


### PR DESCRIPTION
See this piece of documentation: https://developers.google.com/maps/documentation/javascript/browsersupport.
Version 3.47 of the Maps Javascript API will be the last version to support IE11.

TEST=manual