### PR TITLE
move aria-expanded attribute from autocomplete div to text input

### DIFF
--- a/conf/i18n/translations/messages.pot
+++ b/conf/i18n/translations/messages.pot
@@ -108,7 +108,7 @@ msgstr ""
 msgid "Invalid email address. Please refresh the page and try submitting your question again."
 msgstr ""
 
-#: src/ui/components/filters/geolocationcomponent.js:296
+#: src/ui/components/filters/geolocationcomponent.js:289
 #: src/ui/components/filters/geolocationcomponent.js:40
 #: src/ui/components/filters/geolocationcomponent.js:48
 msgid "Location"

--- a/conf/i18n/translations/messages.pot
+++ b/conf/i18n/translations/messages.pot
@@ -108,7 +108,7 @@ msgstr ""
 msgid "Invalid email address. Please refresh the page and try submitting your question again."
 msgstr ""
 
-#: src/ui/components/filters/geolocationcomponent.js:286
+#: src/ui/components/filters/geolocationcomponent.js:296
 #: src/ui/components/filters/geolocationcomponent.js:40
 #: src/ui/components/filters/geolocationcomponent.js:48
 msgid "Location"

--- a/src/ui/components/filters/geolocationcomponent.js
+++ b/src/ui/components/filters/geolocationcomponent.js
@@ -224,7 +224,17 @@ export default class GeoLocationComponent extends Component {
       inputEl: inputSelector,
       verticalKey: this._config.verticalKey,
       searchParameters: this.searchParameters,
-      onSubmit: (query, filter) => this._handleSubmit(query, filter)
+      onSubmit: (query, filter) => this._handleSubmit(query, filter),
+      onMount: () => {
+        const inputEl = DOM.query(this._container, inputSelector);
+        if (!inputEl) {
+          return;
+        }
+        const hasAutocompleteResults = this._autocomplete.getState('hasResults');
+        if (inputEl.getAttribute('aria-expanded') !== hasAutocompleteResults) {
+          inputEl.setAttribute('aria-expanded', hasAutocompleteResults);
+        }
+      }
     });
   }
 

--- a/src/ui/components/filters/geolocationcomponent.js
+++ b/src/ui/components/filters/geolocationcomponent.js
@@ -226,14 +226,7 @@ export default class GeoLocationComponent extends Component {
       searchParameters: this.searchParameters,
       onSubmit: (query, filter) => this._handleSubmit(query, filter),
       onMount: () => {
-        const inputEl = DOM.query(this._container, inputSelector);
-        if (!inputEl) {
-          return;
-        }
-        const hasAutocompleteResults = this._autocomplete.getState('hasResults');
-        if (inputEl.getAttribute('aria-expanded') !== hasAutocompleteResults) {
-          inputEl.setAttribute('aria-expanded', hasAutocompleteResults);
-        }
+        this._autocomplete.updateAriaExpanded(DOM.query(this._container, inputSelector));
       }
     });
   }

--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -539,4 +539,14 @@ export default class AutoCompleteComponent extends Component {
       this._onChange();
     }
   }
+
+  updateAriaExpanded (inputEl) {
+    if (!inputEl) {
+      return;
+    }
+    const hasAutocompleteResults = this.getState('hasResults');
+    if (inputEl.getAttribute('aria-expanded') !== hasAutocompleteResults) {
+      inputEl.setAttribute('aria-expanded', hasAutocompleteResults);
+    }
+  }
 }

--- a/src/ui/components/search/filtersearchcomponent.js
+++ b/src/ui/components/search/filtersearchcomponent.js
@@ -220,6 +220,16 @@ export default class FilterSearchComponent extends Component {
         this.core.storage.setWithPersist(`${StorageKeys.FILTER}.${this.name}`, filterNode.getFilter());
         this.core.setStaticFilterNodes(this.name, filterNode);
         this.search(QueryTriggers.FILTER_COMPONENT);
+      },
+      onMount: () => {
+        const inputEl = DOM.query(this._container, inputSelector);
+        if (!inputEl) {
+          return;
+        }
+        const hasAutocompleteResults = this.autoCompleteComponent.getState('hasResults');
+        if (inputEl.getAttribute('aria-expanded') !== hasAutocompleteResults) {
+          inputEl.setAttribute('aria-expanded', hasAutocompleteResults);
+        }
       }
     });
   }

--- a/src/ui/components/search/filtersearchcomponent.js
+++ b/src/ui/components/search/filtersearchcomponent.js
@@ -222,14 +222,7 @@ export default class FilterSearchComponent extends Component {
         this.search(QueryTriggers.FILTER_COMPONENT);
       },
       onMount: () => {
-        const inputEl = DOM.query(this._container, inputSelector);
-        if (!inputEl) {
-          return;
-        }
-        const hasAutocompleteResults = this.autoCompleteComponent.getState('hasResults');
-        if (inputEl.getAttribute('aria-expanded') !== hasAutocompleteResults) {
-          inputEl.setAttribute('aria-expanded', hasAutocompleteResults);
-        }
+        this.autoCompleteComponent.updateAriaExpanded(DOM.query(this._container, inputSelector));
       }
     });
   }

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -568,14 +568,7 @@ export default class SearchComponent extends Component {
         DOM.trigger(DOM.query(this._container, inputSelector), 'input');
       },
       onMount: () => {
-        const inputEl = DOM.query(this._container, inputSelector);
-        if (!inputEl) {
-          return;
-        }
-        const hasAutocompleteResults = this._autocomplete.getState('hasResults');
-        if (inputEl.getAttribute('aria-expanded') !== hasAutocompleteResults) {
-          inputEl.setAttribute('aria-expanded', hasAutocompleteResults);
-        }
+        this._autocomplete.updateAriaExpanded(DOM.query(this._container, inputSelector));
       }
     });
     this._autocomplete.mount();

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -566,6 +566,16 @@ export default class SearchComponent extends Component {
       },
       onChange: () => {
         DOM.trigger(DOM.query(this._container, inputSelector), 'input');
+      },
+      onMount: () => {
+        const inputEl = DOM.query(this._container, inputSelector);
+        if (!inputEl) {
+          return;
+        }
+        const hasAutocompleteResults = this._autocomplete.getState('hasResults');
+        if (inputEl.getAttribute('aria-expanded') !== hasAutocompleteResults) {
+          inputEl.setAttribute('aria-expanded', hasAutocompleteResults);
+        }
       }
     });
     this._autocomplete.mount();

--- a/src/ui/templates/search/autocomplete.hbs
+++ b/src/ui/templates/search/autocomplete.hbs
@@ -1,4 +1,4 @@
-<div class="yxt-AutoComplete-wrapper js-yxt-AutoComplete-wrapper" aria-expanded="{{hasResults}}">
+<div class="yxt-AutoComplete-wrapper js-yxt-AutoComplete-wrapper">
   <span class="yxt-AutoComplete-resultsCount sr-only" aria-live="assertive">
     {{#if hasResults}}
       {{#each sections}}


### PR DESCRIPTION
This commit updates the SearchBar, FilterSearch, and GeolocationFilter
components to have the aria-expanded attribute on the text input instead
of on the container div for the autocomplete.

We cannot use the SDK's setState to do this, because setState does not
work properly for text input, and will reset the user's text cursor location.
This is a known issue.
Instead, an onMount was added to AutoComplete component usages that manually makes
a DOM manipulation.

J=SLAP-2015
TEST=manual

see that for FilterSearch, SearchBar, and GeolocationFilter the input will have
aria-expanded true when there are autocomplete results visible, and false when not visible
tested autocomplete queries with no results
tested autocomplete queries with results that were visible
tested autocomplete queries with results, but that weren't currently visible due to clicking
on the parent document