### PR TITLE
handle "navigate away" use cases for RESULTS_HIDDEN

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -160,6 +160,9 @@ class Answers {
         this.core.storage.delete(StorageKeys.SORT_BYS);
         this.core.filterRegistry.clearAllFilterNodes();
 
+        const queryId = this.core.storage.get(StorageKeys.QUERY_ID);
+        data.set('pop-state-queryId', queryId);
+
         if (!hasQuery) {
           this.core.clearResults();
         } else {
@@ -274,7 +277,7 @@ class Answers {
         this._analyticsReporterService,
         parsedConfig.search?.verticalKey
       );
-      visibilityAnalyticsHandler.initVisibilityChangeListeners();
+      visibilityAnalyticsHandler.initVisibilityChangeListeners(storage);
     }
 
     this.core = new Core({

--- a/src/core/analytics/visibilityanalyticshandler.js
+++ b/src/core/analytics/visibilityanalyticshandler.js
@@ -60,9 +60,11 @@ export default class VisibilityAnalyticsHandler {
      */
     window.addEventListener('popstate', () => {
       const poppedStateQueryId = storage.get(StorageKeys.HISTORY_POP_STATE)?.get('pop-state-queryId');
+      const storageQueryId = this._analyticsReporterService.getQueryId();
       this._analyticsReporterService.setQueryId(poppedStateQueryId);
       this._previousResultsVisibilityEvent = RESULTS_VISIBILITY_EVENT.HIDDEN;
       this._reportVisibilityChangeEvent(RESULTS_VISIBILITY_EVENT.HIDDEN);
+      this._analyticsReporterService.setQueryId(storageQueryId);
     });
 
     storage.registerListener({

--- a/src/core/analytics/visibilityanalyticshandler.js
+++ b/src/core/analytics/visibilityanalyticshandler.js
@@ -21,6 +21,8 @@ export default class VisibilityAnalyticsHandler {
   /**
    * Initialize visibility change event listener(s) to send analytics events
    * when a result page have become visible or have been hidden.
+   *
+   * @param {Storage} storage - a container around application state
    */
   initVisibilityChangeListeners (storage) {
     /**
@@ -77,6 +79,8 @@ export default class VisibilityAnalyticsHandler {
 
   /**
    * Send visibility change related analytics event.
+   *
+   * @param {string} eventName - the name of the analytics event to report
    */
   _reportVisibilityChangeEvent (eventName) {
     const queryId = this._analyticsReporterService.getQueryId();

--- a/src/core/analytics/visibilityanalyticshandler.js
+++ b/src/core/analytics/visibilityanalyticshandler.js
@@ -69,7 +69,7 @@ export default class VisibilityAnalyticsHandler {
       eventType: 'update',
       storageKey: StorageKeys.QUERY_ID,
       callback: id => {
-        if (this._previousResultsVisibilityEvent !== RESULTS_VISIBILITY_EVENT.UNHIDDEN) {
+        if (document.visibilityState === 'visible' && this._previousResultsVisibilityEvent !== RESULTS_VISIBILITY_EVENT.UNHIDDEN) {
           this._previousResultsVisibilityEvent = RESULTS_VISIBILITY_EVENT.UNHIDDEN;
           this._reportVisibilityChangeEvent(RESULTS_VISIBILITY_EVENT.UNHIDDEN);
         }

--- a/src/core/analytics/visibilityanalyticshandler.js
+++ b/src/core/analytics/visibilityanalyticshandler.js
@@ -31,10 +31,10 @@ export default class VisibilityAnalyticsHandler {
      * RESULTS_HIDDEN analytics event does not get send again if the page is already hidden.
      */
     document.addEventListener('visibilitychange', () => {
-      if (document.visibilityState === 'hidden' && this._previousResultsVisibilityEvent !== RESULTS_VISIBILITY_EVENT.HIDDEN) {
+      if (this._resultsVisibilityChangeToHidden()) {
         this._previousResultsVisibilityEvent = RESULTS_VISIBILITY_EVENT.HIDDEN;
         this._reportVisibilityChangeEvent(RESULTS_VISIBILITY_EVENT.HIDDEN);
-      } else if (document.visibilityState === 'visible' && this._previousResultsVisibilityEvent !== RESULTS_VISIBILITY_EVENT.UNHIDDEN) {
+      } else if (this._resultsVisibilityChangeToVisible()) {
         this._previousResultsVisibilityEvent = RESULTS_VISIBILITY_EVENT.UNHIDDEN;
         this._reportVisibilityChangeEvent(RESULTS_VISIBILITY_EVENT.UNHIDDEN);
       }
@@ -71,12 +71,26 @@ export default class VisibilityAnalyticsHandler {
       eventType: 'update',
       storageKey: StorageKeys.QUERY_ID,
       callback: id => {
-        if (document.visibilityState === 'visible' && this._previousResultsVisibilityEvent !== RESULTS_VISIBILITY_EVENT.UNHIDDEN) {
+        if (this._resultsVisibilityChangeToVisible()) {
           this._previousResultsVisibilityEvent = RESULTS_VISIBILITY_EVENT.UNHIDDEN;
           this._reportVisibilityChangeEvent(RESULTS_VISIBILITY_EVENT.UNHIDDEN);
         }
       }
     });
+  }
+
+  /**
+   * Returns true if results page was previously reported as unhidden and the page is now hidden.
+   */
+  _resultsVisibilityChangeToHidden () {
+    return document.visibilityState === 'hidden' && this._previousResultsVisibilityEvent !== RESULTS_VISIBILITY_EVENT.HIDDEN;
+  }
+
+  /**
+   * Returns true if results page was previously reported as hidden and the page is now visible.
+   */
+  _resultsVisibilityChangeToVisible () {
+    return document.visibilityState === 'visible' && this._previousResultsVisibilityEvent !== RESULTS_VISIBILITY_EVENT.UNHIDDEN;
   }
 
   /**

--- a/src/core/analytics/visibilityanalyticshandler.js
+++ b/src/core/analytics/visibilityanalyticshandler.js
@@ -51,10 +51,10 @@ export default class VisibilityAnalyticsHandler {
     }
 
     /**
-     * Use popstate event and storage listener on QUERY_ID to report result visibility change events
-     * for back/forward page navigation of the same answers page, since page history updates caused
-     * by pushState() or replaceState(), such as when a search is performed, will not trigger a page
-     * load, meaning the document's visibility state will not change.
+     * Page history updates caused by pushState() or replaceState(), such as when a search is performed,
+     * will not trigger a complete page load so the document's visibility state will not change. Use
+     * popstate event and storage listener on QUERY_ID to report result visibility change events for
+     * back/forward page navigation of the same answers page.
      */
     window.addEventListener('popstate', () => {
       const poppedStateQueryId = storage.get(StorageKeys.HISTORY_POP_STATE).get('pop-state-queryId');

--- a/src/core/analytics/visibilityanalyticshandler.js
+++ b/src/core/analytics/visibilityanalyticshandler.js
@@ -19,8 +19,8 @@ export default class VisibilityAnalyticsHandler {
   initVisibilityChangeListeners () {
     /**
      * Safari desktop listener and IE11 listeners fire visibility change event twice when switch
-     * to new tab and then close browser. This variable is used to ensure RESULTS_HIDDEN analytics event
-     * does not get send again if the page is already hidden.
+     * to new tab and then close browser. This _documentVisibilityState is used to ensure RESULTS_HIDDEN
+     * analytics event does not get send again if the page is already hidden.
      */
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'hidden' && this._documentVisibilityState !== 'hidden') {
@@ -30,6 +30,16 @@ export default class VisibilityAnalyticsHandler {
         this._documentVisibilityState = 'visible';
         this._reportVisibilityChangeEvent('RESULTS_UNHIDDEN');
       }
+    });
+
+    /**
+     * For back/forward page navigation of the same answers page with different url params, page history
+     * updates caused by push pushState() or replaceState(), such as when a search is performed, will not
+     * trigger a page load, meaning the document's visibility state will not change. So, popstate
+     * listener is used to report RESULTS_HIDDEN event for such cases.
+     */
+    window.addEventListener('popstate', () => {
+      this._reportVisibilityChangeEvent('RESULTS_HIDDEN');
     });
 
     /**

--- a/src/core/analytics/visibilityanalyticshandler.js
+++ b/src/core/analytics/visibilityanalyticshandler.js
@@ -81,6 +81,8 @@ export default class VisibilityAnalyticsHandler {
 
   /**
    * Returns true if results page was previously reported as unhidden and the page is now hidden.
+   *
+   * @returns {boolean}
    */
   _resultsVisibilityChangeToHidden () {
     return document.visibilityState === 'hidden' && this._previousResultsVisibilityEvent !== RESULTS_VISIBILITY_EVENT.HIDDEN;
@@ -88,6 +90,8 @@ export default class VisibilityAnalyticsHandler {
 
   /**
    * Returns true if results page was previously reported as hidden and the page is now visible.
+   *
+   * @returns {boolean}
    */
   _resultsVisibilityChangeToVisible () {
     return document.visibilityState === 'visible' && this._previousResultsVisibilityEvent !== RESULTS_VISIBILITY_EVENT.UNHIDDEN;

--- a/src/core/analytics/visibilityanalyticshandler.js
+++ b/src/core/analytics/visibilityanalyticshandler.js
@@ -57,7 +57,7 @@ export default class VisibilityAnalyticsHandler {
      * back/forward page navigation of the same answers page.
      */
     window.addEventListener('popstate', () => {
-      const poppedStateQueryId = storage.get(StorageKeys.HISTORY_POP_STATE).get('pop-state-queryId');
+      const poppedStateQueryId = storage.get(StorageKeys.HISTORY_POP_STATE)?.get('pop-state-queryId');
       this._analyticsReporterService.setQueryId(poppedStateQueryId);
       this._previousResultsVisibilityEvent = RESULTS_VISIBILITY_EVENT.HIDDEN;
       this._reportVisibilityChangeEvent(RESULTS_VISIBILITY_EVENT.HIDDEN);


### PR DESCRIPTION
Add support for firing results visibility events on "navigate away" use cases. The expected scenarios are:
1. Enter and navigate to a new URL.
2. Click a link that opens in the same tab.
3. Back/Forward away from the page.

Case 1 and 2 is already covered with the existing code. During testing, the analytics event does not get capture properly in the inspector network tab for Chrome and Safari (it does appear in Firefox). However, the analytics event does show up in snowflake database confirming SDK does fire visibility change analytics events on case 1 and 2.

For case 3, b/f navigation between different url origin works as expected with visibilitychange API. However, b/f navigation between different url params from the same answers page will NOT trigger visibilitychange event since [browser will not do a complete reload the page on pushState/replaceState](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState#:~:text=the%20browser%20won%27t%20attempt%20to%20load%20this%20URL%20after%20a%20call%20to%20pushState()), which we use for updating url on search. So, popState is use to capture when a page exit (RESULTS_HIDDEN) from b/f navigation. Since SDK may call 'clearResults' in `storage`'s popState listener function, queryId is stored in POP_STATE_HISTORY's data before everything is cleared so `visibilitychangehandler`'s popState can access the queryId of the popped state. A storage listener is also set on query_id to fire RESULTS_UNHIDDEN for the new page/state if the page previously fired RESULTS_HIDDEN from a popstate event.

J=SLAP-2053
TEST=manual

In network tab, open t[heme site](https://devtestresultshidden-theme-slapshot-pagescdn-com.preview.pagescdn.com/) points to this SDK branch, with no initial search on load, then ran search 'test', and 'test2'. navigate back to no search page and navigate forward to 'test2' page. See that the series of analytics event and their queryId are as expected.

navigate back 'test2' => 'test': 
 -fired `RESULTS_HIDDEN` with 'test2' queryId and `RESULTS_UNHIDDEN` with new 'test' queryid
navigate back 'test' => first page with no search: 
 -fired `RESULTS_HIDDEN` with 'test' queryId
navigate forward first page with no search => 'test': 
 -fired `RESULTS_UNHIDDEN` with new 'test' queryId
navigate forward 'test' => 'test2': 
 -fired `RESULTS_HIDDEN` with 'test' queryId and `RESULTS_UNHIDDEN` with new 'test2' queryId

Inspect in snowflake using answers key 'slanswers-test-analytics', query for user event on today's date. Smoke test navigate away cases on Desktop - Chrome, Safari, Firefox, IE, IOS - Chrome, Safari, Firefox, and Android - Chrome, Firefox.