### PR TITLE
fire follow_up_query analytics on tab nav

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,7 +1,7 @@
 module.exports = [
   {
     path: 'dist/answers.min.js',
-    limit: '185 KB'
+    limit: '190 KB'
   },
   {
     path: 'dist/answers-modern.min.js',

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -182,7 +182,7 @@ export default class Core {
    * @param {string} searcher - searcher type of the new query ("UNIVERSAL" or "VERTICAL")
    */
   _reportFollowUpQueryEvent (newQueryId, searcher) {
-    const previousQueryId = this.storage.get(StorageKeys.QUERY_ID);
+    const previousQueryId = this._analyticsReporter.getQueryId();
     if (previousQueryId && previousQueryId !== newQueryId) {
       const event = new AnalyticsEvent('FOLLOW_UP_QUERY').addOptions({ searcher });
       this._analyticsReporter.report(event);


### PR DESCRIPTION
This pr adds support for firing FOLLOW_UP_QUERY event when user perform a search and proceed to click or hit enter on a tab in the navigation bar. Here, I assume the expected behavior of tab navigation of SDK to a relative url path is that it always fire a new search. If an absolute url path is provided for the tab, the origin of the tab url must be the same as the current page url to fire a FOLLOW_UP_QUERY.

Alternatively, we could include queryId to the url when navigate to new page/tab. The page after navigation would extract the previous queryId from the url if there's a new search fired. This would be more accurate since we would know for sure if a new search is actually fired from a new Answers instance on the new page/tab. However, this required adding new param to the browser url, I opted not to do this approach.

J=SLAP-2054
TEST=manual

navigate between tabs in theme, see that FOLLOW_UP_QUERY event is fired for all/vertical tab navigation.
tested similar behavior in ios and android chrome browser