### PR TITLE
fix json parsing from eventoptions data in autocomplete component

### DIFF
--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -192,8 +192,22 @@ export default class AutoCompleteComponent extends Component {
       sectionIndex: this._sectionIndex,
       resultIndex: this._resultIndex,
       promptHeader: this._originalQuery.length === 0 ? this.promptHeader : null,
-      listLabelIdName: this.listLabelIdName
+      listLabelIdName: this.listLabelIdName,
+      eventOptions: this.eventOptions(data)
     }));
+  }
+
+  eventOptions (data) {
+    const eventOptions = [];
+    data.sections?.forEach(section => {
+      const sectionEventOptions = section.results.map(result => {
+        return {
+          suggestedSearchText: result.value
+        };
+      });
+      eventOptions.push(sectionEventOptions);
+    });
+    return eventOptions;
   }
 
   updateAriaAttribute () {

--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -199,7 +199,7 @@ export default class AutoCompleteComponent extends Component {
 
   eventOptions (data) {
     const eventOptions = data.sections?.map(section =>
-      section.results.map(result => {
+      section.results?.map(result => {
         return { suggestedSearchText: result.value };
       })
     );

--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -198,15 +198,11 @@ export default class AutoCompleteComponent extends Component {
   }
 
   eventOptions (data) {
-    const eventOptions = [];
-    data.sections?.forEach(section => {
-      const sectionEventOptions = section.results.map(result => {
-        return {
-          suggestedSearchText: result.value
-        };
-      });
-      eventOptions.push(sectionEventOptions);
-    });
+    const eventOptions = data.sections?.map(section =>
+      section.results.map(result => {
+        return { suggestedSearchText: result.value };
+      })
+    );
     return eventOptions;
   }
 

--- a/src/ui/templates/search/autocomplete.hbs
+++ b/src/ui/templates/search/autocomplete.hbs
@@ -53,7 +53,7 @@
               data-short="{{shortValue}}"
               data-filter='{{json filter}}'
               data-eventtype="AUTO_COMPLETE_SELECTION"
-              data-eventoptions='{"suggestedSearchText": "{{value}}"}'
+              data-eventoptions='{{json (lookup (lookup @root.eventOptions @../index) @index) }}'
               role="option"
               id="yxt-AutoComplete-option-{{../../_config.name}}-{{@../index}}-{{@index}}"
           >

--- a/tests/ui/components/search/autocompletecomponent.js
+++ b/tests/ui/components/search/autocompletecomponent.js
@@ -1,0 +1,63 @@
+/* eslint-disable quotes */
+/* global MouseEvent */
+import mockManager from '../../../setup/managermocker';
+import DOM from '../../../../src/ui/dom/dom';
+import AutoCompleteComponent from '../../../../src/ui/components/search/autocompletecomponent';
+import { mount } from 'enzyme';
+
+const COMPONENT_MANAGER = mockManager();
+const mockAnalyticsReporter = {
+  report: jest.fn(() => Promise.resolve())
+};
+COMPONENT_MANAGER.setAnalyticsReporter(mockAnalyticsReporter);
+
+function createAutocompleteComponent () {
+  const defaultConfig = {
+    container: '#autocomplete-component',
+    parentContainer: DOM.query('#searchbar'),
+    inputEl: '#inputEl',
+    shouldHideOnEmptySearch: false,
+    verticalKey: 'verticalKey'
+  };
+  return COMPONENT_MANAGER.create(AutoCompleteComponent.type, defaultConfig);
+}
+
+function setupDOM () {
+  const bodyEl = DOM.query('body');
+  DOM.empty(bodyEl);
+  const searchbarEl = DOM.createEl('div', { id: 'searchbar' });
+  DOM.append(bodyEl, searchbarEl);
+  DOM.append(searchbarEl, DOM.createEl('div', { id: 'inputEl' }));
+  DOM.append(bodyEl, DOM.createEl('div', { id: 'autocomplete-component' }));
+}
+
+describe('AUTO_COMPLETE_SELECTION analytics event fire as expected', () => {
+  it('reports analyticsOptions provided when an autocomplete option is selected', () => {
+    setupDOM();
+    const component = createAutocompleteComponent();
+    // simulate that input is focused so autocomplete component is open
+    component.isQueryInputFocused = () => true;
+    component.setState({
+      sections: [
+        {
+          results: [
+            { value: "a Rose by any other name" },
+            { value: "test prompt \"some text ...more text.\"  for TEST output" }
+          ]
+        }
+      ]
+    });
+    const wrapper = mount(component);
+    wrapper
+      .find("[data-value='test prompt \"some text ...more text.\"  for TEST output']")
+      .getDOMNode()
+      .dispatchEvent(new MouseEvent('mousedown', { button: 0 }));
+
+    expect(mockAnalyticsReporter.report).toHaveBeenCalledTimes(1);
+    const expectedEvent = {
+      eventType: "AUTO_COMPLETE_SELECTION",
+      suggestedSearchText: "test prompt \"some text ...more text.\"  for TEST output"
+    };
+    expect(mockAnalyticsReporter.report).toHaveBeenLastCalledWith(expectedEvent);
+  });
+});


### PR DESCRIPTION
This pr address a JSON parse error when autocomplete option's text contains special characters, such as double quotes. When the autocomplete value is read by handlebars and placed in `data-eventoptions` to directly construct a JSON object in string form, the special characters are in escaped-HTML character format. When page load, those characters are no longer escaped. This causes problem when component try to perform JSON.parse on `data-eventoptions` string to send an analytic event.

I briefly checked other areas where we might do insert user custom text to data-eventoptions. Beside verticalkey and pagenumbers, it seems like this is the main place where we would run to this problem. We should check the repo, in another item, for instances this approach of passing JSON data through handlebars occur, outside of data-eventoptions attribute.

<img width="1664" alt="Screen Shot 2022-03-25 at 10 44 43 AM" src="https://user-images.githubusercontent.com/36055303/160148998-27e9545c-fd8d-4f24-a40a-211eee16e4d9.png">


J=SLAP-2013
TEST=manual

see that new jest test failed with previous code, and pass with the new changes
use SDK searchbar in an html page, added a universal prompt with special characters (double quotes) in the text, see that error appear with previous code, and function normally with the new changes. Click on that universal prompt and see that an analytics event with that text value fired.