### PR TITLE
pass SDK-Client HTTP header and allow custom key-value pairs

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,11 +1,11 @@
 module.exports = [
   {
     path: 'dist/answers.min.js',
-    limit: '180 KB'
+    limit: '185 KB'
   },
   {
     path: 'dist/answers-modern.min.js',
-    limit: '150kb'
+    limit: '155 KB'
   },
   {
     path: 'dist/answerstemplates.compiled.min.js',

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ function initAnswers() {
     // Optional, the analytics key describing the Answers integration type. Accepts 'STANDARD', 'OVERLAY', or arbitrary strings. Defaults to 'STANDARD'
     querySource: 'STANDARD',
     // Optional, additional key-value pairs for the Client-SDK HTTP header.
-    customSdkClient: {}
+    customClientSdk: {}
   })
 }
 ```

--- a/README.md
+++ b/README.md
@@ -174,8 +174,12 @@ function initAnswers() {
     disableCssVariablesPonyfill: false,
     // Optional, the analytics key describing the Answers integration type. Accepts 'STANDARD', 'OVERLAY', or arbitrary strings. Defaults to 'STANDARD'
     querySource: 'STANDARD',
-    // Optional, additional key-value pairs for the Client-SDK HTTP header.
-    customClientSdk: {}
+    // Optional, additional values for the HTTP headers listed below. Headers other than those listed below will be ignored.
+    additionalHttpHeaders: {
+      // Additional key-value pairs to send in the Client-SDK header.
+      // ANSWERS_CORE and ANSWERS_SEARCH_UI_SDK are automatically set and cannot be overwritten.
+      'Client-SDK': {}
+    }
   })
 }
 ```

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ function initAnswers() {
     disableCssVariablesPonyfill: false,
     // Optional, the analytics key describing the Answers integration type. Accepts 'STANDARD', 'OVERLAY', or arbitrary strings. Defaults to 'STANDARD'
     querySource: 'STANDARD',
+    // Optional, additional key-value pairs for the Client-SDK HTTP header.
+    customSdkClient: {}
   })
 }
 ```

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -226,7 +226,7 @@ MIT License
 
 The following NPM package may be included in this product:
 
- - @yext/answers-core@1.6.0-beta.4
+ - @yext/answers-core@1.6.0-beta.5
 
 This package contains the following license and notice below:
 

--- a/conf/gulp-tasks/bundle/bundle.js
+++ b/conf/gulp-tasks/bundle/bundle.js
@@ -11,6 +11,7 @@ const {
   TRANSLATION_FLAGGER_REGEX,
   SPEECH_RECOGNITION_LOCALES_SUPPORTED_BY_EDGE
 } = require('../../i18n/constants');
+const rollupJson = require('@rollup/plugin-json');
 
 const TranslateCallParser = require('../../i18n/translatecallparser');
 
@@ -50,7 +51,8 @@ exports.modernBundle = function (
         exclude: [/node_modules/],
         presets: ['@babel/env']
       }),
-      svg()
+      svg(),
+      rollupJson()
     ]
   };
   return _buildBundle(callback, rollupConfig, bundleName, locale, libVersion, translationResolver);
@@ -109,7 +111,8 @@ exports.legacyBundle = function (
           '@babel/plugin-transform-object-assign'
         ]
       }),
-      svg()
+      svg(),
+      rollupJson()
     ]
   };
   return _buildBundle(callback, rollupConfig, bundleName, locale, libVersion, translationResolver);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5780,6 +5780,40 @@
         "@percy/logger": "1.0.0-beta.60"
       }
     },
+    "@rollup/plugin-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "dependencies": {
+        "@types/estree": {
+          "version": "0.0.39",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+          "dev": true
+        },
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        }
+      }
+    },
     "@size-limit/file": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-4.9.1.tgz",
@@ -5995,12 +6029,49 @@
       }
     },
     "@yext/answers-core": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.5.2.tgz",
-      "integrity": "sha512-8L9uzhGAg0b/VaYefH+N8MPHGoftzSV1J7a9ogH6UbVRSICnUDboxEa5oLapfQDCvd4jx9d3NiALy2a1csBDbA==",
+      "version": "1.6.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.6.0-beta.4.tgz",
+      "integrity": "sha512-Ni3DMc8CQWDb7qz1gJjItrFY8VeI5PFS8Uwdz7LWDywiLMlArFrqm5AkK26+TZtbgt996pHqRz1jpMAtTJAYlA==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
-        "cross-fetch": "^3.1.4"
+        "cross-fetch": "^3.1.5"
+      },
+      "dependencies": {
+        "cross-fetch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+          "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+          "requires": {
+            "node-fetch": "2.6.7"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
     },
     "@yext/answers-storage": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6029,9 +6029,9 @@
       }
     },
     "@yext/answers-core": {
-      "version": "1.6.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.6.0-beta.4.tgz",
-      "integrity": "sha512-Ni3DMc8CQWDb7qz1gJjItrFY8VeI5PFS8Uwdz7LWDywiLMlArFrqm5AkK26+TZtbgt996pHqRz1jpMAtTJAYlA==",
+      "version": "1.6.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.6.0-beta.5.tgz",
+      "integrity": "sha512-HUPnVyBBcK9YBsCemSN6ExqvHwLtKZQHyQe1DsRSZfAL9BjhatfpucGbLcHJ+RtIBBFtqEtTuov86k+gkCX2LA==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@mapbox/mapbox-gl-language": "^0.10.1",
-    "@yext/answers-core": "^1.6.0-beta.4",
+    "@yext/answers-core": "^1.6.0-beta.5",
     "@yext/answers-storage": "^1.1.0",
     "@yext/rtf-converter": "^1.5.0",
     "bowser": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@mapbox/mapbox-gl-language": "^0.10.1",
-    "@yext/answers-core": "^1.5.1",
+    "@yext/answers-core": "^1.6.0-beta.4",
     "@yext/answers-storage": "^1.1.0",
     "@yext/rtf-converter": "^1.5.0",
     "bowser": "^2.11.0",
@@ -55,6 +55,7 @@
     "@babel/runtime-corejs3": "^7.13.10",
     "@percy/cli": "^1.0.0-beta.60",
     "@percy/puppeteer": "^2.0.0",
+    "@rollup/plugin-json": "^4.1.0",
     "@size-limit/file": "^4.9.0",
     "@types/jest": "^24.0.15",
     "autoprefixer": "7.2.5",

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -286,7 +286,8 @@ class Answers {
       onVerticalSearch: parsedConfig.onVerticalSearch,
       onUniversalSearch: parsedConfig.onUniversalSearch,
       environment: parsedConfig.environment,
-      componentManager: this.components
+      componentManager: this.components,
+      customClientSdk: parsedConfig.customClientSdk
     });
 
     if (parsedConfig.onStateChange && typeof parsedConfig.onStateChange === 'function') {

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -287,7 +287,7 @@ class Answers {
       onUniversalSearch: parsedConfig.onUniversalSearch,
       environment: parsedConfig.environment,
       componentManager: this.components,
-      customClientSdk: parsedConfig.customClientSdk
+      additionalHttpHeaders: parsedConfig.additionalHttpHeaders
     });
 
     if (parsedConfig.onStateChange && typeof parsedConfig.onStateChange === 'function') {

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -121,6 +121,9 @@ export default class Core {
      * @type {ComponentManager}
      */
     this._componentManager = config.componentManager;
+
+    /** @type {{ [agent: string]: string, ANSWERS_CORE?: never, ANSWERS_SEARCH_UI_SDK?: never }} */
+    this._customClientSdk = config.customClientSdk || {};
   }
 
   /**
@@ -270,7 +273,8 @@ export default class Core {
         locationRadius: locationRadius === 0 ? undefined : locationRadius,
         context: context && JSON.parse(context),
         referrerPageUrl: referrerPageUrl,
-        querySource: this.storage.get(StorageKeys.QUERY_SOURCE)
+        querySource: this.storage.get(StorageKeys.QUERY_SOURCE),
+        customClientSdk: this._getMergedClientSdk()
       })
       .then(response => SearchDataTransformer.transformVertical(response, this._fieldFormatters, verticalKey))
       .then(data => {
@@ -386,7 +390,8 @@ export default class Core {
         sessionTrackingEnabled: this.storage.get(StorageKeys.SESSIONS_OPT_IN).value,
         context: context && JSON.parse(context),
         referrerPageUrl: referrerPageUrl,
-        querySource: this.storage.get(StorageKeys.QUERY_SOURCE)
+        querySource: this.storage.get(StorageKeys.QUERY_SOURCE),
+        customClientSdk: this._getMergedClientSdk()
       })
       .then(response => SearchDataTransformer.transformUniversal(response, urls, this._fieldFormatters))
       .then(data => {
@@ -453,7 +458,8 @@ export default class Core {
     return this._coreLibrary
       .universalAutocomplete({
         input: input,
-        sessionTrackingEnabled: this.storage.get(StorageKeys.SESSIONS_OPT_IN).value
+        sessionTrackingEnabled: this.storage.get(StorageKeys.SESSIONS_OPT_IN).value,
+        customClientSdk: this._getMergedClientSdk()
       })
       .then(response => AutoCompleteResponseTransformer.transformAutoCompleteResponse(response))
       .then(data => {
@@ -477,7 +483,8 @@ export default class Core {
       .verticalAutocomplete({
         input: input,
         verticalKey: verticalKey,
-        sessionTrackingEnabled: this.storage.get(StorageKeys.SESSIONS_OPT_IN).value
+        sessionTrackingEnabled: this.storage.get(StorageKeys.SESSIONS_OPT_IN).value,
+        customClientSdk: this._getMergedClientSdk()
       })
       .then(response => AutoCompleteResponseTransformer.transformAutoCompleteResponse(response))
       .then(data => {
@@ -509,7 +516,8 @@ export default class Core {
         verticalKey: config.verticalKey,
         fields: searchParamFields,
         sectioned: config.searchParameters.sectioned,
-        sessionTrackingEnabled: this.storage.get(StorageKeys.SESSIONS_OPT_IN).value
+        sessionTrackingEnabled: this.storage.get(StorageKeys.SESSIONS_OPT_IN).value,
+        customClientSdk: this._getMergedClientSdk()
       })
       .then(
         response => AutoCompleteResponseTransformer.transformFilterSearchResponse(response),
@@ -535,7 +543,8 @@ export default class Core {
     return this._coreLibrary
       .submitQuestion({
         ...question,
-        sessionTrackingEnabled: this.storage.get(StorageKeys.SESSIONS_OPT_IN).value
+        sessionTrackingEnabled: this.storage.get(StorageKeys.SESSIONS_OPT_IN).value,
+        customClientSdk: this._getMergedClientSdk()
       })
       .then(() => {
         this.storage.set(
@@ -814,5 +823,12 @@ export default class Core {
       }
     }
     return null;
+  }
+
+  _getMergedClientSdk () {
+    return {
+      ...this._customClientSdk,
+      ANSWERS_SEARCH_UI_SDK: LIB_VERSION
+    };
   }
 }

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -22,7 +22,7 @@ import { getCachedLiveApiUrl, getLiveApiUrl } from './utils/urlutils';
 import { SearchParams } from '../ui';
 import SearchStates from './storage/searchstates';
 import Searcher from './models/searcher';
-import { getAdditionalHttpHeaders } from './utils/getAdditionalHttpHeaders';
+import { mergeAdditionalHttpHeaders } from './utils/mergeAdditionalHttpHeaders';
 
 /** @typedef {import('./storage/storage').default} Storage */
 
@@ -120,7 +120,7 @@ export default class Core {
     this._componentManager = config.componentManager;
 
     /** @type {import('@yext/answers-core').AdditionalHttpHeaders} */
-    this._additionalHttpHeaders = getAdditionalHttpHeaders(config.additionalHttpHeaders);
+    this._additionalHttpHeaders = mergeAdditionalHttpHeaders(config.additionalHttpHeaders);
   }
 
   /**
@@ -271,7 +271,7 @@ export default class Core {
         context: context && JSON.parse(context),
         referrerPageUrl: referrerPageUrl,
         querySource: this.storage.get(StorageKeys.QUERY_SOURCE),
-        additionalHttpHeaders: this._mergeAdditionalHttpHeaders()
+        additionalHttpHeaders: this._additionalHttpHeaders
       })
       .then(response => SearchDataTransformer.transformVertical(response, this._fieldFormatters, verticalKey))
       .then(data => {
@@ -388,7 +388,7 @@ export default class Core {
         context: context && JSON.parse(context),
         referrerPageUrl: referrerPageUrl,
         querySource: this.storage.get(StorageKeys.QUERY_SOURCE),
-        customAdditionalHttpHeaders: this._mergeAdditionalHttpHeaders()
+        additionalHttpHeaders: this._additionalHttpHeaders
       })
       .then(response => SearchDataTransformer.transformUniversal(response, urls, this._fieldFormatters))
       .then(data => {
@@ -456,7 +456,7 @@ export default class Core {
       .universalAutocomplete({
         input: input,
         sessionTrackingEnabled: this.storage.get(StorageKeys.SESSIONS_OPT_IN).value,
-        customAdditionalHttpHeaders: this._mergeAdditionalHttpHeaders()
+        additionalHttpHeaders: this._additionalHttpHeaders
       })
       .then(response => AutoCompleteResponseTransformer.transformAutoCompleteResponse(response))
       .then(data => {
@@ -481,7 +481,7 @@ export default class Core {
         input: input,
         verticalKey: verticalKey,
         sessionTrackingEnabled: this.storage.get(StorageKeys.SESSIONS_OPT_IN).value,
-        customAdditionalHttpHeaders: this._mergeAdditionalHttpHeaders()
+        additionalHttpHeaders: this._additionalHttpHeaders
       })
       .then(response => AutoCompleteResponseTransformer.transformAutoCompleteResponse(response))
       .then(data => {
@@ -514,7 +514,7 @@ export default class Core {
         fields: searchParamFields,
         sectioned: config.searchParameters.sectioned,
         sessionTrackingEnabled: this.storage.get(StorageKeys.SESSIONS_OPT_IN).value,
-        customAdditionalHttpHeaders: this._mergeAdditionalHttpHeaders()
+        additionalHttpHeaders: this._additionalHttpHeaders
       })
       .then(
         response => AutoCompleteResponseTransformer.transformFilterSearchResponse(response),
@@ -541,7 +541,7 @@ export default class Core {
       .submitQuestion({
         ...question,
         sessionTrackingEnabled: this.storage.get(StorageKeys.SESSIONS_OPT_IN).value,
-        customAdditionalHttpHeaders: this._mergeAdditionalHttpHeaders()
+        additionalHttpHeaders: this._additionalHttpHeaders
       })
       .then(() => {
         this.storage.set(

--- a/src/core/utils/getAddtionalHttpHeaders.js
+++ b/src/core/utils/getAddtionalHttpHeaders.js
@@ -1,0 +1,25 @@
+import { LIB_VERSION } from '../constants';
+
+const CLIENT_SDK_HEADER = 'Client-SDK';
+
+/**
+ * Merges a given additionalHttpHeaders with the SDK's built in value,
+ * and performs run-time validation.
+ *
+ * @param {Record<string, string>} additionalHttpHeaders
+ * @returns {import('@yext/answers-core').AdditionalHttpHeaders}
+ */
+export function getAdditionalHttpHeaders (additionalHttpHeaders = {}) {
+  const ignoredHeaders = Object.keys(additionalHttpHeaders).filter(v => v === CLIENT_SDK_HEADER);
+  ignoredHeaders.forEach(h => console.warn(
+    `Found unknown HTTP header "${h}", ignoring it. ` +
+    `Only the "${CLIENT_SDK_HEADER}" header is recognized in additionalHttpHeaders.`
+  ));
+
+  return {
+    [CLIENT_SDK_HEADER]: {
+      ...additionalHttpHeaders[CLIENT_SDK_HEADER],
+      ANSWERS_SEARCH_UI_SDK: LIB_VERSION
+    }
+  };
+}

--- a/src/core/utils/mergeAdditionalHttpHeaders.js
+++ b/src/core/utils/mergeAdditionalHttpHeaders.js
@@ -9,8 +9,8 @@ const CLIENT_SDK_HEADER = 'Client-SDK';
  * @param {Record<string, string>} additionalHttpHeaders
  * @returns {import('@yext/answers-core').AdditionalHttpHeaders}
  */
-export function getAdditionalHttpHeaders (additionalHttpHeaders = {}) {
-  const ignoredHeaders = Object.keys(additionalHttpHeaders).filter(v => v === CLIENT_SDK_HEADER);
+export function mergeAdditionalHttpHeaders (additionalHttpHeaders = {}) {
+  const ignoredHeaders = Object.keys(additionalHttpHeaders).filter(v => v !== CLIENT_SDK_HEADER);
   ignoredHeaders.forEach(h => console.warn(
     `Found unknown HTTP header "${h}", ignoring it. ` +
     `Only the "${CLIENT_SDK_HEADER}" header is recognized in additionalHttpHeaders.`

--- a/src/core/utils/mergeAdditionalHttpHeaders.js
+++ b/src/core/utils/mergeAdditionalHttpHeaders.js
@@ -2,6 +2,13 @@ import { LIB_VERSION } from '../constants';
 
 const CLIENT_SDK_HEADER = 'Client-SDK';
 
+const SEARCH_UI_HEADER_KEY = 'ANSWERS_SEARCH_UI_SDK';
+const CORE_HEADER_KEY = 'ANSWERS_CORE';
+
+const DEFAULT_CLIENT_SDK_VALUES = {
+  [SEARCH_UI_HEADER_KEY]: LIB_VERSION
+};
+
 /**
  * Merges a given additionalHttpHeaders with the SDK's built in value,
  * and performs run-time validation.
@@ -10,16 +17,54 @@ const CLIENT_SDK_HEADER = 'Client-SDK';
  * @returns {import('@yext/answers-core').AdditionalHttpHeaders}
  */
 export function mergeAdditionalHttpHeaders (additionalHttpHeaders = {}) {
-  const ignoredHeaders = Object.keys(additionalHttpHeaders).filter(v => v !== CLIENT_SDK_HEADER);
-  ignoredHeaders.forEach(h => console.warn(
-    `Found unknown HTTP header "${h}", ignoring it. ` +
-    `Only the "${CLIENT_SDK_HEADER}" header is recognized in additionalHttpHeaders.`
-  ));
+  if (!validateAdditionalHeadersIsObj(additionalHttpHeaders)) {
+    return {
+      [CLIENT_SDK_HEADER]: DEFAULT_CLIENT_SDK_VALUES
+    };
+  }
+
+  validateAdditionalHttpHeaders(additionalHttpHeaders);
+  const clientSdkValues = additionalHttpHeaders[CLIENT_SDK_HEADER] || {};
+  validateClientSdkValues(clientSdkValues);
+  const {
+    [CORE_HEADER_KEY]: _ignoredCoreValues,
+    [SEARCH_UI_HEADER_KEY]: _ignoredSeachUiValues,
+    ...additionalClientSDKHeaderValues
+  } = clientSdkValues;
 
   return {
     [CLIENT_SDK_HEADER]: {
-      ...additionalHttpHeaders[CLIENT_SDK_HEADER],
-      ANSWERS_SEARCH_UI_SDK: LIB_VERSION
+      ...additionalClientSDKHeaderValues,
+      ...DEFAULT_CLIENT_SDK_VALUES
     }
   };
+}
+
+function validateAdditionalHeadersIsObj (additionalHttpHeaders) {
+  if (typeof additionalHttpHeaders !== 'object') {
+    console.error(
+      'additionalHttpHeaders must be an "object", ' +
+      `not a(n) "${typeof additionalHttpHeaders}".`);
+    return false;
+  }
+  return true;
+}
+
+function validateAdditionalHttpHeaders (additionalHttpHeaders = {}) {
+  const ignoredHeaders = Object.keys(additionalHttpHeaders).filter(v => v !== CLIENT_SDK_HEADER);
+  ignoredHeaders.forEach(h => console.error(
+    `Ignored unknown HTTP header "${h}". ` +
+    `Only the "${CLIENT_SDK_HEADER}" header is recognized in additionalHttpHeaders.`
+  ));
+}
+
+function validateClientSdkValues (clientSdkValues = {}) {
+  const errorMsg = key =>
+    `Ignoring "${key}" values for ${CLIENT_SDK_HEADER}. These values are automatically specified.`;
+  if (CORE_HEADER_KEY in clientSdkValues) {
+    console.error(errorMsg(CORE_HEADER_KEY));
+  }
+  if (SEARCH_UI_HEADER_KEY in clientSdkValues) {
+    console.error(errorMsg(SEARCH_UI_HEADER_KEY));
+  }
 }

--- a/tests/answers-umd.js
+++ b/tests/answers-umd.js
@@ -109,15 +109,24 @@ describe('ANSWERS instance integration testing', () => {
     expect(ANSWERS.getAnalyticsOptIn()).toBeUndefined();
   });
 
-  it('passes the customClientSdk from config', async () => {
+  it('passes the additionalHttpHeaders from config', async () => {
     mockWindow(windowSpy, {
       location: {
         search: ''
       }
     });
     await initAnswers(ANSWERS, {
-      customClientSdk: { TEST_CLIENT_SDK: '1.2.3' }
+      additionalHttpHeaders: {
+        'Client-SDK': {
+          TEST_CLIENT_SDK: '1.2.3'
+        }
+      }
     });
-    expect(ANSWERS.core._customClientSdk).toEqual({ TEST_CLIENT_SDK: '1.2.3' });
+    expect(ANSWERS.core._additionalHttpHeaders).toEqual({
+      'Client-SDK': {
+        ANSWERS_SEARCH_UI_SDK: '@@LIB_VERSION',
+        TEST_CLIENT_SDK: '1.2.3'
+      }
+    });
   });
 });

--- a/tests/answers-umd.js
+++ b/tests/answers-umd.js
@@ -108,4 +108,16 @@ describe('ANSWERS instance integration testing', () => {
     await initAnswers(ANSWERS, { businessId: undefined });
     expect(ANSWERS.getAnalyticsOptIn()).toBeUndefined();
   });
+
+  it('passes the customClientSdk from config', async () => {
+    mockWindow(windowSpy, {
+      location: {
+        search: ''
+      }
+    });
+    await initAnswers(ANSWERS, {
+      customClientSdk: { TEST_CLIENT_SDK: '1.2.3' }
+    });
+    expect(ANSWERS.core._customClientSdk).toEqual({ TEST_CLIENT_SDK: '1.2.3' });
+  });
 });

--- a/tests/core/core.js
+++ b/tests/core/core.js
@@ -84,9 +84,65 @@ describe('sessionId is passed properly', () => {
   });
 });
 
-function getMockCore () {
+describe('customClientSdk param is passed correctly', () => {
+  const mockCore = getMockCore({
+    customClientSdk: { TEST: '1.3.5' }
+  });
+
+  it('verticalSearch', () => {
+    mockCore.verticalSearch();
+    expectCorrectCustomClientSdk('verticalSearch');
+  });
+
+  it('universalSearch', () => {
+    mockCore.search();
+    expectCorrectCustomClientSdk('universalSearch');
+  });
+
+  it('submitQuestion', () => {
+    mockCore.submitQuestion();
+    expectCorrectCustomClientSdk('submitQuestion');
+  });
+
+  it('autoCompleteVertical', () => {
+    mockCore.autoCompleteVertical();
+    expectCorrectCustomClientSdk('verticalAutocomplete');
+  });
+
+  it('autoCompleteUniversal', () => {
+    mockCore.autoCompleteUniversal();
+    expectCorrectCustomClientSdk('universalAutocomplete');
+  });
+
+  it('autoCompleteFilter', () => {
+    mockCore.autoCompleteFilter('input', {
+      searchParameters: {
+        fields: [{
+          fieldId: 'builtin.location',
+          entityTypeId: 'ce_person'
+        }],
+        sectioned: false
+      }
+    });
+    expectCorrectCustomClientSdk('filterSearch');
+  });
+
+  function expectCorrectCustomClientSdk (coreLibMethod) {
+    expect(mockCore._coreLibrary[coreLibMethod]).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customClientSdk: expect.objectContaining({
+          TEST: '1.3.5',
+          ANSWERS_SEARCH_UI_SDK: '@@LIB_VERSION'
+        })
+      })
+    );
+  }
+});
+
+function getMockCore (config = {}) {
   const core = new Core({
-    storage: new Storage().init()
+    storage: new Storage().init(),
+    ...config
   });
   core.init();
   core._coreLibrary.universalSearch = jest.fn(() => Promise.resolve());

--- a/tests/core/core.js
+++ b/tests/core/core.js
@@ -84,13 +84,28 @@ describe('sessionId is passed properly', () => {
   });
 });
 
-describe('additionalHttpHeaders param is passed correctly', () => {
+describe('additionalHttpHeaders are passed correctly', () => {
   const mockCore = getMockCore({
     additionalHttpHeaders: {
       'Client-SDK': {
         TEST: '1.3.5'
       }
     }
+  });
+
+  it('logs a warning if an unrecognized header is found', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    getMockCore({
+      additionalHttpHeaders: {
+        'Client-SDK': {
+          TEST: '1.3.5'
+        },
+        'weee--eee': {},
+        'eee---eeeb': {}
+      }
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    warnSpy.mockRestore();
   });
 
   it('verticalSearch', () => {

--- a/tests/core/core.js
+++ b/tests/core/core.js
@@ -93,21 +93,6 @@ describe('additionalHttpHeaders are passed correctly', () => {
     }
   });
 
-  it('logs a warning if an unrecognized header is found', () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    getMockCore({
-      additionalHttpHeaders: {
-        'Client-SDK': {
-          TEST: '1.3.5'
-        },
-        'weee--eee': {},
-        'eee---eeeb': {}
-      }
-    });
-    expect(warnSpy).toHaveBeenCalledTimes(2);
-    warnSpy.mockRestore();
-  });
-
   it('verticalSearch', () => {
     mockCore.verticalSearch();
     expectCorrectAdditionalHttpHeaders('verticalSearch');

--- a/tests/core/core.js
+++ b/tests/core/core.js
@@ -84,34 +84,38 @@ describe('sessionId is passed properly', () => {
   });
 });
 
-describe('customClientSdk param is passed correctly', () => {
+describe('additionalHttpHeaders param is passed correctly', () => {
   const mockCore = getMockCore({
-    customClientSdk: { TEST: '1.3.5' }
+    additionalHttpHeaders: {
+      'Client-SDK': {
+        TEST: '1.3.5'
+      }
+    }
   });
 
   it('verticalSearch', () => {
     mockCore.verticalSearch();
-    expectCorrectCustomClientSdk('verticalSearch');
+    expectCorrectAdditionalHttpHeaders('verticalSearch');
   });
 
   it('universalSearch', () => {
     mockCore.search();
-    expectCorrectCustomClientSdk('universalSearch');
+    expectCorrectAdditionalHttpHeaders('universalSearch');
   });
 
   it('submitQuestion', () => {
     mockCore.submitQuestion();
-    expectCorrectCustomClientSdk('submitQuestion');
+    expectCorrectAdditionalHttpHeaders('submitQuestion');
   });
 
   it('autoCompleteVertical', () => {
     mockCore.autoCompleteVertical();
-    expectCorrectCustomClientSdk('verticalAutocomplete');
+    expectCorrectAdditionalHttpHeaders('verticalAutocomplete');
   });
 
   it('autoCompleteUniversal', () => {
     mockCore.autoCompleteUniversal();
-    expectCorrectCustomClientSdk('universalAutocomplete');
+    expectCorrectAdditionalHttpHeaders('universalAutocomplete');
   });
 
   it('autoCompleteFilter', () => {
@@ -124,16 +128,18 @@ describe('customClientSdk param is passed correctly', () => {
         sectioned: false
       }
     });
-    expectCorrectCustomClientSdk('filterSearch');
+    expectCorrectAdditionalHttpHeaders('filterSearch');
   });
 
-  function expectCorrectCustomClientSdk (coreLibMethod) {
+  function expectCorrectAdditionalHttpHeaders (coreLibMethod) {
     expect(mockCore._coreLibrary[coreLibMethod]).toHaveBeenCalledWith(
       expect.objectContaining({
-        customClientSdk: expect.objectContaining({
-          TEST: '1.3.5',
-          ANSWERS_SEARCH_UI_SDK: '@@LIB_VERSION'
-        })
+        additionalHttpHeaders: {
+          'Client-SDK': expect.objectContaining({
+            TEST: '1.3.5',
+            ANSWERS_SEARCH_UI_SDK: '@@LIB_VERSION'
+          })
+        }
       })
     );
   }

--- a/tests/core/utils/mergeAdditionalHttpHeaders.js
+++ b/tests/core/utils/mergeAdditionalHttpHeaders.js
@@ -1,0 +1,59 @@
+const { mergeAdditionalHttpHeaders } = require('../../../src/core/utils/mergeAdditionalHttpHeaders');
+
+it('logs an error if an unrecognized header is found', () => {
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
+  const headers = mergeAdditionalHttpHeaders({
+    'Client-SDK': {
+      TEST: '1.3.5'
+    },
+    makise: {},
+    kurisu: {}
+  });
+  expect(errorSpy).toHaveBeenCalledTimes(2);
+  expect(errorSpy).toHaveBeenCalledWith(
+    'Ignored unknown HTTP header "makise". Only the "Client-SDK" header is recognized in additionalHttpHeaders.');
+  expect(errorSpy).toHaveBeenCalledWith(
+    'Ignored unknown HTTP header "kurisu". Only the "Client-SDK" header is recognized in additionalHttpHeaders.');
+  errorSpy.mockRestore();
+  expect(headers).toEqual({
+    'Client-SDK': {
+      ANSWERS_SEARCH_UI_SDK: '@@LIB_VERSION',
+      TEST: '1.3.5'
+    }
+  });
+});
+
+it('logs an error if an additionalHttpHeaders is not an object', () => {
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
+  const headers = mergeAdditionalHttpHeaders(123);
+  expect(errorSpy).toHaveBeenCalledTimes(1);
+  expect(errorSpy).toHaveBeenCalledWith(
+    'additionalHttpHeaders must be an "object", not a(n) "number".');
+  errorSpy.mockRestore();
+  expect(headers).toEqual({
+    'Client-SDK': {
+      ANSWERS_SEARCH_UI_SDK: '@@LIB_VERSION'
+    }
+  });
+});
+
+it('logs an error if either ANSWERS_CORE or ANSWERS_SEARCH_UI_SDK are set in the user\'s Client-SDK', () => {
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
+  const headers = mergeAdditionalHttpHeaders({
+    'Client-SDK': {
+      ANSWERS_CORE: 'answers-core',
+      ANSWERS_SEARCH_UI_SDK: 'answers-search-ui-sdk'
+    }
+  });
+  expect(errorSpy).toHaveBeenCalledTimes(2);
+  expect(errorSpy).toHaveBeenCalledWith(
+    'Ignoring "ANSWERS_SEARCH_UI_SDK" values for Client-SDK. These values are automatically specified.');
+  expect(errorSpy).toHaveBeenCalledWith(
+    'Ignoring "ANSWERS_CORE" values for Client-SDK. These values are automatically specified.');
+  errorSpy.mockRestore();
+  expect(headers).toEqual({
+    'Client-SDK': {
+      ANSWERS_SEARCH_UI_SDK: '@@LIB_VERSION'
+    }
+  });
+});


### PR DESCRIPTION
Our tests are emitting a number of console.errors, however it looks like
this has been the case for some time now. It's probably not worth making an item
to fix these since we're deprecating the SDK, and the tests still test what they need to.

I tried using the compact and preferConst options for rollup/json-plugin, but they didn't
decrease the bundle size at all.

J=SLAP-1948
TEST=manual,auto

test that universal/vertical autocomplete and searches, filter search,
and question submission all pass the Client-SDK header and any custom headers
(tested both with and without customClientSdk set in ANSWERS.init)
tested this works with the hitchhiker-theme's test site