### PR TITLE
Remove duplicate translations

### DIFF
--- a/conf/i18n/translations/es.po
+++ b/conf/i18n/translations/es.po
@@ -6,12 +6,6 @@ msgstr ""
 msgid "[[start]] through [[end]] of [[resultsCount]]"
 msgstr "Desde [[start]] hasta [[end]] de [[resultsCount]]"
 
-#: src/ui/templates/search/autocomplete.hbs:14
-msgid "[[resultsCount]] autocomplete option found"
-msgid_plural "[[resultsCount]] autocomplete options found"
-msgstr[0] "[[resultsCount]] opción de autocompletar encontrada"
-msgstr[1] "[[resultsCount]] opciones de autocompletar encontradas"
-
 #: src/ui/templates/questions/questionsubmission.hbs:7
 msgid "expand question form"
 msgstr "expandir formulario de preguntas"

--- a/conf/i18n/translations/fr.po
+++ b/conf/i18n/translations/fr.po
@@ -483,12 +483,6 @@ msgctxt "Placeholder text for input field"
 msgid "Enter your question here"
 msgstr "Posez votre question ici"
 
-#: src/ui/templates/search/autocomplete.hbs:14
-msgid "[[resultsCount]] autocomplete option found"
-msgid_plural "[[resultsCount]] autocomplete options found"
-msgstr[0] "[[resultsCount]] option de saisie automatique trouvée"
-msgstr[1] "[[resultsCount]] options de saisie automatique trouvées"
-
 #: src/ui/components/filters/facetscomponent.js:277
 msgctxt "True or False"
 msgid "False"

--- a/conf/i18n/translations/it.po
+++ b/conf/i18n/translations/it.po
@@ -6,12 +6,6 @@ msgstr ""
 msgid "[[start]] through [[end]] of [[resultsCount]]"
 msgstr "[[start]] a [[end]] di [[resultsCount]]"
 
-#: src/ui/templates/search/autocomplete.hbs:14
-msgid "[[resultsCount]] autocomplete option found"
-msgid_plural "[[resultsCount]] autocomplete options found"
-msgstr[0] "[[resultsCount]] risultato di completamento automatico trovato"
-msgstr[1] "[[resultsCount]] risultati di completamento automatico trovati"
-
 #: src/ui/templates/questions/questionsubmission.hbs:7
 msgid "expand question form"
 msgstr "espandi il modulo per le domande"

--- a/conf/i18n/translations/ja.po
+++ b/conf/i18n/translations/ja.po
@@ -71,10 +71,6 @@ msgstr "[[date]]より後"
 msgctxt "Before a date. Example: Before [August 15th]"
 msgid "Before [[date]]"
 msgstr "[[date]]より前"
-#: src/ui/templates/results/alternativeverticals.hbs:28
-msgid "([[resultsCount]] result)"
-msgid_plural "([[resultsCount]] results)"
-msgstr[0] "（[[resultsCount]]件の結果）"
 
 #: src/ui/components/filters/daterangefiltercomponent.js:199
 msgctxt "Beginning at a date (with no end date). Example: [August 15th] or later"
@@ -481,12 +477,6 @@ msgstr "クリア"
 msgctxt "Placeholder text for input field"
 msgid "Enter your question here"
 msgstr "ここに質問を入力して下さい"
-
-#: src/ui/templates/search/autocomplete.hbs:14
-msgid "[[resultsCount]] autocomplete option found"
-msgid_plural "[[resultsCount]] autocomplete options found"
-msgstr[0] "オートコンプリート選択が[[resultsCount]]件見つかりました"
-msgstr[1] "オートコンプリート選択が[[resultsCount]]件見つかりました"
 
 #: src/ui/components/filters/facetscomponent.js:277
 msgctxt "True or False"


### PR DESCRIPTION
Fix the translation files due to duplicates

At some point, the 'autocomplete option found' translations were updated to have a period at the end of the sentence. This resulted in duplicate translations where some had a period at the and and other didn't. This PR deletes the extra translations which don't have the period at the end. 

J=SLAP-2023
TEST=manual

Manually run the translation tests and confirm they pass locally