### PR TITLE
implement mobile/desktop visibilitychange workflow

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -772,8 +772,8 @@ class Answers {
       return;
     }
     const searcher = verticalKey ? Searcher.VERTICAL : Searcher.UNIVERSAL;
-    const event2 = new AnalyticsEvent(eventName).addOptions({ searcher });
-    this._analyticsReporterService.report(event2);
+    const event = new AnalyticsEvent(eventName).addOptions({ searcher });
+    this._analyticsReporterService.report(event);
   }
 }
 

--- a/src/core/analytics/visibilityanalyticshandler.js
+++ b/src/core/analytics/visibilityanalyticshandler.js
@@ -39,7 +39,7 @@ export default class VisibilityAnalyticsHandler {
     if (isIE()) {
       window.addEventListener('unload', () => {
         if (this._documentVisibilityState !== 'hidden') {
-          this._reportVisibilityChangeEvent('RESULTS_HIDDEN_UNLOAD');
+          this._reportVisibilityChangeEvent('RESULTS_HIDDEN');
         }
       });
     }

--- a/src/core/analytics/visibilityanalyticshandler.js
+++ b/src/core/analytics/visibilityanalyticshandler.js
@@ -1,0 +1,60 @@
+import { isIE } from '../utils/useragent';
+import AnalyticsEvent from '../analytics/analyticsevent';
+import Searcher from '../models/searcher';
+
+/**
+ * Manages the document's visibility status and handles any visibility related analytics events.
+ */
+export default class VisibilityAnalyticsHandler {
+  constructor (analyticsReporterService, verticalKey) {
+    this._documentVisibilityState = undefined;
+    this._analyticsReporterService = analyticsReporterService;
+    this._verticalKey = verticalKey;
+  }
+
+  /**
+   * Initialize visibility change event listener(s) to send analytics events
+   * when a result page have become visible or have been hidden.
+   */
+  initVisibilityChangeListeners () {
+    /**
+     * Safari desktop listener and IE11 listeners fire visibility change event twice when switch
+     * to new tab and then close browser. This variable is used to ensure RESULTS_HIDDEN analytics event
+     * does not get send again if the page is already hidden.
+     */
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden' && this._documentVisibilityState !== 'hidden') {
+        this._documentVisibilityState = 'hidden';
+        this._reportVisibilityChangeEvent('RESULTS_HIDDEN');
+      } else if (document.visibilityState === 'visible') {
+        this._documentVisibilityState = 'visible';
+        this._reportVisibilityChangeEvent('RESULTS_UNHIDDEN');
+      }
+    });
+
+    /**
+     * VisibilityChange API does not register when page is terminated (close tab/browser) in IE11.
+     * Unload event is used to capture those RESULTS_HIDDEN scenarios.
+     */
+    if (isIE()) {
+      window.addEventListener('unload', () => {
+        if (this._documentVisibilityState !== 'hidden') {
+          this._reportVisibilityChangeEvent('RESULTS_HIDDEN_UNLOAD');
+        }
+      });
+    }
+  }
+
+  /**
+   * Send visibility change related analytics event.
+   */
+  _reportVisibilityChangeEvent (eventName) {
+    const queryId = this._analyticsReporterService.getQueryId();
+    if (!queryId) {
+      return;
+    }
+    const searcher = this._verticalKey ? Searcher.VERTICAL : Searcher.UNIVERSAL;
+    const event = new AnalyticsEvent(eventName).addOptions({ searcher });
+    this._analyticsReporterService.report(event);
+  }
+}

--- a/src/core/utils/useragent.js
+++ b/src/core/utils/useragent.js
@@ -21,3 +21,14 @@ export function isSafari () {
 
   return browserData.browser.name === 'Safari';
 }
+
+/**
+ * Returns whether the current browser is Internet Explorer.
+ *
+ * @returns {boolean}
+ */
+export function isIE () {
+  const browserData = Bowser.parse(navigator.userAgent);
+
+  return browserData.browser.name === 'Internet Explorer';
+}


### PR DESCRIPTION
As part of the search duration metrics epic, this pr add implementations for HIDDEN_RESULTS/UNHIDDEN_RESULTS for desktop and mobile (with some exceptions in ios). The implementation relies on VisibilityChange API and unload event.

Browser specific implementation details on **desktop**:
- Safari: When user place a search, switch to new tab, and eventually close browser (UC 1.5), safari desktop would trigger visibility change event twice (for switching tab, and closing browser). Product said they uses the final event to calculate duration. So, `documentVisibilityState` variable is used to ensures HIDDEN_RESULTS is sent only if page is not hidden (not to fire another event if user already navigate away from the search page).
- IE11: IE11 does not trigger VisibilityChange listener when user close tab/browser. As suggested in MDN webdocs, pagehide event should be the next best alternatives. However, when testing it, pagehide does not fire as expected (strangely it only works when I have unload listener set as well..). So, unload event is used along with VisiblityChange API to track page closing scenarios, which seems consistent so far during testing. With two listeners on ie11, similar issue occur with Safari on UC 1.5. This is resolve with `documentVisibilityState`.

Browser specific details on **mobile**:
- Firefox: close tab/browser doesn’t work.
- Safari: close tab doesn’t work.
- Safari & Chrome: can’t produce consistent results when close from app switcher mode. Certain cases (e.g. switch tab, return to search page, and then close from app switcher) never fire visibilityChange API event, and some cases (e.g. search and then close app switcher without switch tab) was seen firing a few times only.

After some discussions with product, it's decided we would have partial ios support for now with what is currently working and will make a follow up epic to address the rest of the use cases.

J=SLAP-1917
TEST=manual

Setup for the following tests: 
Serve html page that uses local SDK bundle. Use postman mock server to track mock analytics event firing. Use ngrok to test local changes in ios and android. Afterward, confirm that real analytics endpoint requests send successfully by switching tab in chrome desktop.

<img width="702" alt="Screen Shot 2022-03-15 at 1 19 17 PM" src="https://user-images.githubusercontent.com/36055303/158434751-646ba8bf-651e-4b4f-8397-ffbabc73eed1.png">
<img width="585" alt="Screen Shot 2022-03-15 at 1 19 52 PM" src="https://user-images.githubusercontent.com/36055303/158434886-d576d770-5c45-4f47-9704-34912bc443f2.png">
<img width="682" alt="Screen Shot 2022-03-15 at 1 32 28 PM" src="https://user-images.githubusercontent.com/36055303/158437220-8a8803ac-afcc-4f7a-b4e4-75b252550492.png">

