### PR TITLE
non-i18n assets for support branches

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -5,7 +5,6 @@ on:
     branches-ignore:
       - develop
       - master
-      - support/**
       - hotfix/**
       - feature/**-i18n
       - release/**

--- a/.github/workflows/build_and_deploy_i18n.yml
+++ b/.github/workflows/build_and_deploy_i18n.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - support/**
       - hotfix/**
       - feature/**-i18n
       - release/**


### PR DESCRIPTION
this pr removes `support/**` from `build_and_deploy_i18n.yml` so it will not trigger an i18n build when there's a push to a support branch. `support/**` is also remove from the `branches-ignore` list from `build_and_deploy.yml` so the non-i18n asset will run.

J=SLAP-2046
TEST=manual

push a [test support branch](https://github.com/yext/answers-search-ui/pull/1735) and see that only non-i18n asset was built.