### PR TITLE
set SEARCH_COMPLETE state for necessary models when an API error occurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,14 +522,14 @@ ANSWERS.addComponent('SearchBar', {
     // Optional, callback invoked when the autocomplete component changes from closed to open.
     onOpen: function() {},
   },
-  //Optional, options for loading indicator on seachbar
+  // Optional, options for loading indicator on seachbar
   loadingIndicator: {
-    //Optional, whether to include a loading indicator on seachbar
+    // Optional, whether to include a loading indicator on seachbar
     display: false,
-    //Optional, use custom icon url instead of the default loading indicator animation
+    // Optional, use custom icon url instead of the default loading indicator animation
     iconUrl: ""
   },
-  //Optional, options for voice search feature on seachbar
+  // Optional, options for voice search feature on seachbar
   voiceSearch: {
     // Optional, whether or not voice search is enabled
     enabled: false,

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -323,6 +323,9 @@ export default class Core {
         window.performance.mark('yext.answers.verticalQueryResponseRendered');
       }).catch(error => {
         console.error('Vertical search failed with the following error: ' + error);
+        this.storage.set(StorageKeys.VERTICAL_RESULTS, new VerticalResults());
+        this.storage.set(StorageKeys.DIRECT_ANSWER, new DirectAnswer());
+        this.storage.set(StorageKeys.LOCATION_BIAS, new LocationBias({}));
       });
   }
 
@@ -414,6 +417,9 @@ export default class Core {
         window.performance.mark('yext.answers.universalQueryResponseRendered');
       }).catch(error => {
         console.error('Universal search failed with the following error: ' + error);
+        this.storage.set(StorageKeys.UNIVERSAL_RESULTS, new UniversalResults({}));
+        this.storage.set(StorageKeys.DIRECT_ANSWER, new DirectAnswer());
+        this.storage.set(StorageKeys.LOCATION_BIAS, new LocationBias({}));
       });
   }
 

--- a/tests/acceptance/acceptancesuites/facetsonload.js
+++ b/tests/acceptance/acceptancesuites/facetsonload.js
@@ -39,6 +39,7 @@ test('Facets work with back/forward navigation and page refresh', async t => {
   await options.toggleOption('Client Delivery');
   currentFacets = await getFacetsFromRequest();
   const state1 = {
+    c_popularity: [],
     c_puppyPreference: [],
     c_employeeDepartment: [{ c_employeeDepartment: { $eq: 'Client Delivery [SO]' } }],
     languages: [],
@@ -63,6 +64,7 @@ test('Facets work with back/forward navigation and page refresh', async t => {
   await options.toggleOption('Frodo');
   currentFacets = await getFacetsFromRequest();
   const state3 = {
+    c_popularity: [],
     c_puppyPreference: [{ c_puppyPreference: { $eq: 'Frodo' } }],
     c_employeeDepartment: [
       { c_employeeDepartment: { $eq: 'Client Delivery [SO]' } },


### PR DESCRIPTION
Now when an API error occurs, the SEARCH_COMPLETE state is set for models
that are set to SEARCH_LOADING.

J=SLAP-1467
TEST=manual

set an invalid apiKey, see the search loading state start and stop as expected
see expected console log for both universal + vertical searches

also do the same thing with an invalid verticalKey for vertical searches

see that no location bias or direct answer renders after an API error