### PR TITLE
Update build for i18n deploy workflow

### DIFF
--- a/.github/workflows/build_and_deploy_i18n.yml
+++ b/.github/workflows/build_and_deploy_i18n.yml
@@ -12,7 +12,7 @@ jobs:
   call_build:
     uses: ./.github/workflows/build.yml
     with:
-      build_script: build-basic
+      build_script: build-unminified-legacy
 
   call_unit_test:
     uses: ./.github/workflows/unit_test.yml

--- a/.github/workflows/build_and_deploy_i18n.yml
+++ b/.github/workflows/build_and_deploy_i18n.yml
@@ -12,7 +12,7 @@ jobs:
   call_build:
     uses: ./.github/workflows/build.yml
     with:
-      build_script: build-locales
+      build_script: build-basic
 
   call_unit_test:
     uses: ./.github/workflows/unit_test.yml
@@ -30,6 +30,11 @@ jobs:
     secrets:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+  
+  call_build_locales:
+    uses: ./.github/workflows/build.yml
+    with:
+      build_script: build-locales
 
   call_deploy:
     if: github.ref_name != 'develop'
@@ -38,6 +43,7 @@ jobs:
       - call_format_branch_name
       - call_acceptance
       - call_misc_tests
+      - call_build_locales
     uses: ./.github/workflows/deploy.yml
     with:
       directory: dev/${{ needs.call_format_branch_name.outputs.formatted_branch }}
@@ -52,6 +58,7 @@ jobs:
       - call_format_branch_name
       - call_acceptance
       - call_misc_tests
+      - call_build_locales
     uses: ./.github/workflows/deploy.yml
     with:
       directory: canary/latest
@@ -66,6 +73,7 @@ jobs:
       - call_format_branch_name
       - call_acceptance
       - call_misc_tests
+      - call_build_locales
     uses: ./.github/workflows/deploy.yml
     with:
       directory: canary/${{ github.sha }}

--- a/conf/gulp-tasks/library.gulpfile.js
+++ b/conf/gulp-tasks/library.gulpfile.js
@@ -31,6 +31,21 @@ exports.dev = function devJSBundle () {
 };
 
 /**
+ * Creates the un-minified legacy JS bundle and compiles CSS.
+ * @returns {Promise<Function>}
+ */
+exports.basic = function basicJSBundle () {
+  return createBundleTaskFactory(DEFAULT_LOCALE).then(basicTaskFactory => {
+    return new Promise(resolve => {
+      return parallel(
+        basicTaskFactory.create(BundleType.LEGACY_IIFE),
+        compileCSS
+      )(resolve);
+    });
+  });
+};
+
+/**
  * Creates a build task for each provided language and combines them into a series task.
  * This function also supports locales, but it is named to reflect the current use case
  * of creating bundles for just languages.

--- a/conf/gulp-tasks/library.gulpfile.js
+++ b/conf/gulp-tasks/library.gulpfile.js
@@ -34,11 +34,11 @@ exports.dev = function devJSBundle () {
  * Creates the un-minified legacy JS bundle and compiles CSS.
  * @returns {Promise<Function>}
  */
-exports.basic = function basicJSBundle () {
-  return createBundleTaskFactory(DEFAULT_LOCALE).then(basicTaskFactory => {
+exports.unminifiedLegacy = function unminifiedLegacyJSBundle () {
+  return createBundleTaskFactory(DEFAULT_LOCALE).then(unminifiedLegacyTaskFactory => {
     return new Promise(resolve => {
       return parallel(
-        basicTaskFactory.create(BundleType.LEGACY_IIFE),
+        unminifiedLegacyTaskFactory.create(BundleType.LEGACY_IIFE),
         compileCSS
       )(resolve);
     });

--- a/conf/gulp-tasks/templates.gulpfile.js
+++ b/conf/gulp-tasks/templates.gulpfile.js
@@ -33,21 +33,18 @@ async function devTemplates (shouldWatch = true) {
   const translator = await createTranslator(DEFAULT_LOCALE);
   const precompileTemplates = createPrecompileTemplatesTask(DEFAULT_LOCALE, translator);
 
-  const nonWatchTasks = [precompileTemplates, bundleTemplatesUMD, cleanFiles];
+  const templateTasks = [precompileTemplates, bundleTemplatesUMD, cleanFiles];
 
   function watchTemplates () {
     return watch(['./src/ui/templates/**/*.hbs'], {
       ignored: './dist/'
-    }, series(precompileTemplates, bundleTemplatesUMD, cleanFiles));
+    }, series(...templateTasks));
   }
 
+  const tasks = shouldWatch ? [...templateTasks, watchTemplates] : templateTasks;
+
   return new Promise(resolve => {
-    return shouldWatch
-      ? series(
-        ...nonWatchTasks,
-        watchTemplates
-      )(resolve)
-      : series(...nonWatchTasks)(resolve);
+    return series(...tasks)(resolve);
   });
 }
 

--- a/conf/gulp-tasks/templates.gulpfile.js
+++ b/conf/gulp-tasks/templates.gulpfile.js
@@ -49,7 +49,7 @@ async function devTemplates (shouldWatch = true) {
 }
 
 exports.dev = devTemplates;
-exports.basic = function () {
+exports.unminifiedLegacy = function () {
   return devTemplates(false);
 };
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,9 +12,9 @@ exports.dev = parallel(
   templates.dev,
   library.dev
 );
-exports.basic = parallel(
-  templates.basic,
-  library.basic
+exports.unminifiedLegacy = parallel(
+  templates.unminifiedLegacy,
+  library.unminifiedLegacy
 );
 exports.buildLanguages = parallel(
   templates.buildLanguages,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,10 @@ exports.dev = parallel(
   templates.dev,
   library.dev
 );
+exports.basic = parallel(
+  templates.basic,
+  library.basic
+);
 exports.buildLanguages = parallel(
   templates.buildLanguages,
   library.buildLanguages

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "build-languages": "gulp buildLanguages && size-limit",
     "build-locales": "gulp buildLocales && size-limit",
     "build-search-bar-only": "gulp buildSearchBarOnlyAssets && size-limit",
-    "build-basic": "gulp basic",
+    "build-unminified-legacy": "gulp basic",
     "dev": "gulp dev",
     "lint": "eslint .",
     "test": "eslint . && stylelint src/**/*.scss && cross-env NODE_ICU_DATA=node_modules/full-icu jest",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "build-languages": "gulp buildLanguages && size-limit",
     "build-locales": "gulp buildLocales && size-limit",
     "build-search-bar-only": "gulp buildSearchBarOnlyAssets && size-limit",
-    "build-unminified-legacy": "gulp basic",
+    "build-unminified-legacy": "gulp unminifiedLegacy",
     "dev": "gulp dev",
     "lint": "eslint .",
     "test": "eslint . && stylelint src/**/*.scss && cross-env NODE_ICU_DATA=node_modules/full-icu jest",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "build-languages": "gulp buildLanguages && size-limit",
     "build-locales": "gulp buildLocales && size-limit",
     "build-search-bar-only": "gulp buildSearchBarOnlyAssets && size-limit",
+    "build-basic": "gulp basic",
     "dev": "gulp dev",
     "lint": "eslint .",
     "test": "eslint . && stylelint src/**/*.scss && cross-env NODE_ICU_DATA=node_modules/full-icu jest",


### PR DESCRIPTION
This PR updates the `build_and_deploy_i18n` workflow to run a simplified build before the acceptance tests instead of the full i18n build. This shortens the amount of time it takes before we see the results of the acceptance tests. The simplified build is the same as the `dev` build, but without the watch task. The i18n build runs in parallel and still must complete successfully before the deploy jobs are run.

The `build_and_deploy_hold` workflow also runs the i18n build, but another item (SLAP-2103) plans to remove the acceptance tests from this workflow, so it doesn't seem necessary to update it to run a simplified build.

J=SLAP-2099
TEST=auto

Tested on another branch (`test-basic-build`) and saw that the acceptance and unit tests run once the basic build is complete, the i18n build runs in parallel, and the deploy waits until both the tests and the i18n build finish.