### PR TITLE
Revert @percy/cli upgrade from PR #1721

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@babel/plugin-transform-runtime": "^7.9.0",
         "@babel/preset-env": "^7.13.10",
         "@babel/runtime-corejs3": "^7.13.10",
-        "@percy/cli": "^1.0.7",
+        "@percy/cli": "1.0.0-beta.76",
         "@percy/puppeteer": "^2.0.0",
         "@rollup/plugin-json": "^4.1.0",
         "@size-limit/file": "^4.9.0",
@@ -89,7 +89,6 @@
         "rollup-plugin-node-resolve": "^4.0.1",
         "rollup-plugin-svg": "^2.0.0",
         "sass": "^1.34.0",
-        "serve-handler": "^6.1.3",
         "size-limit": "^4.9.0",
         "stylelint": "^14.5.3",
         "stylelint-config-standard-scss": "^3.0.0",
@@ -99,7 +98,7 @@
         "vinyl-source-stream": "^2.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3241,184 +3240,193 @@
       }
     },
     "node_modules/@percy/cli": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.1.3.tgz",
-      "integrity": "sha512-L1Wu1Ypk34I7PPhUEQbSIlm627z1TzyNp5pjBRZQLHP0kQZBVm43fgrPxtOwkiN8YFmHKk8OTPnbqh6xfuMESA==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.0.0-beta.76.tgz",
+      "integrity": "sha512-X3I+28KNedv2vlitVnhu751QdxC0JMmFN51gOBNHkh4gy5rU372oQk1Y6XUQHYjq69BvZMHJnv4Pxhh2RFDZgg==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-build": "1.1.3",
-        "@percy/cli-command": "1.1.3",
-        "@percy/cli-config": "1.1.3",
-        "@percy/cli-exec": "1.1.3",
-        "@percy/cli-snapshot": "1.1.3",
-        "@percy/cli-upload": "1.1.3",
-        "@percy/client": "1.1.3",
-        "@percy/logger": "1.1.3"
+        "@percy/cli-build": "1.0.0-beta.76",
+        "@percy/cli-command": "1.0.0-beta.76",
+        "@percy/cli-config": "1.0.0-beta.76",
+        "@percy/cli-exec": "1.0.0-beta.76",
+        "@percy/cli-snapshot": "1.0.0-beta.76",
+        "@percy/cli-upload": "1.0.0-beta.76",
+        "@percy/client": "1.0.0-beta.76",
+        "@percy/logger": "1.0.0-beta.76"
       },
       "bin": {
-        "percy": "bin/run.cjs"
+        "percy": "bin/run"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/@percy/cli-build": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.1.3.tgz",
-      "integrity": "sha512-KBO+unniEdTJZu3lVr32eNypX34zILIAjPdvVXkfGSGbYtisw0NpP/dzLiGi5HbSLhtF84RNI3danppBuOTzTg==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.0.0-beta.76.tgz",
+      "integrity": "sha512-8NRos48C/CL8s8SahKIx/c65P6rBsSxWYojqzIL73dOCwEsWf/X8/r7Jf4DS6oK8A56g7F1KfDLsaMFdRQi5YA==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.1.3"
+        "@percy/cli-command": "1.0.0-beta.76",
+        "@percy/logger": "1.0.0-beta.76"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/@percy/cli-command": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.1.3.tgz",
-      "integrity": "sha512-HCy7Y74TC2zMtgGpwQPhezwBSfPDe4ppcMpolcXkvptVz2xhbnIgMgcGObziexHNKBpwLtCoNKyR2cSWj3F5IQ==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.0.0-beta.76.tgz",
+      "integrity": "sha512-/ceDY2Y+l7uv+ttIxbS0+VPY4/EJpL64oXblCwz1Ecd+5yFE1Ud+wWpdAWJxqc8Vipt+eMC+E7swB1U5X99ZEA==",
       "dev": true,
       "dependencies": {
-        "@percy/config": "1.1.3",
-        "@percy/core": "1.1.3",
-        "@percy/logger": "1.1.3"
+        "@percy/config": "1.0.0-beta.76",
+        "@percy/core": "1.0.0-beta.76",
+        "@percy/logger": "1.0.0-beta.76"
       },
       "bin": {
-        "percy-cli-readme": "bin/readme.js"
+        "percy-cli-readme": "bin/readme"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/@percy/cli-config": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.1.3.tgz",
-      "integrity": "sha512-1B2+DzGODj+6u0RhrT867wb8tGfobqFPS9yi2sfZz1SZhFsw+/DHZEhRBQ5efLGyv5FAo0CCaFneocINhTTvEw==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.0.0-beta.76.tgz",
+      "integrity": "sha512-quYr2hYqeafDnHFPKZQlncy5qPkmjfPg22mv/HmABqH+GPe30gADOEqOAW0/NeprK+jq2IRxx3NdYKUBa/kZAg==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.1.3"
+        "@percy/cli-command": "1.0.0-beta.76",
+        "@percy/config": "1.0.0-beta.76"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/@percy/cli-exec": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.1.3.tgz",
-      "integrity": "sha512-5GlzZA/zeYjQGY7lNwAIxpHabjSNSJ4RJzuvT16awaOOS2XDxhI6+V6/120KzKfiZklBE8f/jXrWb0hYrpGeUA==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.0.0-beta.76.tgz",
+      "integrity": "sha512-SJWZ8m3duNWJZzqd0m34Gnydn5vTS84jwt4+nhZ3/gqSmNN9QLX0fJJNGpRjuB7oVzEzdh1pAhaxyIM7+0pV8A==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.1.3",
+        "@percy/cli-command": "1.0.0-beta.76",
+        "@percy/core": "1.0.0-beta.76",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/@percy/cli-snapshot": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.1.3.tgz",
-      "integrity": "sha512-LQK4/pqbhr0qUgU6/9nq1bAWRLOj65UAufaAlZum3/B4bx4xFeiOGk+QdvldjLbgVasz93P6whxSv+r9tAi+Lg==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.0.0-beta.76.tgz",
+      "integrity": "sha512-C981wuC0lm0i4plbRqtlOMHx+/0lIyGGII3ypTs7pFwY1CrNiy7+bWXfdD/PHdVCVZ+YeVuqjEB1GA9A05u8oQ==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.1.3",
-        "yaml": "^2.0.0"
+        "@percy/cli-command": "1.0.0-beta.76",
+        "@percy/config": "1.0.0-beta.76",
+        "@percy/core": "1.0.0-beta.76",
+        "globby": "^11.0.4",
+        "path-to-regexp": "^6.2.0",
+        "picomatch": "^2.3.0",
+        "serve-handler": "^6.1.3",
+        "yaml": "^1.10.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/@percy/cli-upload": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.1.3.tgz",
-      "integrity": "sha512-uvZ1WuUGAAFrubw6MCEdRgIWMkh3A1pyKzBgJ5eO9BLmIrE3o8Z1O0lE52PUN0uLKOPH0IU6pQI6NkcAU04O8A==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.0.0-beta.76.tgz",
+      "integrity": "sha512-5hz3PCEl9MMF2Fkqn6QKUk+hJVfGZLuJLm6zYOcAF2FdLbw6CnFN8dz8K4EIrQLjH3DgTbI+YkEsr7b89V+aLA==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.1.3",
-        "fast-glob": "^3.2.11",
+        "@percy/cli-command": "1.0.0-beta.76",
+        "@percy/client": "1.0.0-beta.76",
+        "@percy/logger": "1.0.0-beta.76",
+        "globby": "^11.0.4",
         "image-size": "^1.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/@percy/client": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.1.3.tgz",
-      "integrity": "sha512-p2WsLVm03aWVmZl/cQdSH9wcwKg/zrmmlCdaQfqaDh45tVDuE63A5BhREKW+KPtH130o8WkNDughY+d3B3D7bQ==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.0.0-beta.76.tgz",
+      "integrity": "sha512-vq0npya/YobIwbqrhiCXF7liwHJNmMEiAkefv5AXLmhCxIJ9eWjvgYew4xssuf+QPHfdv10EVa5kkMSr8INxeA==",
       "dev": true,
       "dependencies": {
-        "@percy/env": "1.1.3",
-        "@percy/logger": "1.1.3"
+        "@percy/env": "1.0.0-beta.76",
+        "@percy/logger": "1.0.0-beta.76"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/@percy/config": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.1.3.tgz",
-      "integrity": "sha512-lXSjQDczTt2+x/246VUdTkv8KAEURbQHpkPzJ8FyFx8UoKmlbbzSzjEFVBZWJZsldK0kV5ZYOQGJ3ofmNNIPZg==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.0.0-beta.76.tgz",
+      "integrity": "sha512-e3sLzcrVlsax5q1RwO8sek2Qjqb617WFpa1+wnXqPSMSxiEBlr+lbUC/C5a1hHKEWdFz4RKSJC+2mjhT8ylm3g==",
       "dev": true,
       "dependencies": {
-        "@percy/logger": "1.1.3",
+        "@percy/logger": "1.0.0-beta.76",
         "ajv": "^8.6.2",
         "cosmiconfig": "^7.0.0",
-        "yaml": "^2.0.0"
+        "yaml": "^1.10.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/@percy/core": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.1.3.tgz",
-      "integrity": "sha512-D6GYMRsqKbiYdMSxmsTLOrbuTSSj/ibi17JlydsWOs6qu/I8HOFymxyA+hb77GfGcK+sxPXU77IJ4QptYLcnsQ==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.0.0-beta.76.tgz",
+      "integrity": "sha512-sTtwdNBmhX/IvKrNGT3TWrZ0ngJZ2Kh6Y4m9M9H4pciGHmiSFcMqsBB0tK6IMbfIsGqFz8ePOTj++4RLSMlK/g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@percy/client": "1.1.3",
-        "@percy/config": "1.1.3",
-        "@percy/dom": "1.1.3",
-        "@percy/logger": "1.1.3",
+        "@percy/client": "1.0.0-beta.76",
+        "@percy/config": "1.0.0-beta.76",
+        "@percy/dom": "1.0.0-beta.76",
+        "@percy/logger": "1.0.0-beta.76",
         "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
-        "fast-glob": "^3.2.11",
-        "micromatch": "^4.0.4",
         "mime-types": "^2.1.34",
         "path-to-regexp": "^6.2.0",
         "rimraf": "^3.0.2",
         "ws": "^8.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/@percy/dom": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.1.3.tgz",
-      "integrity": "sha512-b/O/wfaeMrpNbX8ArIE+GqT7YEm+Og/guuMTO8tlNM9wHSCWRXOdXA0vBHIlvG7gHGWAWmBhJIqXQ6bIU1U8Hw==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.0.0-beta.76.tgz",
+      "integrity": "sha512-9v/yXjIe2UhAkjnO2pWT0Ki4rzgIl0Z6YyWcn1b5NfsBcMm99Hcse+otDsQJF8z0MkU4ZykiPY63zmjs45wChQ==",
       "dev": true
     },
     "node_modules/@percy/env": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.1.3.tgz",
-      "integrity": "sha512-Im1SYSzhy27wlSz5DmP5ekpqBilBX08HdQaGNDngZKJUQiMqN0eYYiEG0fuWAjLaG2pXBHoXww85SaZq14+5Qw==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.0.0-beta.76.tgz",
+      "integrity": "sha512-+Mx9K3wjFriMT0cMD5l+VRo6mhQ/XssKy77SUeWrOaGIk7Xs/FsnDUpLOCXAGUeJr1AznZM76ng99IOBM6pY4w==",
       "dev": true,
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/@percy/logger": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.1.3.tgz",
-      "integrity": "sha512-5xI7RnMgQsrIVETJQgKZXXPESUvUy90NUFkuAXuZTsZnlot3b+IANDkZLI3aIf45MF0Wyx9MVgNUL9f4XD42rA==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.0-beta.76.tgz",
+      "integrity": "sha512-v5zIMNv1xqdcWBAOK5A6ZEO99ZBwzWS3phLEfkKbIlGIUxvjkJHSfZv/k1dnt2RRfpDNkM6X5pMg2yI8j1+d+g==",
       "dev": true,
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/@percy/puppeteer": {
@@ -6424,14 +6432,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/crc": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
@@ -6747,15 +6747,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/cssnano/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/csso": {
@@ -23294,12 +23285,11 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.1.tgz",
-      "integrity": "sha512-1NpAYQ3wjzIlMs0mgdBmYzLkFgWBIWrzYVDYfrixhoFNNgJ444/jT2kUT2sicRbJES3oQYRZugjB6Ro8SjKeFg==",
-      "dev": true,
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 6"
       }
     },
     "node_modules/yargs": {
@@ -25840,119 +25830,128 @@
       }
     },
     "@percy/cli": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.1.3.tgz",
-      "integrity": "sha512-L1Wu1Ypk34I7PPhUEQbSIlm627z1TzyNp5pjBRZQLHP0kQZBVm43fgrPxtOwkiN8YFmHKk8OTPnbqh6xfuMESA==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.0.0-beta.76.tgz",
+      "integrity": "sha512-X3I+28KNedv2vlitVnhu751QdxC0JMmFN51gOBNHkh4gy5rU372oQk1Y6XUQHYjq69BvZMHJnv4Pxhh2RFDZgg==",
       "dev": true,
       "requires": {
-        "@percy/cli-build": "1.1.3",
-        "@percy/cli-command": "1.1.3",
-        "@percy/cli-config": "1.1.3",
-        "@percy/cli-exec": "1.1.3",
-        "@percy/cli-snapshot": "1.1.3",
-        "@percy/cli-upload": "1.1.3",
-        "@percy/client": "1.1.3",
-        "@percy/logger": "1.1.3"
+        "@percy/cli-build": "1.0.0-beta.76",
+        "@percy/cli-command": "1.0.0-beta.76",
+        "@percy/cli-config": "1.0.0-beta.76",
+        "@percy/cli-exec": "1.0.0-beta.76",
+        "@percy/cli-snapshot": "1.0.0-beta.76",
+        "@percy/cli-upload": "1.0.0-beta.76",
+        "@percy/client": "1.0.0-beta.76",
+        "@percy/logger": "1.0.0-beta.76"
       }
     },
     "@percy/cli-build": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.1.3.tgz",
-      "integrity": "sha512-KBO+unniEdTJZu3lVr32eNypX34zILIAjPdvVXkfGSGbYtisw0NpP/dzLiGi5HbSLhtF84RNI3danppBuOTzTg==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.0.0-beta.76.tgz",
+      "integrity": "sha512-8NRos48C/CL8s8SahKIx/c65P6rBsSxWYojqzIL73dOCwEsWf/X8/r7Jf4DS6oK8A56g7F1KfDLsaMFdRQi5YA==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.1.3"
+        "@percy/cli-command": "1.0.0-beta.76",
+        "@percy/logger": "1.0.0-beta.76"
       }
     },
     "@percy/cli-command": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.1.3.tgz",
-      "integrity": "sha512-HCy7Y74TC2zMtgGpwQPhezwBSfPDe4ppcMpolcXkvptVz2xhbnIgMgcGObziexHNKBpwLtCoNKyR2cSWj3F5IQ==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.0.0-beta.76.tgz",
+      "integrity": "sha512-/ceDY2Y+l7uv+ttIxbS0+VPY4/EJpL64oXblCwz1Ecd+5yFE1Ud+wWpdAWJxqc8Vipt+eMC+E7swB1U5X99ZEA==",
       "dev": true,
       "requires": {
-        "@percy/config": "1.1.3",
-        "@percy/core": "1.1.3",
-        "@percy/logger": "1.1.3"
+        "@percy/config": "1.0.0-beta.76",
+        "@percy/core": "1.0.0-beta.76",
+        "@percy/logger": "1.0.0-beta.76"
       }
     },
     "@percy/cli-config": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.1.3.tgz",
-      "integrity": "sha512-1B2+DzGODj+6u0RhrT867wb8tGfobqFPS9yi2sfZz1SZhFsw+/DHZEhRBQ5efLGyv5FAo0CCaFneocINhTTvEw==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.0.0-beta.76.tgz",
+      "integrity": "sha512-quYr2hYqeafDnHFPKZQlncy5qPkmjfPg22mv/HmABqH+GPe30gADOEqOAW0/NeprK+jq2IRxx3NdYKUBa/kZAg==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.1.3"
+        "@percy/cli-command": "1.0.0-beta.76",
+        "@percy/config": "1.0.0-beta.76"
       }
     },
     "@percy/cli-exec": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.1.3.tgz",
-      "integrity": "sha512-5GlzZA/zeYjQGY7lNwAIxpHabjSNSJ4RJzuvT16awaOOS2XDxhI6+V6/120KzKfiZklBE8f/jXrWb0hYrpGeUA==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.0.0-beta.76.tgz",
+      "integrity": "sha512-SJWZ8m3duNWJZzqd0m34Gnydn5vTS84jwt4+nhZ3/gqSmNN9QLX0fJJNGpRjuB7oVzEzdh1pAhaxyIM7+0pV8A==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.1.3",
+        "@percy/cli-command": "1.0.0-beta.76",
+        "@percy/core": "1.0.0-beta.76",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       }
     },
     "@percy/cli-snapshot": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.1.3.tgz",
-      "integrity": "sha512-LQK4/pqbhr0qUgU6/9nq1bAWRLOj65UAufaAlZum3/B4bx4xFeiOGk+QdvldjLbgVasz93P6whxSv+r9tAi+Lg==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.0.0-beta.76.tgz",
+      "integrity": "sha512-C981wuC0lm0i4plbRqtlOMHx+/0lIyGGII3ypTs7pFwY1CrNiy7+bWXfdD/PHdVCVZ+YeVuqjEB1GA9A05u8oQ==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.1.3",
-        "yaml": "^2.0.0"
+        "@percy/cli-command": "1.0.0-beta.76",
+        "@percy/config": "1.0.0-beta.76",
+        "@percy/core": "1.0.0-beta.76",
+        "globby": "^11.0.4",
+        "path-to-regexp": "^6.2.0",
+        "picomatch": "^2.3.0",
+        "serve-handler": "^6.1.3",
+        "yaml": "^1.10.0"
       }
     },
     "@percy/cli-upload": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.1.3.tgz",
-      "integrity": "sha512-uvZ1WuUGAAFrubw6MCEdRgIWMkh3A1pyKzBgJ5eO9BLmIrE3o8Z1O0lE52PUN0uLKOPH0IU6pQI6NkcAU04O8A==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.0.0-beta.76.tgz",
+      "integrity": "sha512-5hz3PCEl9MMF2Fkqn6QKUk+hJVfGZLuJLm6zYOcAF2FdLbw6CnFN8dz8K4EIrQLjH3DgTbI+YkEsr7b89V+aLA==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.1.3",
-        "fast-glob": "^3.2.11",
+        "@percy/cli-command": "1.0.0-beta.76",
+        "@percy/client": "1.0.0-beta.76",
+        "@percy/logger": "1.0.0-beta.76",
+        "globby": "^11.0.4",
         "image-size": "^1.0.0"
       }
     },
     "@percy/client": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.1.3.tgz",
-      "integrity": "sha512-p2WsLVm03aWVmZl/cQdSH9wcwKg/zrmmlCdaQfqaDh45tVDuE63A5BhREKW+KPtH130o8WkNDughY+d3B3D7bQ==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.0.0-beta.76.tgz",
+      "integrity": "sha512-vq0npya/YobIwbqrhiCXF7liwHJNmMEiAkefv5AXLmhCxIJ9eWjvgYew4xssuf+QPHfdv10EVa5kkMSr8INxeA==",
       "dev": true,
       "requires": {
-        "@percy/env": "1.1.3",
-        "@percy/logger": "1.1.3"
+        "@percy/env": "1.0.0-beta.76",
+        "@percy/logger": "1.0.0-beta.76"
       }
     },
     "@percy/config": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.1.3.tgz",
-      "integrity": "sha512-lXSjQDczTt2+x/246VUdTkv8KAEURbQHpkPzJ8FyFx8UoKmlbbzSzjEFVBZWJZsldK0kV5ZYOQGJ3ofmNNIPZg==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.0.0-beta.76.tgz",
+      "integrity": "sha512-e3sLzcrVlsax5q1RwO8sek2Qjqb617WFpa1+wnXqPSMSxiEBlr+lbUC/C5a1hHKEWdFz4RKSJC+2mjhT8ylm3g==",
       "dev": true,
       "requires": {
-        "@percy/logger": "1.1.3",
+        "@percy/logger": "1.0.0-beta.76",
         "ajv": "^8.6.2",
         "cosmiconfig": "^7.0.0",
-        "yaml": "^2.0.0"
+        "yaml": "^1.10.0"
       }
     },
     "@percy/core": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.1.3.tgz",
-      "integrity": "sha512-D6GYMRsqKbiYdMSxmsTLOrbuTSSj/ibi17JlydsWOs6qu/I8HOFymxyA+hb77GfGcK+sxPXU77IJ4QptYLcnsQ==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.0.0-beta.76.tgz",
+      "integrity": "sha512-sTtwdNBmhX/IvKrNGT3TWrZ0ngJZ2Kh6Y4m9M9H4pciGHmiSFcMqsBB0tK6IMbfIsGqFz8ePOTj++4RLSMlK/g==",
       "dev": true,
       "requires": {
-        "@percy/client": "1.1.3",
-        "@percy/config": "1.1.3",
-        "@percy/dom": "1.1.3",
-        "@percy/logger": "1.1.3",
+        "@percy/client": "1.0.0-beta.76",
+        "@percy/config": "1.0.0-beta.76",
+        "@percy/dom": "1.0.0-beta.76",
+        "@percy/logger": "1.0.0-beta.76",
         "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
-        "fast-glob": "^3.2.11",
-        "micromatch": "^4.0.4",
         "mime-types": "^2.1.34",
         "path-to-regexp": "^6.2.0",
         "rimraf": "^3.0.2",
@@ -25960,21 +25959,21 @@
       }
     },
     "@percy/dom": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.1.3.tgz",
-      "integrity": "sha512-b/O/wfaeMrpNbX8ArIE+GqT7YEm+Og/guuMTO8tlNM9wHSCWRXOdXA0vBHIlvG7gHGWAWmBhJIqXQ6bIU1U8Hw==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.0.0-beta.76.tgz",
+      "integrity": "sha512-9v/yXjIe2UhAkjnO2pWT0Ki4rzgIl0Z6YyWcn1b5NfsBcMm99Hcse+otDsQJF8z0MkU4ZykiPY63zmjs45wChQ==",
       "dev": true
     },
     "@percy/env": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.1.3.tgz",
-      "integrity": "sha512-Im1SYSzhy27wlSz5DmP5ekpqBilBX08HdQaGNDngZKJUQiMqN0eYYiEG0fuWAjLaG2pXBHoXww85SaZq14+5Qw==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.0.0-beta.76.tgz",
+      "integrity": "sha512-+Mx9K3wjFriMT0cMD5l+VRo6mhQ/XssKy77SUeWrOaGIk7Xs/FsnDUpLOCXAGUeJr1AznZM76ng99IOBM6pY4w==",
       "dev": true
     },
     "@percy/logger": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.1.3.tgz",
-      "integrity": "sha512-5xI7RnMgQsrIVETJQgKZXXPESUvUy90NUFkuAXuZTsZnlot3b+IANDkZLI3aIf45MF0Wyx9MVgNUL9f4XD42rA==",
+      "version": "1.0.0-beta.76",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.0-beta.76.tgz",
+      "integrity": "sha512-v5zIMNv1xqdcWBAOK5A6ZEO99ZBwzWS3phLEfkKbIlGIUxvjkJHSfZv/k1dnt2RRfpDNkM6X5pMg2yI8j1+d+g==",
       "dev": true
     },
     "@percy/puppeteer": {
@@ -28387,13 +28386,6 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
-      },
-      "dependencies": {
-        "yaml": {
-          "version": "1.10.2",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-          "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
-        }
       }
     },
     "crc": {
@@ -28600,14 +28592,6 @@
         "cssnano-preset-default": "^5.2.7",
         "lilconfig": "^2.0.3",
         "yaml": "^1.10.2"
-      },
-      "dependencies": {
-        "yaml": {
-          "version": "1.10.2",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-          "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-          "dev": true
-        }
       }
     },
     "cssnano-preset-default": {
@@ -41854,10 +41838,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.1.tgz",
-      "integrity": "sha512-1NpAYQ3wjzIlMs0mgdBmYzLkFgWBIWrzYVDYfrixhoFNNgJ444/jT2kUT2sicRbJES3oQYRZugjB6Ro8SjKeFg==",
-      "dev": true
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@babel/plugin-transform-runtime": "^7.9.0",
     "@babel/preset-env": "^7.13.10",
     "@babel/runtime-corejs3": "^7.13.10",
-    "@percy/cli": "^1.0.7",
+    "@percy/cli": "1.0.0-beta.76",
     "@percy/puppeteer": "^2.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@size-limit/file": "^4.9.0",
@@ -103,7 +103,6 @@
     "rollup-plugin-node-resolve": "^4.0.1",
     "rollup-plugin-svg": "^2.0.0",
     "sass": "^1.34.0",
-    "serve-handler": "^6.1.3",
     "size-limit": "^4.9.0",
     "stylelint": "^14.5.3",
     "stylelint-config-standard-scss": "^3.0.0",
@@ -174,7 +173,7 @@
   "author": "Yext",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=14"
+    "node": ">=12"
   },
   "exports": {
     "./css": "./dist/answers.css",


### PR DESCRIPTION
Netlify checks were failing because of the upgraded `@percy/core`'s post-install script