### PR TITLE
ie11 support and relative links in constructRedirectUrl

### DIFF
--- a/src/ui/components/search/filtersearchcomponent.js
+++ b/src/ui/components/search/filtersearchcomponent.js
@@ -210,7 +210,7 @@ export default class FilterSearchComponent extends Component {
         // serialized and submitted.
         if (typeof this.redirectUrl === 'string') {
           const newRedirectUrl = constructRedirectUrl(this.redirectUrl, params);
-          window.location.href = newRedirectUrl.href;
+          window.location.href = newRedirectUrl;
           return false;
         }
 

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -520,8 +520,8 @@ export default class SearchComponent extends Component {
     if (typeof this.redirectUrl === 'string') {
       if (this._allowEmptySearch || query) {
         const newRedirectUrl = constructRedirectUrl(this.redirectUrl, params);
-        window.open(newRedirectUrl.href, this.redirectUrlTarget) ||
-          (window.location.href = newRedirectUrl.href);
+        window.open(newRedirectUrl, this.redirectUrlTarget) ||
+          (window.location.href = newRedirectUrl);
         return false;
       }
     }

--- a/src/ui/tools/urlutils.js
+++ b/src/ui/tools/urlutils.js
@@ -6,16 +6,17 @@ import SearchParams from '../dom/searchparams';
  *
  * @param {string} redirectUrl user-specified redirect url
  * @param {SearchParams} params url params saved in answers storage
- * @returns {URL} new redirect url including params from answers storage
+ * @returns {string} new redirect url including params from answers storage
  */
 export function constructRedirectUrl (redirectUrl, params) {
-  const newRedirectUrl = new URL(redirectUrl);
-  const redirectUrlParams = new SearchParams(newRedirectUrl.search);
+  const urlParser = document.createElement('a');
+  urlParser.href = redirectUrl;
+  const redirectUrlParams = new SearchParams(urlParser.search);
   for (const [key, val] of params.entries()) {
     if (!redirectUrlParams.has(key)) {
       redirectUrlParams.set(key, val);
     }
   }
-  newRedirectUrl.search = redirectUrlParams.toString();
-  return newRedirectUrl;
+  urlParser.search = redirectUrlParams.toString();
+  return urlParser.href;
 }

--- a/tests/ui/tools/urlutils.js
+++ b/tests/ui/tools/urlutils.js
@@ -6,20 +6,34 @@ describe('constructRedirectUrl', () => {
     const userRedirectUrl = 'https://answers.yext.com/';
     const params = new SearchParams('?answers-param=rose');
     const newRedirectUrl = constructRedirectUrl(userRedirectUrl, params);
-    expect(newRedirectUrl.search).toEqual('?answers-param=rose');
+    expect(newRedirectUrl).toEqual('https://answers.yext.com/?answers-param=rose');
   });
 
   it('handle duplicate params', () => {
     const userRedirectUrl = 'https://answers.yext.com/?query=test';
     const params = new SearchParams('?query=rose');
     const newRedirectUrl = constructRedirectUrl(userRedirectUrl, params);
-    expect(newRedirectUrl.search).toEqual('?query=test');
+    expect(newRedirectUrl).toEqual('https://answers.yext.com/?query=test');
   });
 
   it('handle a mix of user-specified and answers params', () => {
     const userRedirectUrl = 'https://answers.yext.com/?query=test&context=abc';
     const params = new SearchParams('?query=rose&filter=manager');
     const newRedirectUrl = constructRedirectUrl(userRedirectUrl, params);
-    expect(newRedirectUrl.search).toEqual('?query=test&context=abc&filter=manager');
+    expect(newRedirectUrl).toEqual('https://answers.yext.com/?query=test&context=abc&filter=manager');
+  });
+
+  it('handle relative url', () => {
+    const userRedirectUrl = './people.html/?query=test';
+    const params = new SearchParams('?another=param');
+    const newRedirectUrl = constructRedirectUrl(userRedirectUrl, params);
+    expect(newRedirectUrl).toEqual('http://localhost/people.html/?query=test&another=param');
+  });
+
+  it('handle relative url without starting with current directory "./"', () => {
+    const userRedirectUrl = 'people.html/?query=test';
+    const params = new SearchParams('?another=param');
+    const newRedirectUrl = constructRedirectUrl(userRedirectUrl, params);
+    expect(newRedirectUrl).toEqual('http://localhost/people.html/?query=test&another=param');
   });
 });


### PR DESCRIPTION
ie11 on browserstack works with url api but it's not actually supported as specified in mdn - testing it through local window desktop confirmed that this would not work. This pr replace the usage of URL api. This update also ensures cases of user providing relative link format for their redirectUrl.

J=none
TEST=manual

see new jest tests passed.
add redirectUrl (absolute/relative path) to searchBar and see that it navigates as expected in Chrome, safari, firefox.
use ngrok to serve a page with the sdk change, and tested redirectUrl in a local window laptop with ie browser.