### PR TITLE
FOLLOW_UP_QUERY event for tab navigation and refresh

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,7 +1,7 @@
 module.exports = [
   {
     path: 'dist/answers.min.js',
-    limit: '185 KB'
+    limit: '190 KB'
   },
   {
     path: 'dist/answers-modern.min.js',

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -195,9 +195,13 @@ class Answers {
      * search on load.
      */
     const searchParams = new SearchParams(window.location.search);
+    console.log('searchParams', searchParams);
     if (searchParams.has(StorageKeys.QUERY_ID)) {
       const isPageReload = window.performance.getEntriesByType('navigation')?.[0]?.type === 'reload';
+      console.log('isPageReload', isPageReload);
+      console.log('document.referrer', document.referrer);
       if (!document.referrer && !isPageReload) {
+        console.log('delete QUERY_ID');
         searchParams.delete(StorageKeys.QUERY_ID);
       }
     }

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -195,13 +195,9 @@ class Answers {
      * search on load.
      */
     const searchParams = new SearchParams(window.location.search);
-    console.log('searchParams', searchParams);
     if (searchParams.has(StorageKeys.QUERY_ID)) {
       const isPageReload = window.performance.getEntriesByType('navigation')?.[0]?.type === 'reload';
-      console.log('isPageReload', isPageReload);
-      console.log('document.referrer', document.referrer);
       if (!document.referrer && !isPageReload) {
-        console.log('delete QUERY_ID');
         searchParams.delete(StorageKeys.QUERY_ID);
       }
     }

--- a/src/core/analytics/visibilityanalyticshandler.js
+++ b/src/core/analytics/visibilityanalyticshandler.js
@@ -19,8 +19,8 @@ export default class VisibilityAnalyticsHandler {
   initVisibilityChangeListeners () {
     /**
      * Safari desktop listener and IE11 listeners fire visibility change event twice when switch
-     * to new tab and then close browser. This variable is used to ensure RESULTS_HIDDEN analytics event
-     * does not get send again if the page is already hidden.
+     * to new tab and then close browser. _documentVisibilityState is used to ensure RESULTS_HIDDEN
+     * analytics event does not get send again if the page is already hidden.
      */
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'hidden' && this._documentVisibilityState !== 'hidden') {

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -281,7 +281,6 @@ export default class Core {
         this._persistLocationRadius();
         this._reportFollowUpQueryEvent(data[StorageKeys.QUERY_ID], Searcher.VERTICAL);
 
-        console.log('queryId from search', data[StorageKeys.QUERY_ID]);
         this.storage.setWithPersist(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
         this.storage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
         this.storage.set(StorageKeys.ALTERNATIVE_VERTICALS, data[StorageKeys.ALTERNATIVE_VERTICALS]);
@@ -333,7 +332,6 @@ export default class Core {
 
   clearResults () {
     this.storage.set(StorageKeys.QUERY, null);
-    console.log('queryId from clear results', '');
     this.storage.setWithPersist(StorageKeys.QUERY_ID, '');
     this.storage.set(StorageKeys.RESULTS_HEADER, {});
     this.storage.set(StorageKeys.SPELL_CHECK, {}); // TODO has a model but not cleared w new
@@ -399,7 +397,6 @@ export default class Core {
       .then(response => SearchDataTransformer.transformUniversal(response, urls, this._fieldFormatters))
       .then(data => {
         this._reportFollowUpQueryEvent(data[StorageKeys.QUERY_ID], Searcher.UNIVERSAL);
-        console.log('queryId from search', data[StorageKeys.QUERY_ID]);
         this.storage.setWithPersist(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
         this.storage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
         this.storage.set(StorageKeys.DIRECT_ANSWER, data[StorageKeys.DIRECT_ANSWER]);
@@ -728,7 +725,6 @@ export default class Core {
       QueryTriggers.SUGGEST,
       QueryTriggers.QUERY_PARAMETER
     ];
-    console.log('queryTrigger', queryTrigger);
     if (replaceStateTriggers.includes(queryTrigger)) {
       this.storage.replaceHistoryWithState();
     } else {

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -184,6 +184,7 @@ export default class Core {
   _reportFollowUpQueryEvent (newQueryId, searcher) {
     const previousQueryId = this.storage.get(StorageKeys.QUERY_ID);
     if (previousQueryId && previousQueryId !== newQueryId) {
+      this._analyticsReporter.setQueryId(previousQueryId);
       const event = new AnalyticsEvent('FOLLOW_UP_QUERY').addOptions({ searcher });
       this._analyticsReporter.report(event);
     }
@@ -280,7 +281,8 @@ export default class Core {
         this._persistLocationRadius();
         this._reportFollowUpQueryEvent(data[StorageKeys.QUERY_ID], Searcher.VERTICAL);
 
-        this.storage.set(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
+        console.log('queryId from search', data[StorageKeys.QUERY_ID]);
+        this.storage.setWithPersist(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
         this.storage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
         this.storage.set(StorageKeys.ALTERNATIVE_VERTICALS, data[StorageKeys.ALTERNATIVE_VERTICALS]);
 
@@ -331,7 +333,8 @@ export default class Core {
 
   clearResults () {
     this.storage.set(StorageKeys.QUERY, null);
-    this.storage.set(StorageKeys.QUERY_ID, '');
+    console.log('queryId from clear results', '');
+    this.storage.setWithPersist(StorageKeys.QUERY_ID, '');
     this.storage.set(StorageKeys.RESULTS_HEADER, {});
     this.storage.set(StorageKeys.SPELL_CHECK, {}); // TODO has a model but not cleared w new
     this.storage.set(StorageKeys.DYNAMIC_FILTERS, {}); // TODO has a model but not cleared w new
@@ -396,7 +399,8 @@ export default class Core {
       .then(response => SearchDataTransformer.transformUniversal(response, urls, this._fieldFormatters))
       .then(data => {
         this._reportFollowUpQueryEvent(data[StorageKeys.QUERY_ID], Searcher.UNIVERSAL);
-        this.storage.set(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
+        console.log('queryId from search', data[StorageKeys.QUERY_ID]);
+        this.storage.setWithPersist(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
         this.storage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
         this.storage.set(StorageKeys.DIRECT_ANSWER, data[StorageKeys.DIRECT_ANSWER]);
         this.storage.set(StorageKeys.UNIVERSAL_RESULTS, data[StorageKeys.UNIVERSAL_RESULTS]);
@@ -594,7 +598,7 @@ export default class Core {
    * @param {string} queryId The query id to store
    */
   setQueryId (queryId) {
-    this.storage.set(StorageKeys.QUERY_ID, queryId);
+    this.storage.setWithPersist(StorageKeys.QUERY_ID, queryId);
   }
 
   triggerSearch (queryTrigger, newQuery) {
@@ -724,6 +728,7 @@ export default class Core {
       QueryTriggers.SUGGEST,
       QueryTriggers.QUERY_PARAMETER
     ];
+    console.log('queryTrigger', queryTrigger);
     if (replaceStateTriggers.includes(queryTrigger)) {
       this.storage.replaceHistoryWithState();
     } else {


### PR DESCRIPTION
This pr add support to fire `FOLLOW_UP_QUERY` analytics event when user perform a search and then click on tab navigation OR refresh the page.
- `FOLLOW_UP_QUERY` analytics event requires the previous query id in is payload. To have the previous query id persist during page navigation/refresh, the id is store as a new param in the URL using the logic of persistentStorage already use in the SDK every time a search is made and a new id is generated. 
- With this approach, there could be a case of user copying a link with query and query-id in the url to a new tab, in which an initial search is performed and a follow_up_query event is fired even though there's only one actual search. To prevent this, query-id param is deleted on load IF the page navigation is not because of a href link click (check through document.referrer) OR if it's not a page refresh (check using PerformanceNavigationTiming API)
 
J=SLAP-2054 & SLAP-2055
TEST=manual

Attempted to test through localhost with theme site, there were issues with .html extensions that cut off the search param during href navigation (localhost:5042/jobs?query=test would preserve the search params BUT localhost:5042/jobs.**html**?query=test navigates to localhost:5042/jobs.html)
Instead, tested with other approaches:
- [serve theme site in storm](https://devtestfollowupquery-theme-slapshot-pagescdn-com.preview.pagescdn.com/?query=virginia&referrerPageUrl=&query-id=01806ba7-670a-a7f9-9e7c-375566d79940) through a dev branch that points to this SDK dev branch.
  - site performed a search onload by default. See that the query-id appears in the URL. I clicked on a vertical tab, which triggers another search onload. See that the query-id updates according to the new search and a `FOLLOW_UP_QUERY` event is fired with the old query-id in its payload.
  - refresh the page after the site performed a search. See that query-id updates accordingly and a `FOLLOW_UP_QUERY` event is fired with the old query-id in its payload.
  - Copy link with query-id to another tab. see that no `FOLLOW_UP_QUERY` was fired from initial search. smoke test in different browsers (desktop chrome, firefox, safari, ie; mobile ios safari, android chrome)
 
 This also work when tested with `python -m SimpleHttpServer 5042` instead of `npm run serve-test-site` in theme