### PR TITLE
Use reusable workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,23 +9,9 @@ on:
   pull_request:
 
 jobs:
-  Coveralls:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [16.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npx gulp templates
-    - run: npx jest --coverage
-    - name: Coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+  call_coveralls:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/coverage.yml@v1
+    with:
+      test_script: npx gulp templates && npx jest --coverage
+    secrets:
+      caller_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/percy_snapshots.yml
+++ b/.github/workflows/percy_snapshots.yml
@@ -6,25 +6,10 @@ on:
   pull_request:
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [16.x]
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npm run build
-    - name: Percy Snapshots
-      run: npx percy exec -- node tests/acceptance/percy/snapshots.js
-      env:
-        PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+  call_percy_snapshots:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/percy_snapshots.yml@v1
+    with:
+      snapshots_script_path: tests/acceptance/percy/snapshots.js
+      fetch_depth: 0
+    secrets:
+      PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.github/workflows/sync_develop_and_main.yml
+++ b/.github/workflows/sync_develop_and_main.yml
@@ -1,27 +1,11 @@
-name: create PR from main to develop
+name: Create PR from main to develop
 
 on:
   push:
     branches: [main, master]
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
-  createPullRequest:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: extract package version
-        id: vars
-        run: |
-          PACKAGE_VERSION="v$(cat ./package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')"
-          echo ::set-output name=tag::${PACKAGE_VERSION}
-      - uses: repo-sync/pull-request@v2
-        with:
-          source_branch: "${{ github.event.repository.default_branch }}"
-          destination_branch: "develop"
-          pr_title: "Merge ${{ github.event.repository.default_branch }} (${{ steps.vars.outputs.tag }}) into develop"
-          pr_body: "Merge ${{ github.event.repository.default_branch }} (${{ steps.vars.outputs.tag }}) into develop"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+  call_sync_develop_and_main:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/sync_develop_and_main.yml@v1
+    secrets:
+      caller_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/third_party_notices_check.yml
+++ b/.github/workflows/third_party_notices_check.yml
@@ -3,19 +3,5 @@ name: Check Third Party Notices File
 on: pull_request
 
 jobs:
-  license-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 16.x
-      - uses: actions/checkout@v2
-      - run: npm ci
-      - run: npm run generate-notices
-      - name: Update THIRD-PARTY-NOTICES
-        uses: EndBug/add-and-commit@v7
-        with:
-          message: "Automated update to THIRD-PARTY-NOTICES from github action's 3rd party notices check"
-          add: 'THIRD-PARTY-NOTICES'
-          push: true
-          default_author: github_actions
+  call_notices_check:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/third_party_notices_check.yml@v1

--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -4,49 +4,8 @@ on:
   push:
     branches: [release/*, hotfix/*]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
-  update-version:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-      - name: update package version
-        id: vars
-        run: |
-          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
-          PACKAGE_VERSION="${GITHUB_REF##*/}"
-          echo ::set-output name=branch::${BRANCH_NAME}
-          if [[ $PACKAGE_VERSION =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]
-          then
-            if [[ $PACKAGE_VERSION =~ ^v[0-9]+\.[0-9]+$ ]]
-            then
-              PACKAGE_VERSION="${PACKAGE_VERSION}.0"
-            fi
-            echo ::set-output name=version::${PACKAGE_VERSION}
-            git config user.name 'github-actions[bot]'
-            git config user.email 'github-actions[bot]@users.noreply.github.com'
-            if npm version ${PACKAGE_VERSION} | tee >( grep -q 'npm ERR! Version not changed' )
-            then
-              echo "Package version is already in sync with branch name."
-              echo ::set-output name=should_create_pr::0
-              exit 0
-            fi
-            echo ::set-output name=should_create_pr::1
-            git push -u origin HEAD:"dev/update-version-${PACKAGE_VERSION}"
-          else
-            echo "Branch name ${BRANCH_NAME} does not have the correct format with package version."
-            exit 1
-          fi
-      - name: create version update pr
-        if: steps.vars.outputs.should_create_pr == 1
-        uses: repo-sync/pull-request@v2
-        with:
-          source_branch: "dev/update-version-${{ steps.vars.outputs.version }}"
-          destination_branch: "${{ steps.vars.outputs.branch }}"
-          pr_title: "Update Package Version to ${{ steps.vars.outputs.version }}"
-          pr_body: "*An automated PR which updates the version number in package.json and package-lock.json files*"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+  call_version_update:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/version_update.yml@v1
+    secrets:
+      caller_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wcag_test.yml
+++ b/.github/workflows/wcag_test.yml
@@ -5,21 +5,7 @@ on:
     branches: [develop, hotfix/*, release/*, support/*]
 
 jobs:
-  WCAG-test:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [16.x]
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npm run build
-    - run: npm run wcag
+  call_wcag_test:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/wcag_test.yml@v1
+    with:
+      fetch_depth: 0


### PR DESCRIPTION
Update the github workflows to use the callable workflows in the `slapshot-reusable-workflows` repo.

J=SLAP-2005
TEST=auto

- See that the `coverage`, `percy_snapshots`, `third_party_notices_check`, and `wcag_test` workflows run on this PR as expected.
- Test on another branch (`dev/test-reusable-workflows`) and see that notices are updated when needed.
- Fork the repo and commit to master. See that the `sync_develop_and_main` workflow creates a PR as expected. Push to a hotfix branch and see that the `version-update` workflow creates a PR only when the package version doesn't match the branch