### PR TITLE
add truncatedSuffix param to formatRichText

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -538,7 +538,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/rtf-converter@1.6.1
+ - @yext/rtf-converter@1.7.0
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mapbox/mapbox-gl-language": "^0.10.1",
         "@yext/answers-core": "^1.6.0-beta.5",
         "@yext/answers-storage": "^1.1.0",
-        "@yext/rtf-converter": "^1.6.1",
+        "@yext/rtf-converter": "^1.7.0",
         "bowser": "^2.11.0",
         "cross-fetch": "^3.1.5",
         "css-vars-ponyfill": "^2.4.3",
@@ -4331,9 +4331,9 @@
       }
     },
     "node_modules/@yext/rtf-converter": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@yext/rtf-converter/-/rtf-converter-1.6.1.tgz",
-      "integrity": "sha512-xH0DEyTcbQDMqUs893v2f5rSfh1KTtY8jo8eDPH66HYWkyX+xNsYH69im7qmehWg/4W+FLTVYkIkClvFK7Ai+w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@yext/rtf-converter/-/rtf-converter-1.7.0.tgz",
+      "integrity": "sha512-i4H2HifDfmtVJMXnGQbFnLS4kxd1ze604DHKl/wZNy2WPzWh4oTwF+3LKzKbTOnM8+dRS1msztm1EqZQ7g/bYA==",
       "dependencies": {
         "markdown-it": "^12.0.0",
         "markdown-it-plugin-underline": "0.0.1",
@@ -25939,9 +25939,9 @@
       "version": "1.1.0"
     },
     "@yext/rtf-converter": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@yext/rtf-converter/-/rtf-converter-1.6.1.tgz",
-      "integrity": "sha512-xH0DEyTcbQDMqUs893v2f5rSfh1KTtY8jo8eDPH66HYWkyX+xNsYH69im7qmehWg/4W+FLTVYkIkClvFK7Ai+w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@yext/rtf-converter/-/rtf-converter-1.7.0.tgz",
+      "integrity": "sha512-i4H2HifDfmtVJMXnGQbFnLS4kxd1ze604DHKl/wZNy2WPzWh4oTwF+3LKzKbTOnM8+dRS1msztm1EqZQ7g/bYA==",
       "requires": {
         "markdown-it": "^12.0.0",
         "markdown-it-plugin-underline": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@mapbox/mapbox-gl-language": "^0.10.1",
     "@yext/answers-core": "^1.6.0-beta.5",
     "@yext/answers-storage": "^1.1.0",
-    "@yext/rtf-converter": "^1.6.1",
+    "@yext/rtf-converter": "^1.7.0",
     "bowser": "^2.11.0",
     "cross-fetch": "^3.1.5",
     "css-vars-ponyfill": "^2.4.3",

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -86,8 +86,9 @@ class Answers {
      * A reference to the formatRichText function.
      * @type {Function}
      */
-    this.formatRichText = (markdown, eventOptionsFieldName, targetConfig, truncatedLength) =>
-      RichTextFormatter.format(markdown, eventOptionsFieldName, targetConfig, truncatedLength);
+    this.formatRichText = (markdown, eventOptionsFieldName, targetConfig, truncatedLength, truncatedSuffix) =>
+      RichTextFormatter.format(
+        markdown, eventOptionsFieldName, targetConfig, truncatedLength, truncatedSuffix);
 
     /**
      * A reference to the localizeDistance function.

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -86,9 +86,7 @@ class Answers {
      * A reference to the formatRichText function.
      * @type {Function}
      */
-    this.formatRichText = (markdown, eventOptionsFieldName, targetConfig, truncatedLength, truncatedSuffix) =>
-      RichTextFormatter.format(
-        markdown, eventOptionsFieldName, targetConfig, truncatedLength, truncatedSuffix);
+    this.formatRichText = RichTextFormatter.format;
 
     /**
      * A reference to the localizeDistance function.

--- a/src/core/utils/richtextformatter.js
+++ b/src/core/utils/richtextformatter.js
@@ -22,7 +22,7 @@ class RichTextFormatterImpl {
    *                          The length to truncate the rich text content to. This parameter is optional.
    * @returns {string} The HTML representation of the field value, serialized as a string.
    */
-  format (fieldValue, fieldName, targetConfig, truncatedLength) {
+  format (fieldValue, fieldName, targetConfig, truncatedLength, truncatedSuffix = '...') {
     if (typeof fieldValue !== 'string') {
       throw new AnswersCoreError(
         `Rich text "${fieldValue}" needs to be a string. Currently is a ${typeof fieldValue}`
@@ -37,7 +37,7 @@ class RichTextFormatterImpl {
       (tokens, idx) => this._urlTransformer(tokens, idx, targetConfig));
 
     const richTextHtml = truncatedLength
-      ? RtfConverter.toTruncatedHTML(fieldValue, truncatedLength)
+      ? RtfConverter.toTruncatedHTML(fieldValue, truncatedLength, truncatedSuffix)
       : RtfConverter.toHTML(fieldValue);
 
     fieldName = fieldName || '';

--- a/src/core/utils/richtextformatter.js
+++ b/src/core/utils/richtextformatter.js
@@ -6,7 +6,7 @@ import { AnswersCoreError } from '../errors/errors';
  * This class leverages the {@link RtfConverter} library to perform Rich Text to
  * HTML conversions.
  */
-class RichTextFormatterImpl {
+export default class RichTextFormatterImpl {
   /**
    * Generates an HTML representation of the provided Rich Text field value. Note that
    * the HTML will contain a wrapper div. This is to support click analytics for Rich Text
@@ -22,19 +22,19 @@ class RichTextFormatterImpl {
    *                          The length to truncate the rich text content to. This parameter is optional.
    * @returns {string} The HTML representation of the field value, serialized as a string.
    */
-  format (fieldValue, fieldName, targetConfig, truncatedLength, truncatedSuffix = '...') {
+  static format (fieldValue, fieldName, targetConfig, truncatedLength, truncatedSuffix = '...') {
     if (typeof fieldValue !== 'string') {
       throw new AnswersCoreError(
         `Rich text "${fieldValue}" needs to be a string. Currently is a ${typeof fieldValue}`
       );
     }
 
-    const pluginName = this._generatePluginName();
+    const pluginName = generatePluginName();
     RtfConverter.addPlugin(
       iterator,
       pluginName,
       'link_open',
-      (tokens, idx) => this._urlTransformer(tokens, idx, targetConfig));
+      (tokens, idx) => urlTransformer(tokens, idx, targetConfig));
 
     const richTextHtml = truncatedLength
       ? RtfConverter.toTruncatedHTML(fieldValue, truncatedLength, truncatedSuffix)
@@ -50,48 +50,45 @@ class RichTextFormatterImpl {
 
     return html;
   }
-
-  /**
-   * An inline token parser for use with the {@link iterator} Markdown-it plugin.
-   * This token parser adds a cta-type data attribute to any link it encounters.
-   */
-  _urlTransformer (tokens, idx, targetConfig) {
-    targetConfig = targetConfig || {};
-    let target;
-    if (typeof targetConfig === 'string') {
-      target = targetConfig;
-    }
-
-    const href = tokens[idx].attrGet('href');
-    let ctaType;
-    if (href.startsWith('mailto')) {
-      ctaType = 'EMAIL';
-      target = target || targetConfig.email;
-    } else if (href.startsWith('tel')) {
-      ctaType = 'TAP_TO_CALL';
-      target = target || targetConfig.phone;
-    } else {
-      ctaType = 'VIEW_WEBSITE';
-      target = target || targetConfig.url;
-    }
-
-    tokens[idx].attrSet('data-cta-type', ctaType);
-    target && tokens[idx].attrSet('target', target);
-  }
-
-  /**
-   * A function that generates a unique UUID to serve as the name for a
-   * Markdown-it plugin.
-   *
-   * @returns {string} the UUID.
-   */
-  _generatePluginName () {
-    function s4 () {
-      return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
-    }
-    return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
-  }
 }
 
-const RichTextFormatter = new RichTextFormatterImpl();
-export default RichTextFormatter;
+/**
+ * An inline token parser for use with the {@link iterator} Markdown-it plugin.
+ * This token parser adds a cta-type data attribute to any link it encounters.
+ */
+function urlTransformer (tokens, idx, targetConfig) {
+  targetConfig = targetConfig || {};
+  let target;
+  if (typeof targetConfig === 'string') {
+    target = targetConfig;
+  }
+
+  const href = tokens[idx].attrGet('href');
+  let ctaType;
+  if (href.startsWith('mailto')) {
+    ctaType = 'EMAIL';
+    target = target || targetConfig.email;
+  } else if (href.startsWith('tel')) {
+    ctaType = 'TAP_TO_CALL';
+    target = target || targetConfig.phone;
+  } else {
+    ctaType = 'VIEW_WEBSITE';
+    target = target || targetConfig.url;
+  }
+
+  tokens[idx].attrSet('data-cta-type', ctaType);
+  target && tokens[idx].attrSet('target', target);
+}
+
+/**
+ * A function that generates a unique UUID to serve as the name for a
+ * Markdown-it plugin.
+ *
+ * @returns {string} the UUID.
+ */
+function generatePluginName () {
+  function s4 () {
+    return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
+  }
+  return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
+}

--- a/tests/core/utils/richtextformatter.js
+++ b/tests/core/utils/richtextformatter.js
@@ -29,11 +29,12 @@ describe('adds cta-type data attribute to links', () => {
 });
 
 describe('adds target attribute to links', () => {
+  const richText =
+    '++[url link](http://google.com)++\n\n' +
+    '++[phone link](tel:+17326183404)++\n\n' +
+    '++[email link](mailto:oshi@yext.com)++\n';
+
   it('adds attributes correctly when targetConfig is a string', () => {
-    const richText =
-      '++[url link](http://google.com)++\n\n' +
-      '++[phone link](tel:+17326183404)++\n\n' +
-      '++[email link](mailto:oshi@yext.com)++\n';
     const expectedHTML =
       '<div class="js-yxt-rtfValue" data-field-name="someField">\n' +
       '<p><u><a href="http://google.com" data-cta-type="VIEW_WEBSITE" target="_blank">url link</a></u></p>\n' +
@@ -44,10 +45,6 @@ describe('adds target attribute to links', () => {
   });
 
   it('adds attributes correctly when targetConfig is an object', () => {
-    const richText =
-      '++[url link](http://google.com)++\n\n' +
-      '++[phone link](tel:+17326183404)++\n\n' +
-      '++[email link](mailto:oshi@yext.com)++\n';
     const expectedHTML =
       '<div class="js-yxt-rtfValue" data-field-name="someField">\n' +
       '<p><u><a href="http://google.com" data-cta-type="VIEW_WEBSITE" target="_self">url link</a></u></p>\n' +
@@ -59,16 +56,29 @@ describe('adds target attribute to links', () => {
   });
 });
 
-it('can return truncated HTML', () => {
+describe('truncated HTML', () => {
   const richText =
     '++[url link](http://google.com)++\n\n' +
     '++[phone link](tel:+17326183404)++\n\n' +
     '++[email link](mailto:oshi@yext.com)++\n';
-  const expectedHTML =
+  const expectedHTML = suffix =>
     '<div class="js-yxt-rtfValue" data-field-name="someField">\n' +
     '<p><u><a href="http://google.com" data-cta-type="VIEW_WEBSITE" target="_blank">url link</a></u></p>\n' +
-    '<p><u><a href="tel:+17326183404" data-cta-type="TAP_TO_CALL" target="_blank">ph</a></u></p>\n' +
+    `<p><u><a href="tel:+17326183404" data-cta-type="TAP_TO_CALL" target="_blank">ph${suffix}</a></u></p>\n` +
     '</div>';
-  const truncatedHTML = RichTextFormatter.format(richText, 'someField', '_blank', 10);
-  expect(truncatedHTML).toEqual(expectedHTML);
+
+  it('works as expected', () => {
+    const truncatedHTML = RichTextFormatter.format(richText, 'someField', '_blank', 10, '');
+    expect(truncatedHTML).toEqual(expectedHTML(''));
+  });
+
+  it('uses the correct default truncated suffix', () => {
+    const truncatedHTML = RichTextFormatter.format(richText, 'someField', '_blank', 10);
+    expect(truncatedHTML).toEqual(expectedHTML('...'));
+  });
+
+  it('can set a custom truncated suffix', () => {
+    const truncatedHTML = RichTextFormatter.format(richText, 'someField', '_blank', 10, '---');
+    expect(truncatedHTML).toEqual(expectedHTML('---'));
+  });
 });


### PR DESCRIPTION
This is necessary so that the truncated suffix appears WITHIN the actual rich text content.

Also change the RichTextFormatter class from a singleton instance class to just a class with a static method on it.
It did not hold any state, so there really was not any point of `format` being an instance method. This simplifies
things upstream a little.

J=SLAP-2039
TEST=manual,auto

test that I can use ANSWERS.formatRichText and the suffix appears when truncating