### PR TITLE
Upgrade @percy/cli version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "@rollup/plugin-json": "^4.1.0",
         "@size-limit/file": "^4.9.0",
         "@types/jest": "^24.0.15",
-        "@types/serve-handler": "^6.1.1",
         "autoprefixer": "^10.4.4",
         "cross-env": "^7.0.3",
         "cssnano": "^5.1.4",
@@ -3996,15 +3995,6 @@
       "version": "0.0.8",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-handler": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/serve-handler/-/serve-handler-6.1.1.tgz",
-      "integrity": "sha512-bIwSmD+OV8w0t2e7EWsuQYlGoS1o5aEdVktgkXaa43Zm0qVWi21xaSRb3DQA1UXD+DJ5bRq1Rgu14ZczB+CjIQ==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -25386,15 +25376,6 @@
     },
     "@types/resolve": {
       "version": "0.0.8",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/serve-handler": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/serve-handler/-/serve-handler-6.1.1.tgz",
-      "integrity": "sha512-bIwSmD+OV8w0t2e7EWsuQYlGoS1o5aEdVktgkXaa43Zm0qVWi21xaSRb3DQA1UXD+DJ5bRq1Rgu14ZczB+CjIQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "rollup-plugin-node-resolve": "^4.0.1",
         "rollup-plugin-svg": "^2.0.0",
         "sass": "^1.34.0",
+        "serve-handler": "^6.1.3",
         "size-limit": "^4.9.0",
         "stylelint": "^14.5.3",
         "stylelint-config-standard-scss": "^3.0.0",
@@ -9168,6 +9169,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^1.3.2"
+      }
+    },
+    "node_modules/fast-url-parser/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
       "license": "MIT"
@@ -17548,6 +17564,15 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "node_modules/range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "dev": true,
@@ -18758,6 +18783,67 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/serve-handler": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.3.tgz",
+      "integrity": "sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==",
+      "dev": true,
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "fast-url-parser": "1.1.3",
+        "mime-types": "2.1.18",
+        "minimatch": "3.0.4",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "2.2.1",
+        "range-parser": "1.2.0"
+      }
+    },
+    "node_modules/serve-handler/node_modules/bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/serve-handler/node_modules/content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-handler/node_modules/mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-handler/node_modules/mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "~1.33.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-handler/node_modules/path-to-regexp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
+      "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
+      "dev": true
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
@@ -28943,6 +29029,23 @@
       "version": "2.0.6",
       "dev": true
     },
+    "fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+      "dev": true,
+      "requires": {
+        "punycode": "^1.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
+      }
+    },
     "fastest-levenshtein": {
       "version": "1.0.12"
     },
@@ -34827,6 +34930,12 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
+    },
     "react-is": {
       "version": "16.13.1",
       "dev": true
@@ -35679,6 +35788,57 @@
       "dev": true,
       "requires": {
         "sver-compat": "^1.5.0"
+      }
+    },
+    "serve-handler": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.3.tgz",
+      "integrity": "sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "fast-url-parser": "1.1.3",
+        "mime-types": "2.1.18",
+        "minimatch": "3.0.4",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "2.2.1",
+        "range-parser": "1.2.0"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+          "dev": true
+        },
+        "content-disposition": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+          "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+          "dev": true
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "dev": true,
+          "requires": {
+            "mime-db": "~1.33.0"
+          }
+        },
+        "path-to-regexp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
+          "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
+          "dev": true
+        }
       }
     },
     "set-blocking": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@babel/plugin-transform-runtime": "^7.9.0",
         "@babel/preset-env": "^7.13.10",
         "@babel/runtime-corejs3": "^7.13.10",
-        "@percy/cli": "^1.0.0-beta.60",
+        "@percy/cli": "^1.0.7",
         "@percy/puppeteer": "^2.0.0",
         "@rollup/plugin-json": "^4.1.0",
         "@size-limit/file": "^4.9.0",
@@ -98,7 +98,7 @@
         "vinyl-source-stream": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3405,506 +3405,188 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@oclif/command": {
-      "version": "1.8.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oclif/config": "^1.15.1",
-        "@oclif/errors": "^1.3.3",
-        "@oclif/parser": "^3.8.3",
-        "@oclif/plugin-help": "^3",
-        "debug": "^4.1.1",
-        "semver": "^7.3.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@oclif/config": "^1"
-      }
-    },
-    "node_modules/@oclif/command/node_modules/debug": {
-      "version": "4.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@oclif/command/node_modules/semver": {
-      "version": "7.3.5",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@oclif/config": {
-      "version": "1.17.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oclif/errors": "^1.3.3",
-        "@oclif/parser": "^3.8.0",
-        "debug": "^4.1.1",
-        "globby": "^11.0.1",
-        "is-wsl": "^2.1.1",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@oclif/config/node_modules/debug": {
-      "version": "4.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@oclif/config/node_modules/globby": {
-      "version": "11.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@oclif/errors": {
-      "version": "1.3.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^3.0.0",
-        "fs-extra": "^8.1",
-        "indent-string": "^4.0.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@oclif/errors/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@oclif/errors/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@oclif/errors/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/errors/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@oclif/errors/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@oclif/linewrap": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@oclif/parser": {
-      "version": "3.8.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oclif/errors": "^1.2.2",
-        "@oclif/linewrap": "^1.0.0",
-        "chalk": "^2.4.2",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@oclif/parser/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@oclif/plugin-help": {
-      "version": "3.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oclif/command": "^1.5.20",
-        "@oclif/config": "^1.15.1",
-        "@oclif/errors": "^1.2.2",
-        "chalk": "^4.1.0",
-        "indent-string": "^4.0.0",
-        "lodash.template": "^4.4.0",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@oclif/plugin-help/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@oclif/plugin-help/node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@oclif/plugin-help/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@oclif/plugin-help/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/plugin-help/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@oclif/plugin-help/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@oclif/plugin-help/node_modules/widest-line": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@percy/cli": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.0.7.tgz",
+      "integrity": "sha512-eUgUe3cYd/V+AspzJorXTsYReTUvAFUwMIbhc0E7N3bUfjZamtSLlwaF9XnN2OQhEleCDwifmtmaajPfMd4ayg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@oclif/plugin-help": "^3.2.0",
-        "@percy/cli-build": "1.0.0-beta.65",
-        "@percy/cli-config": "1.0.0-beta.65",
-        "@percy/cli-exec": "1.0.0-beta.65",
-        "@percy/cli-snapshot": "1.0.0-beta.65",
-        "@percy/cli-upload": "1.0.0-beta.65"
+        "@percy/cli-build": "1.0.7",
+        "@percy/cli-command": "1.0.7",
+        "@percy/cli-config": "1.0.7",
+        "@percy/cli-exec": "1.0.7",
+        "@percy/cli-snapshot": "1.0.7",
+        "@percy/cli-upload": "1.0.7",
+        "@percy/client": "1.0.7",
+        "@percy/logger": "1.0.7"
       },
       "bin": {
-        "percy": "bin/run"
+        "percy": "bin/run.cjs"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/cli-build": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.0.7.tgz",
+      "integrity": "sha512-SmRI3ajNlWwL01s6SSS3qV1OKXr4s5MTrazijb4rrDDNzrtgtpafNCzsb5mXC+T4dBPzzgxUvfl38oRMDQGLnw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.0.0-beta.65",
-        "@percy/client": "1.0.0-beta.65",
-        "@percy/env": "1.0.0-beta.65",
-        "@percy/logger": "1.0.0-beta.65"
+        "@percy/cli-command": "1.0.7"
       },
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@percy/cli-build/node_modules/@percy/logger": {
-      "version": "1.0.0-beta.65",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/cli-command": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.0.7.tgz",
+      "integrity": "sha512-GwQjallqX+/ybKGUAbx5i6qh/V175sid5D3TU+D0078FpG4Kbdk0xTD6f3rRNMB2hcylBJk8y/69gvHTs3Q00w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@oclif/command": "^1.8.0",
-        "@oclif/config": "^1.17.0",
-        "@oclif/plugin-help": "^3.2.0",
-        "@percy/config": "1.0.0-beta.65",
-        "@percy/logger": "1.0.0-beta.65"
+        "@percy/config": "1.0.7",
+        "@percy/core": "1.0.7",
+        "@percy/logger": "1.0.7"
+      },
+      "bin": {
+        "percy-cli-readme": "bin/readme.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/cli-command/node_modules/@percy/logger": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.7.tgz",
+      "integrity": "sha512-pYW6i0/M9h2PMDGiAYpRzWBt2DMyafsF6fNnIlNGOukQKlqlcae4dxPQFq6Mu3tVv3JMUfIx9h2lew5WquF95g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/cli-config": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.0.7.tgz",
+      "integrity": "sha512-vUgabFFMXf4Con78wUxSRPnRRFbEGE+yAA0qoBaTe75m6C+kQSq0NjxmHwrhfrHcJSVA/s1dip7LqQPVf/X/wA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@oclif/command": "^1.8.0",
-        "@oclif/config": "^1.17.0",
-        "@percy/config": "1.0.0-beta.65",
-        "@percy/logger": "1.0.0-beta.65"
+        "@percy/cli-command": "1.0.7"
       },
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@percy/cli-config/node_modules/@percy/logger": {
-      "version": "1.0.0-beta.65",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/cli-exec": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.0.7.tgz",
+      "integrity": "sha512-y2Jk8375ntbkxUWLSF+08gfA04ACJ1lDwiQFxUoWrJBVN1nK/Lh41YOyZfMWxFjIO1B7tN49CoHtKdcBLWHRSA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.0.0-beta.65",
-        "@percy/core": "1.0.0-beta.65",
-        "@percy/logger": "1.0.0-beta.65",
+        "@percy/cli-command": "1.0.7",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       },
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@percy/cli-exec/node_modules/@percy/logger": {
-      "version": "1.0.0-beta.65",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/cli-snapshot": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.0.7.tgz",
+      "integrity": "sha512-W/4dOYohrsHab/H7PrsNObUA+1nJPxlQEmzKrRy6Yj58zEwK9lP6WFAIQK9n2HbEioNy1PUvdLXb+SIQX/ofUg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.0.0-beta.65",
-        "@percy/config": "1.0.0-beta.65",
-        "@percy/core": "1.0.0-beta.65",
-        "@percy/dom": "1.0.0-beta.65",
-        "@percy/logger": "1.0.0-beta.65",
-        "globby": "^11.0.4",
-        "path-to-regexp": "^6.2.0",
-        "picomatch": "^2.3.0",
-        "serve-handler": "^6.1.3",
-        "yaml": "^1.10.0"
+        "@percy/cli-command": "1.0.7",
+        "yaml": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
-    "node_modules/@percy/cli-snapshot/node_modules/@percy/logger": {
-      "version": "1.0.0-beta.65",
+    "node_modules/@percy/cli-snapshot/node_modules/yaml": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0.tgz",
+      "integrity": "sha512-JbfdlHKGP2Ik9IHylzWlGd4pPK++EU46/IxMykphS2ZKw7a7h+dHNmcXObLgpRDriBY+rpWslldikckX8oruWQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">= 14"
       }
     },
     "node_modules/@percy/cli-upload": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.0.7.tgz",
+      "integrity": "sha512-AfahrDw8dQfa+Fi+OmXddEHGxTD5OZQTDCetOZqtpHl83pRabmeoSFMiqXt9QPMwkN8KE7294YHT4I80YjHzaQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.0.0-beta.65",
-        "@percy/client": "1.0.0-beta.65",
-        "@percy/config": "1.0.0-beta.65",
-        "@percy/logger": "1.0.0-beta.65",
-        "globby": "^11.0.4",
+        "@percy/cli-command": "1.0.7",
+        "fast-glob": "^3.2.11",
         "image-size": "^1.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
-    "node_modules/@percy/cli-upload/node_modules/@percy/logger": {
-      "version": "1.0.0-beta.65",
+    "node_modules/@percy/cli/node_modules/@percy/logger": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.7.tgz",
+      "integrity": "sha512-pYW6i0/M9h2PMDGiAYpRzWBt2DMyafsF6fNnIlNGOukQKlqlcae4dxPQFq6Mu3tVv3JMUfIx9h2lew5WquF95g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/client": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.0.7.tgz",
+      "integrity": "sha512-8mCZsxBsc/Spw01tlySzDSBSDrPys8DIYvU8vnQekWafQh5pu01CeiC7wMNlNucLR/6OmQzaaY0fC8YM5tkMYw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@percy/env": "1.0.0-beta.65",
-        "@percy/logger": "1.0.0-beta.65"
+        "@percy/env": "1.0.7",
+        "@percy/logger": "1.0.7"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/client/node_modules/@percy/logger": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.7.tgz",
+      "integrity": "sha512-pYW6i0/M9h2PMDGiAYpRzWBt2DMyafsF6fNnIlNGOukQKlqlcae4dxPQFq6Mu3tVv3JMUfIx9h2lew5WquF95g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/config": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.0.7.tgz",
+      "integrity": "sha512-aR4RGf36AipFhoieoSmpP8Uv/kRLZuMvhY6/8LxsIr2UsQysikh+YQDv4BfUxeTgeO+9eTlXZsCav3uDUqI/wQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@percy/logger": "1.0.0-beta.65",
+        "@percy/logger": "1.0.7",
         "ajv": "^8.6.2",
         "cosmiconfig": "^7.0.0",
-        "yaml": "^1.10.0"
+        "yaml": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/config/node_modules/@percy/logger": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.7.tgz",
+      "integrity": "sha512-pYW6i0/M9h2PMDGiAYpRzWBt2DMyafsF6fNnIlNGOukQKlqlcae4dxPQFq6Mu3tVv3JMUfIx9h2lew5WquF95g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/config/node_modules/ajv": {
-      "version": "8.6.2",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -3917,9 +3599,10 @@
       }
     },
     "node_modules/@percy/config/node_modules/cosmiconfig": {
-      "version": "7.0.0",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -3931,10 +3614,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/@percy/config/node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@percy/config/node_modules/import-fresh": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -3948,13 +3641,15 @@
     },
     "node_modules/@percy/config/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "node_modules/@percy/config/node_modules/parse-json": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -3970,43 +3665,61 @@
     },
     "node_modules/@percy/config/node_modules/resolve-from": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
+    "node_modules/@percy/config/node_modules/yaml": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0.tgz",
+      "integrity": "sha512-JbfdlHKGP2Ik9IHylzWlGd4pPK++EU46/IxMykphS2ZKw7a7h+dHNmcXObLgpRDriBY+rpWslldikckX8oruWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/@percy/core": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.0.7.tgz",
+      "integrity": "sha512-hyNsvGqL15nV5JhUGdHrX8v+3Og2yfNhBqBxg+0KC7PNPnRxXxezWjyjglzk8MRspi0MpUujjGKzZTVTItg3XA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
-        "@percy/client": "1.0.0-beta.65",
-        "@percy/config": "1.0.0-beta.65",
-        "@percy/dom": "1.0.0-beta.65",
-        "@percy/logger": "1.0.0-beta.65",
+        "@percy/client": "1.0.7",
+        "@percy/config": "1.0.7",
+        "@percy/dom": "1.0.7",
+        "@percy/logger": "1.0.7",
+        "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
+        "fast-glob": "^3.2.11",
+        "micromatch": "^4.0.4",
+        "mime-types": "^2.1.34",
+        "path-to-regexp": "^6.2.0",
         "rimraf": "^3.0.2",
         "ws": "^8.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/core/node_modules/@percy/logger": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.7.tgz",
+      "integrity": "sha512-pYW6i0/M9h2PMDGiAYpRzWBt2DMyafsF6fNnIlNGOukQKlqlcae4dxPQFq6Mu3tVv3JMUfIx9h2lew5WquF95g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/core/node_modules/ws": {
-      "version": "8.1.0",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4024,16 +3737,18 @@
       }
     },
     "node_modules/@percy/dom": {
-      "version": "1.0.0-beta.65",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.0.7.tgz",
+      "integrity": "sha512-9NZD6RSHhHX2BZIoJHyXMPOL5afSHJUl+o+wBIorwad2jevr+DYGMXrn6Fz+IdI7677JP3BuTNu3xpuf+ivNFg==",
+      "dev": true
     },
     "node_modules/@percy/env": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.0.7.tgz",
+      "integrity": "sha512-TK7Q3KGReDt5AiLk4fPK81mKrXAIVHgevzvSw7NN2l3aw1uot8vBOUBjwOJQKyJkqblvdxywmMkErhcu95/IAw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/logger": {
@@ -6531,31 +6246,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/clean-stack": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clean-stack/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cli-spinners": {
       "version": "2.5.0",
       "dev": true,
@@ -6781,6 +6471,38 @@
       "dependencies": {
         "bluebird": "^3.1.1"
       }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-disposition/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/content-type": {
       "version": "1.0.4",
@@ -9412,19 +9134,18 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.2.4",
-      "dev": true,
-      "license": "MIT",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.0",
+        "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.2",
-        "picomatch": "^2.2.1"
+        "micromatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=8.6.0"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -9434,19 +9155,6 @@
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fast-url-parser": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^1.3.2"
-      }
-    },
-    "node_modules/fast-url-parser/node_modules/punycode": {
-      "version": "1.4.1",
       "dev": true,
       "license": "MIT"
     },
@@ -10700,21 +10408,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globby/node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
     "node_modules/globjoin": {
       "version": "0.1.4",
       "license": "MIT"
@@ -11766,9 +11459,10 @@
       }
     },
     "node_modules/image-size": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.1.tgz",
+      "integrity": "sha512-VAwkvNSNGClRw9mDHhc5Efax8PLlsOGcUTh0T/LIriC8vPA3U5PdqXWqkz406MoYHMKW8Uf9gWr05T/rYB44kQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "queue": "6.0.2"
       },
@@ -12502,17 +12196,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -15474,19 +15157,21 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.44.0",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.27",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -16710,8 +16395,9 @@
     },
     "node_modules/path-to-regexp": {
       "version": "6.2.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
+      "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -17789,8 +17475,9 @@
     },
     "node_modules/queue": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "inherits": "~2.0.3"
       }
@@ -19062,69 +18749,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/serve-handler": {
-      "version": "6.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.0.0",
-        "content-disposition": "0.5.2",
-        "fast-url-parser": "1.1.3",
-        "mime-types": "2.1.18",
-        "minimatch": "3.0.4",
-        "path-is-inside": "1.0.2",
-        "path-to-regexp": "2.2.1",
-        "range-parser": "1.2.0"
-      }
-    },
-    "node_modules/serve-handler/node_modules/bytes": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/serve-handler/node_modules/content-disposition": {
-      "version": "0.5.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/serve-handler/node_modules/mime-db": {
-      "version": "1.33.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/serve-handler/node_modules/mime-types": {
-      "version": "2.1.18",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "~1.33.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/serve-handler/node_modules/path-to-regexp": {
-      "version": "2.2.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/serve-handler/node_modules/range-parser": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "dev": true,
@@ -20207,21 +19831,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/stylelint/node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8.6.0"
       }
     },
     "node_modules/stylelint/node_modules/get-stdin": {
@@ -21887,11 +21496,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "dev": true,
@@ -22685,58 +22289,6 @@
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "license": "MIT"
-    },
-    "node_modules/wrap-ansi": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -25291,346 +24843,147 @@
         "fastq": "^1.6.0"
       }
     },
-    "@oclif/command": {
-      "version": "1.8.0",
-      "dev": true,
-      "requires": {
-        "@oclif/config": "^1.15.1",
-        "@oclif/errors": "^1.3.3",
-        "@oclif/parser": "^3.8.3",
-        "@oclif/plugin-help": "^3",
-        "debug": "^4.1.1",
-        "semver": "^7.3.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "semver": {
-          "version": "7.3.5",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
-    "@oclif/config": {
-      "version": "1.17.0",
-      "dev": true,
-      "requires": {
-        "@oclif/errors": "^1.3.3",
-        "@oclif/parser": "^3.8.0",
-        "debug": "^4.1.1",
-        "globby": "^11.0.1",
-        "is-wsl": "^2.1.1",
-        "tslib": "^2.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "globby": {
-          "version": "11.0.4",
-          "dev": true,
-          "requires": {
-            "array-union": "^2.1.0",
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.1.1",
-            "ignore": "^5.1.4",
-            "merge2": "^1.3.0",
-            "slash": "^3.0.0"
-          }
-        }
-      }
-    },
-    "@oclif/errors": {
-      "version": "1.3.5",
-      "dev": true,
-      "requires": {
-        "clean-stack": "^3.0.0",
-        "fs-extra": "^8.1",
-        "indent-string": "^4.0.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        }
-      }
-    },
-    "@oclif/linewrap": {
-      "version": "1.0.0",
-      "dev": true
-    },
-    "@oclif/parser": {
-      "version": "3.8.5",
-      "dev": true,
-      "requires": {
-        "@oclif/errors": "^1.2.2",
-        "@oclif/linewrap": "^1.0.0",
-        "chalk": "^2.4.2",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "dev": true
-        }
-      }
-    },
-    "@oclif/plugin-help": {
-      "version": "3.2.3",
-      "dev": true,
-      "requires": {
-        "@oclif/command": "^1.5.20",
-        "@oclif/config": "^1.15.1",
-        "@oclif/errors": "^1.2.2",
-        "chalk": "^4.1.0",
-        "indent-string": "^4.0.0",
-        "lodash.template": "^4.4.0",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "widest-line": {
-          "version": "3.1.0",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.0.0"
-          }
-        }
-      }
-    },
     "@percy/cli": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.0.7.tgz",
+      "integrity": "sha512-eUgUe3cYd/V+AspzJorXTsYReTUvAFUwMIbhc0E7N3bUfjZamtSLlwaF9XnN2OQhEleCDwifmtmaajPfMd4ayg==",
       "dev": true,
       "requires": {
-        "@oclif/plugin-help": "^3.2.0",
-        "@percy/cli-build": "1.0.0-beta.65",
-        "@percy/cli-config": "1.0.0-beta.65",
-        "@percy/cli-exec": "1.0.0-beta.65",
-        "@percy/cli-snapshot": "1.0.0-beta.65",
-        "@percy/cli-upload": "1.0.0-beta.65"
+        "@percy/cli-build": "1.0.7",
+        "@percy/cli-command": "1.0.7",
+        "@percy/cli-config": "1.0.7",
+        "@percy/cli-exec": "1.0.7",
+        "@percy/cli-snapshot": "1.0.7",
+        "@percy/cli-upload": "1.0.7",
+        "@percy/client": "1.0.7",
+        "@percy/logger": "1.0.7"
+      },
+      "dependencies": {
+        "@percy/logger": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.7.tgz",
+          "integrity": "sha512-pYW6i0/M9h2PMDGiAYpRzWBt2DMyafsF6fNnIlNGOukQKlqlcae4dxPQFq6Mu3tVv3JMUfIx9h2lew5WquF95g==",
+          "dev": true
+        }
       }
     },
     "@percy/cli-build": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.0.7.tgz",
+      "integrity": "sha512-SmRI3ajNlWwL01s6SSS3qV1OKXr4s5MTrazijb4rrDDNzrtgtpafNCzsb5mXC+T4dBPzzgxUvfl38oRMDQGLnw==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.0.0-beta.65",
-        "@percy/client": "1.0.0-beta.65",
-        "@percy/env": "1.0.0-beta.65",
-        "@percy/logger": "1.0.0-beta.65"
-      },
-      "dependencies": {
-        "@percy/logger": {
-          "version": "1.0.0-beta.65",
-          "dev": true
-        }
+        "@percy/cli-command": "1.0.7"
       }
     },
     "@percy/cli-command": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.0.7.tgz",
+      "integrity": "sha512-GwQjallqX+/ybKGUAbx5i6qh/V175sid5D3TU+D0078FpG4Kbdk0xTD6f3rRNMB2hcylBJk8y/69gvHTs3Q00w==",
       "dev": true,
       "requires": {
-        "@oclif/command": "^1.8.0",
-        "@oclif/config": "^1.17.0",
-        "@oclif/plugin-help": "^3.2.0",
-        "@percy/config": "1.0.0-beta.65",
-        "@percy/logger": "1.0.0-beta.65"
+        "@percy/config": "1.0.7",
+        "@percy/core": "1.0.7",
+        "@percy/logger": "1.0.7"
       },
       "dependencies": {
         "@percy/logger": {
-          "version": "1.0.0-beta.65",
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.7.tgz",
+          "integrity": "sha512-pYW6i0/M9h2PMDGiAYpRzWBt2DMyafsF6fNnIlNGOukQKlqlcae4dxPQFq6Mu3tVv3JMUfIx9h2lew5WquF95g==",
           "dev": true
         }
       }
     },
     "@percy/cli-config": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.0.7.tgz",
+      "integrity": "sha512-vUgabFFMXf4Con78wUxSRPnRRFbEGE+yAA0qoBaTe75m6C+kQSq0NjxmHwrhfrHcJSVA/s1dip7LqQPVf/X/wA==",
       "dev": true,
       "requires": {
-        "@oclif/command": "^1.8.0",
-        "@oclif/config": "^1.17.0",
-        "@percy/config": "1.0.0-beta.65",
-        "@percy/logger": "1.0.0-beta.65"
-      },
-      "dependencies": {
-        "@percy/logger": {
-          "version": "1.0.0-beta.65",
-          "dev": true
-        }
+        "@percy/cli-command": "1.0.7"
       }
     },
     "@percy/cli-exec": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.0.7.tgz",
+      "integrity": "sha512-y2Jk8375ntbkxUWLSF+08gfA04ACJ1lDwiQFxUoWrJBVN1nK/Lh41YOyZfMWxFjIO1B7tN49CoHtKdcBLWHRSA==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.0.0-beta.65",
-        "@percy/core": "1.0.0-beta.65",
-        "@percy/logger": "1.0.0-beta.65",
+        "@percy/cli-command": "1.0.7",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
-      },
-      "dependencies": {
-        "@percy/logger": {
-          "version": "1.0.0-beta.65",
-          "dev": true
-        }
       }
     },
     "@percy/cli-snapshot": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.0.7.tgz",
+      "integrity": "sha512-W/4dOYohrsHab/H7PrsNObUA+1nJPxlQEmzKrRy6Yj58zEwK9lP6WFAIQK9n2HbEioNy1PUvdLXb+SIQX/ofUg==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.0.0-beta.65",
-        "@percy/config": "1.0.0-beta.65",
-        "@percy/core": "1.0.0-beta.65",
-        "@percy/dom": "1.0.0-beta.65",
-        "@percy/logger": "1.0.0-beta.65",
-        "globby": "^11.0.4",
-        "path-to-regexp": "^6.2.0",
-        "picomatch": "^2.3.0",
-        "serve-handler": "^6.1.3",
-        "yaml": "^1.10.0"
+        "@percy/cli-command": "1.0.7",
+        "yaml": "^2.0.0"
       },
       "dependencies": {
-        "@percy/logger": {
-          "version": "1.0.0-beta.65",
+        "yaml": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0.tgz",
+          "integrity": "sha512-JbfdlHKGP2Ik9IHylzWlGd4pPK++EU46/IxMykphS2ZKw7a7h+dHNmcXObLgpRDriBY+rpWslldikckX8oruWQ==",
           "dev": true
         }
       }
     },
     "@percy/cli-upload": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.0.7.tgz",
+      "integrity": "sha512-AfahrDw8dQfa+Fi+OmXddEHGxTD5OZQTDCetOZqtpHl83pRabmeoSFMiqXt9QPMwkN8KE7294YHT4I80YjHzaQ==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.0.0-beta.65",
-        "@percy/client": "1.0.0-beta.65",
-        "@percy/config": "1.0.0-beta.65",
-        "@percy/logger": "1.0.0-beta.65",
-        "globby": "^11.0.4",
+        "@percy/cli-command": "1.0.7",
+        "fast-glob": "^3.2.11",
         "image-size": "^1.0.0"
-      },
-      "dependencies": {
-        "@percy/logger": {
-          "version": "1.0.0-beta.65",
-          "dev": true
-        }
       }
     },
     "@percy/client": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.0.7.tgz",
+      "integrity": "sha512-8mCZsxBsc/Spw01tlySzDSBSDrPys8DIYvU8vnQekWafQh5pu01CeiC7wMNlNucLR/6OmQzaaY0fC8YM5tkMYw==",
       "dev": true,
       "requires": {
-        "@percy/env": "1.0.0-beta.65",
-        "@percy/logger": "1.0.0-beta.65"
+        "@percy/env": "1.0.7",
+        "@percy/logger": "1.0.7"
       },
       "dependencies": {
         "@percy/logger": {
-          "version": "1.0.0-beta.65",
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.7.tgz",
+          "integrity": "sha512-pYW6i0/M9h2PMDGiAYpRzWBt2DMyafsF6fNnIlNGOukQKlqlcae4dxPQFq6Mu3tVv3JMUfIx9h2lew5WquF95g==",
           "dev": true
         }
       }
     },
     "@percy/config": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.0.7.tgz",
+      "integrity": "sha512-aR4RGf36AipFhoieoSmpP8Uv/kRLZuMvhY6/8LxsIr2UsQysikh+YQDv4BfUxeTgeO+9eTlXZsCav3uDUqI/wQ==",
       "dev": true,
       "requires": {
-        "@percy/logger": "1.0.0-beta.65",
+        "@percy/logger": "1.0.7",
         "ajv": "^8.6.2",
         "cosmiconfig": "^7.0.0",
-        "yaml": "^1.10.0"
+        "yaml": "^2.0.0"
       },
       "dependencies": {
         "@percy/logger": {
-          "version": "1.0.0-beta.65",
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.7.tgz",
+          "integrity": "sha512-pYW6i0/M9h2PMDGiAYpRzWBt2DMyafsF6fNnIlNGOukQKlqlcae4dxPQFq6Mu3tVv3JMUfIx9h2lew5WquF95g==",
           "dev": true
         },
         "ajv": {
-          "version": "8.6.2",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -25640,7 +24993,9 @@
           }
         },
         "cosmiconfig": {
-          "version": "7.0.0",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+          "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
           "dev": true,
           "requires": {
             "@types/parse-json": "^4.0.0",
@@ -25648,10 +25003,20 @@
             "parse-json": "^5.0.0",
             "path-type": "^4.0.0",
             "yaml": "^1.10.0"
+          },
+          "dependencies": {
+            "yaml": {
+              "version": "1.10.2",
+              "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+              "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+              "dev": true
+            }
           }
         },
         "import-fresh": {
           "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
           "dev": true,
           "requires": {
             "parent-module": "^1.0.0",
@@ -25660,10 +25025,14 @@
         },
         "json-schema-traverse": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
         },
         "parse-json": {
           "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
@@ -25674,41 +25043,64 @@
         },
         "resolve-from": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        },
+        "yaml": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0.tgz",
+          "integrity": "sha512-JbfdlHKGP2Ik9IHylzWlGd4pPK++EU46/IxMykphS2ZKw7a7h+dHNmcXObLgpRDriBY+rpWslldikckX8oruWQ==",
           "dev": true
         }
       }
     },
     "@percy/core": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.0.7.tgz",
+      "integrity": "sha512-hyNsvGqL15nV5JhUGdHrX8v+3Og2yfNhBqBxg+0KC7PNPnRxXxezWjyjglzk8MRspi0MpUujjGKzZTVTItg3XA==",
       "dev": true,
       "requires": {
-        "@percy/client": "1.0.0-beta.65",
-        "@percy/config": "1.0.0-beta.65",
-        "@percy/dom": "1.0.0-beta.65",
-        "@percy/logger": "1.0.0-beta.65",
+        "@percy/client": "1.0.7",
+        "@percy/config": "1.0.7",
+        "@percy/dom": "1.0.7",
+        "@percy/logger": "1.0.7",
+        "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
+        "fast-glob": "^3.2.11",
+        "micromatch": "^4.0.4",
+        "mime-types": "^2.1.34",
+        "path-to-regexp": "^6.2.0",
         "rimraf": "^3.0.2",
         "ws": "^8.0.0"
       },
       "dependencies": {
         "@percy/logger": {
-          "version": "1.0.0-beta.65",
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.7.tgz",
+          "integrity": "sha512-pYW6i0/M9h2PMDGiAYpRzWBt2DMyafsF6fNnIlNGOukQKlqlcae4dxPQFq6Mu3tVv3JMUfIx9h2lew5WquF95g==",
           "dev": true
         },
         "ws": {
-          "version": "8.1.0",
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
           "dev": true,
           "requires": {}
         }
       }
     },
     "@percy/dom": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.0.7.tgz",
+      "integrity": "sha512-9NZD6RSHhHX2BZIoJHyXMPOL5afSHJUl+o+wBIorwad2jevr+DYGMXrn6Fz+IdI7677JP3BuTNu3xpuf+ivNFg==",
       "dev": true
     },
     "@percy/env": {
-      "version": "1.0.0-beta.65",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.0.7.tgz",
+      "integrity": "sha512-TK7Q3KGReDt5AiLk4fPK81mKrXAIVHgevzvSw7NN2l3aw1uot8vBOUBjwOJQKyJkqblvdxywmMkErhcu95/IAw==",
       "dev": true
     },
     "@percy/logger": {
@@ -27476,19 +26868,6 @@
         }
       }
     },
-    "clean-stack": {
-      "version": "3.0.1",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "4.0.0"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "dev": true
-        }
-      }
-    },
     "cli-spinners": {
       "version": "2.5.0",
       "dev": true
@@ -27637,6 +27016,23 @@
       "dev": true,
       "requires": {
         "bluebird": "^3.1.1"
+      }
+    },
+    "content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.2.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
       }
     },
     "content-type": {
@@ -29509,15 +28905,15 @@
       "version": "3.1.3"
     },
     "fast-glob": {
-      "version": "3.2.4",
-      "dev": true,
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.0",
+        "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.2",
-        "picomatch": "^2.2.1"
+        "micromatch": "^4.0.4"
       }
     },
     "fast-json-stable-stringify": {
@@ -29527,19 +28923,6 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "dev": true
-    },
-    "fast-url-parser": {
-      "version": "1.1.3",
-      "dev": true,
-      "requires": {
-        "punycode": "^1.3.2"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "dev": true
-        }
-      }
     },
     "fastest-levenshtein": {
       "version": "1.0.12"
@@ -30416,20 +29799,6 @@
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "fast-glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-          "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-          "requires": {
-            "@nodelib/fs.stat": "^2.0.2",
-            "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.2",
-            "merge2": "^1.3.0",
-            "micromatch": "^4.0.4"
-          }
-        }
       }
     },
     "globjoin": {
@@ -31170,7 +30539,9 @@
       "dev": true
     },
     "image-size": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.1.tgz",
+      "integrity": "sha512-VAwkvNSNGClRw9mDHhc5Efax8PLlsOGcUTh0T/LIriC8vPA3U5PdqXWqkz406MoYHMKW8Uf9gWr05T/rYB44kQ==",
       "dev": true,
       "requires": {
         "queue": "6.0.2"
@@ -31613,13 +30984,6 @@
     "is-windows": {
       "version": "1.0.2",
       "dev": true
-    },
-    "is-wsl": {
-      "version": "2.2.0",
-      "dev": true,
-      "requires": {
-        "is-docker": "^2.0.0"
-      }
     },
     "isarray": {
       "version": "1.0.0"
@@ -33854,14 +33218,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.44.0",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.27",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {
@@ -34689,6 +34057,8 @@
     },
     "path-to-regexp": {
       "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
+      "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==",
       "dev": true
     },
     "path-type": {
@@ -35386,6 +34756,8 @@
     },
     "queue": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
       "dev": true,
       "requires": {
         "inherits": "~2.0.3"
@@ -36290,49 +35662,6 @@
         "sver-compat": "^1.5.0"
       }
     },
-    "serve-handler": {
-      "version": "6.1.3",
-      "dev": true,
-      "requires": {
-        "bytes": "3.0.0",
-        "content-disposition": "0.5.2",
-        "fast-url-parser": "1.1.3",
-        "mime-types": "2.1.18",
-        "minimatch": "3.0.4",
-        "path-is-inside": "1.0.2",
-        "path-to-regexp": "2.2.1",
-        "range-parser": "1.2.0"
-      },
-      "dependencies": {
-        "bytes": {
-          "version": "3.0.0",
-          "dev": true
-        },
-        "content-disposition": {
-          "version": "0.5.2",
-          "dev": true
-        },
-        "mime-db": {
-          "version": "1.33.0",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.18",
-          "dev": true,
-          "requires": {
-            "mime-db": "~1.33.0"
-          }
-        },
-        "path-to-regexp": {
-          "version": "2.2.1",
-          "dev": true
-        },
-        "range-parser": {
-          "version": "1.2.0",
-          "dev": true
-        }
-      }
-    },
     "set-blocking": {
       "version": "2.0.0",
       "dev": true
@@ -37037,18 +36366,6 @@
           "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
             "ms": "2.1.2"
-          }
-        },
-        "fast-glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-          "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-          "requires": {
-            "@nodelib/fs.stat": "^2.0.2",
-            "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.2",
-            "merge2": "^1.3.0",
-            "micromatch": "^4.0.4"
           }
         },
         "get-stdin": {
@@ -38308,10 +37625,6 @@
         }
       }
     },
-    "tslib": {
-      "version": "2.3.1",
-      "dev": true
-    },
     "tunnel-agent": {
       "version": "0.6.0",
       "dev": true,
@@ -38905,40 +38218,6 @@
     },
     "wordwrap": {
       "version": "1.0.0"
-    },
-    "wrap-ansi": {
-      "version": "4.0.0",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
     },
     "wrappy": {
       "version": "1.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@rollup/plugin-json": "^4.1.0",
         "@size-limit/file": "^4.9.0",
         "@types/jest": "^24.0.15",
+        "@types/serve-handler": "^6.1.1",
         "autoprefixer": "^10.4.4",
         "cross-env": "^7.0.3",
         "cssnano": "^5.1.4",
@@ -3994,6 +3995,15 @@
       "version": "0.0.8",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-handler": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/serve-handler/-/serve-handler-6.1.1.tgz",
+      "integrity": "sha512-bIwSmD+OV8w0t2e7EWsuQYlGoS1o5aEdVktgkXaa43Zm0qVWi21xaSRb3DQA1UXD+DJ5bRq1Rgu14ZczB+CjIQ==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -25290,6 +25300,15 @@
     },
     "@types/resolve": {
       "version": "0.0.8",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/serve-handler": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/serve-handler/-/serve-handler-6.1.1.tgz",
+      "integrity": "sha512-bIwSmD+OV8w0t2e7EWsuQYlGoS1o5aEdVktgkXaa43Zm0qVWi21xaSRb3DQA1UXD+DJ5bRq1Rgu14ZczB+CjIQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@rollup/plugin-json": "^4.1.0",
     "@size-limit/file": "^4.9.0",
     "@types/jest": "^24.0.15",
-    "@types/serve-handler": "^6.1.1",
     "autoprefixer": "^10.4.4",
     "cross-env": "^7.0.3",
     "cssnano": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@babel/plugin-transform-runtime": "^7.9.0",
     "@babel/preset-env": "^7.13.10",
     "@babel/runtime-corejs3": "^7.13.10",
-    "@percy/cli": "^1.0.0-beta.60",
+    "@percy/cli": "^1.0.7",
     "@percy/puppeteer": "^2.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@size-limit/file": "^4.9.0",
@@ -173,7 +173,7 @@
   "author": "Yext",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "exports": {
     "./css": "./dist/answers.css",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "rollup-plugin-node-resolve": "^4.0.1",
     "rollup-plugin-svg": "^2.0.0",
     "sass": "^1.34.0",
+    "serve-handler": "^6.1.3",
     "size-limit": "^4.9.0",
     "stylelint": "^14.5.3",
     "stylelint-config-standard-scss": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@rollup/plugin-json": "^4.1.0",
     "@size-limit/file": "^4.9.0",
     "@types/jest": "^24.0.15",
+    "@types/serve-handler": "^6.1.1",
     "autoprefixer": "^10.4.4",
     "cross-env": "^7.0.3",
     "cssnano": "^5.1.4",


### PR DESCRIPTION
This PR upgrades the @percy/cli version from a beta version to the latest (v1.0.7).

NOTE: There were 2 breaking changes:
- Node versions older than node 14 are no longer supported. So, running `npm ci` using node 12 on the SDK would now break
- They moved packages to ESM, so a package (`serve-handler`) needed to be added as a `devDependency` for it's `require` statement in `snapshots.js` to work

J=SLAP-2045
TEST=manual

Checked that the Percy snapshots are still generated correctly.