### PR TITLE
remove unused verticalKey config from Facets + FilterBox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1346,8 +1346,6 @@ ANSWERS.addComponent('FilterBox', {
       ]
     }
   ],
-  // Required, the vertical key for the search, default null
-  verticalKey: 'verticalKey',
   // Optional, title to display above the filter
   title: 'Filters',
   // Optional, show number of results for each filter
@@ -1395,8 +1393,6 @@ The Facets component displays filters relevant to the current search, configured
 ANSWERS.addComponent('Facets', {
   // Required, the selector for the container element where the component will be injected
   container: '.facets-container',
-  // Required
-  verticalKey: '<VERTICAL_KEY>',
   // Optional, title to display above the facets
   title: 'Filters',
   // Optional, show number of results for each facet

--- a/conf/i18n/translations/messages.pot
+++ b/conf/i18n/translations/messages.pot
@@ -474,12 +474,12 @@ msgctxt "Title of section"
 msgid "Ask a Question"
 msgstr ""
 
-#: src/ui/components/filters/facetscomponent.js:306
+#: src/ui/components/filters/facetscomponent.js:299
 msgctxt "True or False"
 msgid "False"
 msgstr ""
 
-#: src/ui/components/filters/facetscomponent.js:303
+#: src/ui/components/filters/facetscomponent.js:296
 msgctxt "True or False"
 msgid "True"
 msgstr ""

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -187,13 +187,6 @@ export default class FacetsComponent extends Component {
     this.config = new FacetsConfig(config);
 
     /**
-     * The vertical key for the search
-     * @type {string}
-     * @private
-     */
-    this._verticalKey = config.verticalKey;
-
-    /**
      * The selector of the apply button
      * @type {string}
      * @private
@@ -355,7 +348,6 @@ export default class FacetsComponent extends Component {
         parentContainer: this._container,
         name: `${this.name}.filterbox`,
         container: '.js-yxt-Facets',
-        verticalKey: this._verticalKey,
         resetFilter: this.config.resetFacet,
         resetFilters: this.config.resetFacets,
         resetFilterLabel: this.config.resetFacetLabel,

--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -155,13 +155,6 @@ export default class FilterBoxComponent extends Component {
     }
 
     /**
-     * The vertical key for the search
-     * @type {string}
-     * @private
-     */
-    this._verticalKey = config.verticalKey || null;
-
-    /**
      * The components created for each filter config
      * @type {Component[]}
      * @private


### PR DESCRIPTION
verticalKey is not used internally by these components anywhere.

J=SLAP-2041
TEST=manual

facets + filterbox still work