### PR TITLE
fix for having both google and mapbox maps on the same page

### DIFF
--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -81,7 +81,7 @@ export default class GoogleMapProvider extends MapProvider {
       return;
     }
 
-    let script = DOM.query('#yext-map-js');
+    let script = DOM.query('#yext-map-google-js');
     if (script) {
       const onLoadFunc = script.onload;
       script.onload = function () {
@@ -92,7 +92,7 @@ export default class GoogleMapProvider extends MapProvider {
     }
 
     script = DOM.createEl('script', {
-      id: 'yext-map-js',
+      id: 'yext-map-google-js',
       onload: () => {
         self._isLoaded = true;
         onLoad();

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -54,7 +54,7 @@ export default class MapBoxMapProvider extends MapProvider {
     });
 
     const css = DOM.createEl('link', {
-      id: 'yext-map-css',
+      id: 'yext-map-mapbox-css',
       rel: 'stylesheet',
       href: `https://api.mapbox.com/mapbox-gl-js/${version}/mapbox-gl.css`
     });

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -32,7 +32,7 @@ export default class MapBoxMapProvider extends MapProvider {
   loadJS (onLoad) {
     const version = 'v1.13.1';
     const script = DOM.createEl('script', {
-      id: 'yext-map-js',
+      id: 'yext-map-mapbox-js',
       onload: () => {
         this._isLoaded = true;
         mapboxgl.accessToken = this._apiKey;


### PR DESCRIPTION
Before this fix, you could not have both a google and a mapbox map
on the page at the same time, because they were using the same DOM id.

Giving them unique ids lets them exist simultaneously. This is a very
rare usecase that probably isn't worth a hotfix.

J=SLAP-1969
TEST=manual

hooked up local SDK to theme test-site, saw both google and mapbox map on the
same universal search page