### PR TITLE
add fetch-depth: 0 to actions/checkout usages

### DIFF
--- a/.github/testcafe.json
+++ b/.github/testcafe.json
@@ -3,5 +3,6 @@
   "appCommand": "npx serve -l tcp://0.0.0.0:9999",
   "appInitDelay": 4000,
   "skipJsErrors": true,
-  "retryTestPages": true
+  "retryTestPages": true,
+  "hostname": "localhost"
 }

--- a/.github/testcafe.json
+++ b/.github/testcafe.json
@@ -2,5 +2,6 @@
   "src": ["tests/acceptance/acceptancesuites/*.js", "!tests/acceptance/acceptancesuites/searchbaronlysuite.js"],
   "appCommand": "npx serve -l tcp://0.0.0.0:9999",
   "appInitDelay": 4000,
-  "skipJsErrors": true
+  "skipJsErrors": true,
+  "retryTestPages": true
 }

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js
+      - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
           node-version: 16

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14
+      - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: 'npm'
       - run: npm ci
       - name: Download build-output artifact
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14
+      - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: 'npm'
       - run: npm ci
       - name: Download build-output artifact

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js
+      - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
           node-version: 16

--- a/.github/workflows/acceptance_search_bar.yml
+++ b/.github/workflows/acceptance_search_bar.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14
+      - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: 'npm'
       - run: npm ci
       - name: Download build-output artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Use Node.js 16
       uses: actions/setup-node@v2
       with:
         node-version: 16
         cache: 'npm'
-        fetch-depth: 0
     - run: npm ci
     - run: npm run ${{ inputs.build_script }}
     - name: Create build-output artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
       with:
         node-version: 16
         cache: 'npm'
+    - run: git fetch --prune --unshallow --tags
     - run: npm ci
     - run: npm run ${{ inputs.build_script }}
     - name: Create build-output artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         node-version: 16
         cache: 'npm'
-    - run: git fetch --prune --unshallow --tags
+        fetch-depth: 0
     - run: npm ci
     - run: npm run ${{ inputs.build_script }}
     - name: Create build-output artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 14
+    - name: Use Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 14
+        node-version: 16
         cache: 'npm'
     - run: npm ci
     - run: npm run ${{ inputs.build_script }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js
+    - name: Use Node.js 16
       uses: actions/setup-node@v2
       with:
         node-version: 16

--- a/.github/workflows/miscellaneous_tests.yml
+++ b/.github/workflows/miscellaneous_tests.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14
+      - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: 'npm'
       - run: npm ci
       - run: sudo apt-get install -qq gettext

--- a/.github/workflows/miscellaneous_tests.yml
+++ b/.github/workflows/miscellaneous_tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js
+      - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
           node-version: 16

--- a/.github/workflows/percy_snapshots.yml
+++ b/.github/workflows/percy_snapshots.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14
+      - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: 'npm'
       - run: npm ci
       - name: Download build-output artifact

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js
+      - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
           node-version: 16

--- a/.github/workflows/wcag_test.yml
+++ b/.github/workflows/wcag_test.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2
       with:

--- a/conf/gulp-tasks/utils/libversion.js
+++ b/conf/gulp-tasks/utils/libversion.js
@@ -1,13 +1,16 @@
+const { execSync } = require('child_process');
+
 /**
  * Attempts to compute the correct library version for an SDK asset.
  *
  * @returns {string} The SDK asset's library version.
  */
 function getLibVersion () {
+  console.log(execSync('git --version').toString().trim());
   try {
-    const insideWorkTree = require('child_process')
-      .execSync('git rev-parse --is-inside-work-tree 2>/dev/null')
-      .toString().trim();
+    const insideWorkTree =
+      execSync('git rev-parse --is-inside-work-tree 2>/dev/null')
+        .toString().trim();
     if (insideWorkTree === 'true') {
       return require('child_process')
         .execSync('git describe --tags')

--- a/conf/gulp-tasks/utils/libversion.js
+++ b/conf/gulp-tasks/utils/libversion.js
@@ -8,6 +8,7 @@ const { execSync } = require('child_process');
 function getLibVersion () {
   console.log(execSync('git --version').toString().trim());
   console.log('tags---', execSync('git tag').toString().trim());
+  console.log('logs---', execSync('git log').toString().trim());
   try {
     const insideWorkTree =
       execSync('git rev-parse --is-inside-work-tree 2>/dev/null')

--- a/conf/gulp-tasks/utils/libversion.js
+++ b/conf/gulp-tasks/utils/libversion.js
@@ -7,7 +7,7 @@ const { execSync } = require('child_process');
  */
 function getLibVersion () {
   console.log(execSync('git --version').toString().trim());
-  console.log(execSync('git tag').toString().trim());
+  console.log('tags---', execSync('git tag').toString().trim());
   try {
     const insideWorkTree =
       execSync('git rev-parse --is-inside-work-tree 2>/dev/null')

--- a/conf/gulp-tasks/utils/libversion.js
+++ b/conf/gulp-tasks/utils/libversion.js
@@ -7,6 +7,7 @@ const { execSync } = require('child_process');
  */
 function getLibVersion () {
   console.log(execSync('git --version').toString().trim());
+  console.log(execSync('git tag').toString().trim());
   try {
     const insideWorkTree =
       execSync('git rev-parse --is-inside-work-tree 2>/dev/null')

--- a/conf/gulp-tasks/utils/libversion.js
+++ b/conf/gulp-tasks/utils/libversion.js
@@ -6,9 +6,6 @@ const { execSync } = require('child_process');
  * @returns {string} The SDK asset's library version.
  */
 function getLibVersion () {
-  console.log(execSync('git --version').toString().trim());
-  console.log('tags---', execSync('git tag').toString().trim());
-  console.log('logs---', execSync('git log').toString().trim());
   try {
     const insideWorkTree =
       execSync('git rev-parse --is-inside-work-tree 2>/dev/null')

--- a/conf/gulp-tasks/utils/libversion.js
+++ b/conf/gulp-tasks/utils/libversion.js
@@ -14,11 +14,9 @@ function getLibVersion () {
         .toString().trim();
     }
   } catch (e) {
-    // if above command fails, catch error and continue, as we are not in a git repository
+    console.error('Error getting lib version');
+    throw e;
   }
-
-  console.warn('Warning: Not in a github repository, using default hardcoded library version.');
-  return 'TEST';
 }
 
 module.exports = getLibVersion;


### PR DESCRIPTION
By default, actions/checkout only fetches the latest commit of the git tree in question.
To fetch the full tree, we need to specify `fetch-depth: 0`. This is only necessary in the SDK, which
bases its version off of git tag instead of package.json version. This was added only to actions/checkout
usages that actually run the SDK's build, not those that just download the built output, or don't use the build
output at all.

We can't switch the SDK to use the package.json version, unless we want to drop the git hash in the version
for canary/latest.

https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches

I also updated `getLibVersion` to not quietly suppress errors, because that could lead to scenarios
like this again. There's never really a time we would need to gracefully handle not being able to get
the lib version correctly - those times are almost always bugs we need to catch.

Additionally, I updated our github actions to all use node 16. We have package-lock v2, so it's detrimental to stay on 14.
I also added `retryTestPages` to the testcafe config, which will automatically retry loading the page when the network
request fails to load it. This change required adding `hostname: "localhost"` as well, since under the hood testcafe
uses webworkers for this.

J=none
TEST=manual

see that the assets for this branch set jsLibVersion and Client-SDK correctly