### PR TITLE
Should Deploy Major Version Fix

### DIFF
--- a/.github/workflows/should_deploy_major_version.yml
+++ b/.github/workflows/should_deploy_major_version.yml
@@ -26,8 +26,8 @@ jobs:
           MINOR_VERSION=$(echo "${GITHUB_REF_NAME##${{ inputs.ignore_prefix }}}" | cut -d '.' -f 2) 
           MAJOR_VERSION=$(echo "${GITHUB_REF_NAME##${{ inputs.ignore_prefix }}}" | cut -d '.' -f 1)
           NEXT_MINOR_VERSION=$(( $MINOR_VERSION + 1 ))
-          OUTPUT=$(git tag --list "$MAJOR_VERSION.$NEXT_MINOR_VERSION.*")
-          if [ -z $OUTPUT ]
+          TAGS_FOR_NEXT_MINOR=$(git tag --list "${{ inputs.ignore_prefix }}$MAJOR_VERSION.$NEXT_MINOR_VERSION.*")
+          if [ -z "$TAGS_FOR_NEXT_MINOR" ]
           then
             echo 'Major version should be deployed.'
             echo ::set-output name=should_deploy_major_version::true


### PR DESCRIPTION
Fixes the should_deploy_major_version.yml Github Action

One issue was that the `git tag --list` command was returning a list of tags separated by new lines which were each passed as a separate argument in the `if [ -z` line. We can fix this by surrounding TAGS_FOR_NEXT_MINOR with double quotes so that only one string and therefore one argument is passed to the `-z` command.

Secondly, the `git tag --list` wasn't taking into account the search-bar prefix. By adding `${{ inputs.ignore_prefix }}` to the `git tag --list` param, we can properly check the tags for the search bar.

J=SLAP-2023
TEST=manual

Run the bash script locally, however substitute ${{ inputs.ignore_prefix }} for `search-bar-` which is what Github Actions does before running the script. Confirm that the script indicates that a GITHUB_REF_NAME of 'search-bar-v1.3.1' should deploy a major, but a major version should not be deployed for `search-bar-v1.2.7` or `search-bar-v1.1.7` (assuming the v1.3.0 tag exists)