### PR TITLE
Remove Useragent Test

### DIFF
--- a/.github/run_useragent_acceptance.sh
+++ b/.github/run_useragent_acceptance.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-export BROWSERSTACK_USE_AUTOMATE="1"
-export BROWSERSTACK_PROJECT_NAME="Answers SDK"
-export BROWSERSTACK_BUILD_ID="${GITHUB_REF_NAME} - ${GITHUB_RUN_ID}"
-COMMIT_MSG_TITLE=$(git log -n 1 --pretty=format:%s)
-export BROWSERSTACK_TEST_RUN_NAME=$COMMIT_MSG_TITLE
-
-npx testcafe chrome:headless,firefox:headless,browserstack:safari,browserstack:edge tests/acceptance/useragent/useragentsuite.js --config-file ./.github/testcafe.json

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -47,24 +47,3 @@ jobs:
         env:
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-
-  useragent:
-    name: Useragent Acceptance
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js 14
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
-          cache: 'npm'
-      - run: npm ci
-      - name: Download build-output artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: build-output
-          path: dist/
-      - run: ./.github/run_useragent_acceptance.sh
-        env:
-          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
-          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}


### PR DESCRIPTION
Remove the useragent acceptance tests from the Github migration because they were removed from the Circle CI tests in #1662

J=SLAP-2023
TEST=none

Confirm the useragent acceptance test is no longer being ran
