### PR TITLE
Remove retryTestPages

### DIFF
--- a/.github/testcafe.json
+++ b/.github/testcafe.json
@@ -2,7 +2,5 @@
   "src": ["tests/acceptance/acceptancesuites/*.js", "!tests/acceptance/acceptancesuites/searchbaronlysuite.js"],
   "appCommand": "npx serve -l tcp://0.0.0.0:9999",
   "appInitDelay": 4000,
-  "skipJsErrors": true,
-  "retryTestPages": true,
-  "hostname": "localhost"
+  "skipJsErrors": true
 }


### PR DESCRIPTION
Browserstack acceptance tests have been failing when testing on both Safari and IE11 since adding `retryTestPages`. This is likely because `retryTestPages` doesn't work with IE11, so this PR removes it and `"hostname": "localhost"`, which was added to support `retryTestPages`.

J=none
TEST=auto

Tested on a dummy branch that removing `retryTestPages` successfully starts running tests on both Safari and IE11.