### PR TITLE
keep results on search failure

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -9,23 +9,23 @@ on:
         required: true
 
 jobs:
-  headless_acceptance:
-    name: Headless Acceptance
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js 16
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16
-          cache: 'npm'
-      - run: npm ci
-      - name: Download build-output artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: build-output
-          path: dist/
-      - run: ./.github/run_headless_acceptance.sh
+  # headless_acceptance:
+  #   name: Headless Acceptance
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Use Node.js 16
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 16
+  #         cache: 'npm'
+  #     - run: npm ci
+  #     - name: Download build-output artifact
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: build-output
+  #         path: dist/
+  #     - run: ./.github/run_headless_acceptance.sh
 
   browserstack_acceptance:
     name: Browserstack Acceptance
@@ -38,12 +38,12 @@ jobs:
           node-version: 16
           cache: 'npm'
       - run: npm ci
-      - name: Download build-output artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: build-output
-          path: dist/
-      - run: ./.github/run_browserstack_acceptance.sh
-        env:
-          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
-          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+      # - name: Download build-output artifact
+      #   uses: actions/download-artifact@v2
+      #   with:
+      #     name: build-output
+      #     path: dist/
+      # - run: ./.github/run_browserstack_acceptance.sh
+      #   env:
+      #     BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+      #     BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -9,23 +9,23 @@ on:
         required: true
 
 jobs:
-  # headless_acceptance:
-  #   name: Headless Acceptance
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Use Node.js 16
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 16
-  #         cache: 'npm'
-  #     - run: npm ci
-  #     - name: Download build-output artifact
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: build-output
-  #         path: dist/
-  #     - run: ./.github/run_headless_acceptance.sh
+  headless_acceptance:
+    name: Headless Acceptance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: 'npm'
+      - run: npm ci
+      - name: Download build-output artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: build-output
+          path: dist/
+      - run: ./.github/run_headless_acceptance.sh
 
   browserstack_acceptance:
     name: Browserstack Acceptance
@@ -38,12 +38,12 @@ jobs:
           node-version: 16
           cache: 'npm'
       - run: npm ci
-      # - name: Download build-output artifact
-      #   uses: actions/download-artifact@v2
-      #   with:
-      #     name: build-output
-      #     path: dist/
-      # - run: ./.github/run_browserstack_acceptance.sh
-      #   env:
-      #     BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
-      #     BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+      - name: Download build-output artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: build-output
+          path: dist/
+      - run: ./.github/run_browserstack_acceptance.sh
+        env:
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -433,12 +433,13 @@ export default class Core {
    * @param {Searcher} searcherType
    */
   _markSearchComplete (searcherType) {
-    const results = searcherType === Searcher.UNIVERSAL
-      ? this.storage.get(StorageKeys.UNIVERSAL_RESULTS)
-      : this.storage.get(StorageKeys.VERTICAL_RESULTS);
+    const resultStorageKey = searcherType === Searcher.UNIVERSAL
+      ? StorageKeys.UNIVERSAL_RESULTS
+      : StorageKeys.VERTICAL_RESULTS;
+    const results = this.storage.get(resultStorageKey);
     if (results) {
       results.searchState = SearchStates.SEARCH_COMPLETE;
-      this.storage.set(StorageKeys.UNIVERSAL_RESULTS, results);
+      this.storage.set(resultStorageKey, results);
     }
     const directanswer = this.storage.get(StorageKeys.DIRECT_ANSWER);
     if (directanswer) {

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -273,13 +273,6 @@ export default class Core {
         querySource: this.storage.get(StorageKeys.QUERY_SOURCE),
         additionalHttpHeaders: this._additionalHttpHeaders
       })
-      .catch(error => {
-        this._markSearchComplete(Searcher.VERTICAL);
-        throw error;
-      })
-      .catch(error => {
-        console.error('The following problem was encountered while executing a vertical search: ' + error);
-      })
       .then(response => SearchDataTransformer.transformVertical(response, this._fieldFormatters, verticalKey))
       .then(data => {
         this._persistFacets();
@@ -334,7 +327,7 @@ export default class Core {
         throw error;
       })
       .catch(error => {
-        console.error('The following problem was encountered while processing vertical search results: ' + error);
+        console.error('The following problem was encountered during vertical search: ' + error);
       });
   }
 
@@ -402,13 +395,6 @@ export default class Core {
         querySource: this.storage.get(StorageKeys.QUERY_SOURCE),
         additionalHttpHeaders: this._additionalHttpHeaders
       })
-      .catch(error => {
-        this._markSearchComplete(Searcher.UNIVERSAL);
-        throw error;
-      })
-      .catch(error => {
-        console.error('The following problem was encountered while executing a universal search: ' + error);
-      })
       .then(response => SearchDataTransformer.transformUniversal(response, urls, this._fieldFormatters))
       .then(data => {
         this._reportFollowUpQueryEvent(data[StorageKeys.QUERY_ID], Searcher.UNIVERSAL);
@@ -437,7 +423,7 @@ export default class Core {
         throw error;
       })
       .catch(error => {
-        console.error('The following problem was encountered while processing universal search results: ' + error);
+        console.error('The following problem was encountered during universal search: ' + error);
       });
   }
 

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -399,7 +399,6 @@ export default class Core {
       })
       .then(response => SearchDataTransformer.transformUniversal(response, urls, this._fieldFormatters))
       .then(data => {
-        throw new Error('this is a mock throw');
         this._reportFollowUpQueryEvent(data[StorageKeys.QUERY_ID], Searcher.UNIVERSAL);
         this.storage.set(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
         this.storage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -433,14 +433,14 @@ export default class Core {
    * @param {Searcher} searcherType
    */
   _markSearchComplete (searcherType) {
-    const resultStorageKey = searcherType === Searcher.UNIVERSAL
-      ? StorageKeys.UNIVERSAL_RESULTS
-      : StorageKeys.VERTICAL_RESULTS;
-    const results = this.storage.get(resultStorageKey);
-    if (results) {
-      results.searchState = SearchStates.SEARCH_COMPLETE;
-      this.storage.set(resultStorageKey, results);
-    }
+    // const resultStorageKey = searcherType === Searcher.UNIVERSAL
+    //   ? StorageKeys.UNIVERSAL_RESULTS
+    //   : StorageKeys.VERTICAL_RESULTS;
+    // const results = this.storage.get(resultStorageKey);
+    // if (results) {
+    //   results.searchState = SearchStates.SEARCH_COMPLETE;
+    //   this.storage.set(resultStorageKey, results);
+    // }
     const directanswer = this.storage.get(StorageKeys.DIRECT_ANSWER);
     if (directanswer) {
       directanswer.searchState = SearchStates.SEARCH_COMPLETE;

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -324,9 +324,13 @@ export default class Core {
         }
         this.updateHistoryAfterSearch(queryTrigger);
         window.performance.mark('yext.answers.verticalQueryResponseRendered');
-      }).catch(error => {
-        console.error('The following problem was encountered while processing vertical search results: ' + error);
+      })
+      .catch(error => {
         this._updateResultsSearchState(Searcher.VERTICAL, SearchStates.SEARCH_COMPLETE);
+        throw error;
+      })
+      .catch(error => {
+        console.error('The following problem was encountered while processing vertical search results: ' + error);
       });
   }
 
@@ -419,9 +423,13 @@ export default class Core {
         }
         this.updateHistoryAfterSearch(queryTrigger);
         window.performance.mark('yext.answers.universalQueryResponseRendered');
-      }).catch(error => {
-        console.error('The following problem was encountered while processing universal search results: ' + error);
+      })
+      .catch(error => {
         this._updateResultsSearchState(Searcher.UNIVERSAL, SearchStates.SEARCH_COMPLETE);
+        throw error;
+      })
+      .catch(error => {
+        console.error('The following problem was encountered while processing universal search results: ' + error);
       });
   }
 

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -433,14 +433,14 @@ export default class Core {
    * @param {Searcher} searcherType
    */
   _markSearchComplete (searcherType) {
-    // const resultStorageKey = searcherType === Searcher.UNIVERSAL
-    //   ? StorageKeys.UNIVERSAL_RESULTS
-    //   : StorageKeys.VERTICAL_RESULTS;
-    // const results = this.storage.get(resultStorageKey);
-    // if (results) {
-    //   results.searchState = SearchStates.SEARCH_COMPLETE;
-    //   this.storage.set(resultStorageKey, results);
-    // }
+    const resultStorageKey = searcherType === Searcher.UNIVERSAL
+      ? StorageKeys.UNIVERSAL_RESULTS
+      : StorageKeys.VERTICAL_RESULTS;
+    const results = this.storage.get(resultStorageKey);
+    if (results) {
+      results.searchState = SearchStates.SEARCH_COMPLETE;
+      this.storage.set(resultStorageKey, results);
+    }
     const directanswer = this.storage.get(StorageKeys.DIRECT_ANSWER);
     if (directanswer) {
       directanswer.searchState = SearchStates.SEARCH_COMPLETE;

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -323,9 +323,6 @@ export default class Core {
         window.performance.mark('yext.answers.verticalQueryResponseRendered');
       }).catch(error => {
         console.error('Vertical search failed with the following error: ' + error);
-        this.storage.set(StorageKeys.VERTICAL_RESULTS, new VerticalResults());
-        this.storage.set(StorageKeys.DIRECT_ANSWER, new DirectAnswer());
-        this.storage.set(StorageKeys.LOCATION_BIAS, new LocationBias({}));
       });
   }
 
@@ -417,9 +414,6 @@ export default class Core {
         window.performance.mark('yext.answers.universalQueryResponseRendered');
       }).catch(error => {
         console.error('Universal search failed with the following error: ' + error);
-        this.storage.set(StorageKeys.UNIVERSAL_RESULTS, new UniversalResults({}));
-        this.storage.set(StorageKeys.DIRECT_ANSWER, new DirectAnswer());
-        this.storage.set(StorageKeys.LOCATION_BIAS, new LocationBias({}));
       });
   }
 

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -428,7 +428,10 @@ export default class Core {
   }
 
   /**
-   * Update the search state of the results in storage to SEARCH_COMPLETE.
+   * Update the search state of the results in storage to SEARCH_COMPLETE
+   * when handling errors from universal and vertical search. This will
+   * trigger a rerender of the components, which could potentially throw
+   * a new error.
    *
    * @param {Searcher} searcherType
    */
@@ -437,17 +440,17 @@ export default class Core {
       ? StorageKeys.UNIVERSAL_RESULTS
       : StorageKeys.VERTICAL_RESULTS;
     const results = this.storage.get(resultStorageKey);
-    if (results) {
+    if (results && results.searchState !== SearchStates.SEARCH_COMPLETE) {
       results.searchState = SearchStates.SEARCH_COMPLETE;
       this.storage.set(resultStorageKey, results);
     }
     const directanswer = this.storage.get(StorageKeys.DIRECT_ANSWER);
-    if (directanswer) {
+    if (directanswer && directanswer.searchState !== SearchStates.SEARCH_COMPLETE) {
       directanswer.searchState = SearchStates.SEARCH_COMPLETE;
       this.storage.set(StorageKeys.DIRECT_ANSWER, directanswer);
     }
     const locationbias = this.storage.get(StorageKeys.LOCATION_BIAS);
-    if (locationbias) {
+    if (locationbias && locationbias.searchState !== SearchStates.SEARCH_COMPLETE) {
       locationbias.searchState = SearchStates.SEARCH_COMPLETE;
       this.storage.set(StorageKeys.LOCATION_BIAS, locationbias);
     }

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -273,6 +273,9 @@ export default class Core {
         querySource: this.storage.get(StorageKeys.QUERY_SOURCE),
         additionalHttpHeaders: this._additionalHttpHeaders
       })
+      .catch(error => {
+        console.error('The following problem was encountered while executing a vertical search: ' + error);
+      })
       .then(response => SearchDataTransformer.transformVertical(response, this._fieldFormatters, verticalKey))
       .then(data => {
         this._persistFacets();
@@ -322,7 +325,7 @@ export default class Core {
         this.updateHistoryAfterSearch(queryTrigger);
         window.performance.mark('yext.answers.verticalQueryResponseRendered');
       }).catch(error => {
-        console.error('Vertical search failed with the following error: ' + error);
+        console.error('The following problem was encountered while processing vertical search results: ' + error);
       });
   }
 
@@ -390,6 +393,9 @@ export default class Core {
         querySource: this.storage.get(StorageKeys.QUERY_SOURCE),
         additionalHttpHeaders: this._additionalHttpHeaders
       })
+      .catch(error => {
+        console.error('The following problem was encountered while executing a universal search: ' + error);
+      })
       .then(response => SearchDataTransformer.transformUniversal(response, urls, this._fieldFormatters))
       .then(data => {
         this._reportFollowUpQueryEvent(data[StorageKeys.QUERY_ID], Searcher.UNIVERSAL);
@@ -413,7 +419,7 @@ export default class Core {
         this.updateHistoryAfterSearch(queryTrigger);
         window.performance.mark('yext.answers.universalQueryResponseRendered');
       }).catch(error => {
-        console.error('Universal search failed with the following error: ' + error);
+        console.error('The following problem was encountered while processing universal search results: ' + error);
       });
   }
 

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -274,6 +274,10 @@ export default class Core {
         additionalHttpHeaders: this._additionalHttpHeaders
       })
       .catch(error => {
+        this._markSearchComplete(Searcher.VERTICAL, SearchStates.SEARCH_COMPLETE);
+        throw error;
+      })
+      .catch(error => {
         console.error('The following problem was encountered while executing a vertical search: ' + error);
       })
       .then(response => SearchDataTransformer.transformVertical(response, this._fieldFormatters, verticalKey))
@@ -326,7 +330,7 @@ export default class Core {
         window.performance.mark('yext.answers.verticalQueryResponseRendered');
       })
       .catch(error => {
-        this._updateResultsSearchState(Searcher.VERTICAL, SearchStates.SEARCH_COMPLETE);
+        this._markSearchComplete(Searcher.VERTICAL, SearchStates.SEARCH_COMPLETE);
         throw error;
       })
       .catch(error => {
@@ -399,6 +403,10 @@ export default class Core {
         additionalHttpHeaders: this._additionalHttpHeaders
       })
       .catch(error => {
+        this._markSearchComplete(Searcher.UNIVERSAL, SearchStates.SEARCH_COMPLETE);
+        throw error;
+      })
+      .catch(error => {
         console.error('The following problem was encountered while executing a universal search: ' + error);
       })
       .then(response => SearchDataTransformer.transformUniversal(response, urls, this._fieldFormatters))
@@ -425,7 +433,7 @@ export default class Core {
         window.performance.mark('yext.answers.universalQueryResponseRendered');
       })
       .catch(error => {
-        this._updateResultsSearchState(Searcher.UNIVERSAL, SearchStates.SEARCH_COMPLETE);
+        this._markSearchComplete(Searcher.UNIVERSAL, SearchStates.SEARCH_COMPLETE);
         throw error;
       })
       .catch(error => {
@@ -434,27 +442,26 @@ export default class Core {
   }
 
   /**
-   * Update the search state of the results in storage
+   * Update the search state of the results in storage to SEARCH_COMPLETE.
    *
    * @param {Searcher} searcherType
-   * @param {SearchStates} searchState
    */
-  _updateResultsSearchState (searcherType, searchState) {
+  _markSearchComplete (searcherType) {
     const results = searcherType === Searcher.UNIVERSAL
       ? this.storage.get(StorageKeys.UNIVERSAL_RESULTS)
       : this.storage.get(StorageKeys.VERTICAL_RESULTS);
     if (results) {
-      results.searchState = searchState;
+      results.searchState = SearchStates.SEARCH_COMPLETE;
       this.storage.set(StorageKeys.UNIVERSAL_RESULTS, results);
     }
     const directanswer = this.storage.get(StorageKeys.DIRECT_ANSWER);
     if (directanswer) {
-      directanswer.searchState = searchState;
+      directanswer.searchState = SearchStates.SEARCH_COMPLETE;
       this.storage.set(StorageKeys.DIRECT_ANSWER, directanswer);
     }
     const locationbias = this.storage.get(StorageKeys.LOCATION_BIAS);
     if (locationbias) {
-      locationbias.searchState = searchState;
+      locationbias.searchState = SearchStates.SEARCH_COMPLETE;
       this.storage.set(StorageKeys.LOCATION_BIAS, locationbias);
     }
   }

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -274,7 +274,7 @@ export default class Core {
         additionalHttpHeaders: this._additionalHttpHeaders
       })
       .catch(error => {
-        this._markSearchComplete(Searcher.VERTICAL, SearchStates.SEARCH_COMPLETE);
+        this._markSearchComplete(Searcher.VERTICAL);
         throw error;
       })
       .catch(error => {
@@ -330,7 +330,7 @@ export default class Core {
         window.performance.mark('yext.answers.verticalQueryResponseRendered');
       })
       .catch(error => {
-        this._markSearchComplete(Searcher.VERTICAL, SearchStates.SEARCH_COMPLETE);
+        this._markSearchComplete(Searcher.VERTICAL);
         throw error;
       })
       .catch(error => {
@@ -403,7 +403,7 @@ export default class Core {
         additionalHttpHeaders: this._additionalHttpHeaders
       })
       .catch(error => {
-        this._markSearchComplete(Searcher.UNIVERSAL, SearchStates.SEARCH_COMPLETE);
+        this._markSearchComplete(Searcher.UNIVERSAL);
         throw error;
       })
       .catch(error => {
@@ -433,7 +433,7 @@ export default class Core {
         window.performance.mark('yext.answers.universalQueryResponseRendered');
       })
       .catch(error => {
-        this._markSearchComplete(Searcher.UNIVERSAL, SearchStates.SEARCH_COMPLETE);
+        this._markSearchComplete(Searcher.UNIVERSAL);
         throw error;
       })
       .catch(error => {

--- a/src/core/models/directanswer.js
+++ b/src/core/models/directanswer.js
@@ -5,7 +5,6 @@ import SearchStates from '../storage/searchstates';
 export default class DirectAnswer {
   constructor (directAnswer = {}) {
     Object.assign(this, { searchState: SearchStates.SEARCH_COMPLETE }, directAnswer);
-    Object.freeze(this);
   }
 
   /**

--- a/src/core/models/verticalresults.js
+++ b/src/core/models/verticalresults.js
@@ -17,8 +17,6 @@ export default class VerticalResults {
      * @type {ResultsContext}
      */
     this.resultsContext = data.resultsContext;
-
-    Object.freeze(this);
   }
 
   /**

--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -376,20 +376,38 @@ export default class Component {
     // Process the DOM to determine if we should create
     // in-memory sub-components for rendering
     const domComponents = DOM.queryAll(this._container, '[data-component]:not([data-is-component-mounted])');
-    const data = this.transformData
-      ? this.transformData(cloneDeep(this._state.get()))
-      : this._state.get();
-    domComponents.forEach(c => this._createSubcomponent(c, data));
-
+    let data;
+    try {
+      data = this.transformData
+        ? this.transformData(cloneDeep(this._state.get()))
+        : this._state.get();
+    } catch (e) {
+      console.error(`The following problem occurred while transforming data for sub-components of ${this.name}: `, e);
+    }
+    domComponents.forEach(c => {
+      try {
+        this._createSubcomponent(c, data);
+      } catch (e) {
+        console.error('The following problem occurred while initializing sub-component: ', c, e);
+      }
+    });
     if (this._progressivelyRenderChildren) {
       this._children.forEach(child => {
         setTimeout(() => {
-          child.mount();
+          try {
+            child.mount();
+          } catch (e) {
+            console.error('The following problem occurred while mounting sub-component: ', child, e);
+          }
         });
       });
     } else {
       this._children.forEach(child => {
-        child.mount();
+        try {
+          child.mount();
+        } catch (e) {
+          console.error('The following problem occurred while mounting sub-component: ', child, e);
+        }
       });
     }
 


### PR DESCRIPTION
 Rendering failures leading to the catch statements in Universal and Vertical search would clear all results. User would still expects other results from the response to render on page. This pr updates the `storage.set` calls to only update the searchState, instead of storing a new empty results, so the non-problematic result sets can still be render.
 
The catch statements in core.js will terminate any further rendering of sub components once it encounter a problematic sub component. User expects sdk to render as much as it can. To ensure non-problematic sub-components can still render, this pr added more catch statements in component.js to gracefully handle errors coming from individual child component's data transformation, initialization and mount stage.

J=none
TEST=manual

use `dev-keep-data-on-search-failure` for SDK version ([from this test branch](https://github.com/yext/answers-search-ui/pull/1745)) in the config file of the site with the issue. Searched 'Listings', and see that the same error appeared in console but the other cards still render as normal.
use `dev-dont-clear-data-on-failure` to test changes in this pr through local html pages that use SDK directly. See that errors are logged but the loading icon is reset to complete during error handling process