### PR TITLE
Upgrade @percy/cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@babel/plugin-transform-runtime": "^7.9.0",
         "@babel/preset-env": "^7.13.10",
         "@babel/runtime-corejs3": "^7.13.10",
-        "@percy/cli": "1.0.0-beta.76",
+        "@percy/cli": "^1.2.1",
         "@percy/puppeteer": "^2.0.0",
         "@rollup/plugin-json": "^4.1.0",
         "@size-limit/file": "^4.9.0",
@@ -89,6 +89,7 @@
         "rollup-plugin-node-resolve": "^4.0.1",
         "rollup-plugin-svg": "^2.0.0",
         "sass": "^1.34.0",
+        "serve-handler": "^6.1.3",
         "size-limit": "^4.9.0",
         "stylelint": "^14.5.3",
         "stylelint-config-standard-scss": "^3.0.0",
@@ -98,7 +99,7 @@
         "vinyl-source-stream": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3240,193 +3241,202 @@
       }
     },
     "node_modules/@percy/cli": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.0.0-beta.76.tgz",
-      "integrity": "sha512-X3I+28KNedv2vlitVnhu751QdxC0JMmFN51gOBNHkh4gy5rU372oQk1Y6XUQHYjq69BvZMHJnv4Pxhh2RFDZgg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.2.1.tgz",
+      "integrity": "sha512-UClQXESfjQlfOsJ4pBrYF6nvOjIHvlRLWBfYj0SuLE2aRTO03Ehis+40dNlMUHVzbywdaXC0EAqyQqk6YBOTlg==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-build": "1.0.0-beta.76",
-        "@percy/cli-command": "1.0.0-beta.76",
-        "@percy/cli-config": "1.0.0-beta.76",
-        "@percy/cli-exec": "1.0.0-beta.76",
-        "@percy/cli-snapshot": "1.0.0-beta.76",
-        "@percy/cli-upload": "1.0.0-beta.76",
-        "@percy/client": "1.0.0-beta.76",
-        "@percy/logger": "1.0.0-beta.76"
+        "@percy/cli-build": "1.2.1",
+        "@percy/cli-command": "1.2.1",
+        "@percy/cli-config": "1.2.1",
+        "@percy/cli-exec": "1.2.1",
+        "@percy/cli-snapshot": "1.2.1",
+        "@percy/cli-upload": "1.2.1",
+        "@percy/client": "1.2.1",
+        "@percy/logger": "1.2.1"
       },
       "bin": {
-        "percy": "bin/run"
+        "percy": "bin/run.cjs"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/cli-build": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.0.0-beta.76.tgz",
-      "integrity": "sha512-8NRos48C/CL8s8SahKIx/c65P6rBsSxWYojqzIL73dOCwEsWf/X8/r7Jf4DS6oK8A56g7F1KfDLsaMFdRQi5YA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.2.1.tgz",
+      "integrity": "sha512-Xs7N0Z2Yzj9/cZ5ii0jimO8HYtuKxSlj9/pR7n3IjtXhmW9oThNMCjYfNiOiQ/MigzVJgLMnnbgsyhm8/+9X3w==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.0.0-beta.76",
-        "@percy/logger": "1.0.0-beta.76"
+        "@percy/cli-command": "1.2.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/cli-command": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.0.0-beta.76.tgz",
-      "integrity": "sha512-/ceDY2Y+l7uv+ttIxbS0+VPY4/EJpL64oXblCwz1Ecd+5yFE1Ud+wWpdAWJxqc8Vipt+eMC+E7swB1U5X99ZEA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.2.1.tgz",
+      "integrity": "sha512-jW7p8MJ3+ZCXCbB0Pv2gUifAzGdY+RhS45a/1jpCj68VHXen6FynPX0XNNnzl1CbYDZ6wkqis3IMIuNdbsKSlw==",
       "dev": true,
       "dependencies": {
-        "@percy/config": "1.0.0-beta.76",
-        "@percy/core": "1.0.0-beta.76",
-        "@percy/logger": "1.0.0-beta.76"
+        "@percy/config": "1.2.1",
+        "@percy/core": "1.2.1",
+        "@percy/logger": "1.2.1"
       },
       "bin": {
-        "percy-cli-readme": "bin/readme"
+        "percy-cli-readme": "bin/readme.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/cli-config": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.0.0-beta.76.tgz",
-      "integrity": "sha512-quYr2hYqeafDnHFPKZQlncy5qPkmjfPg22mv/HmABqH+GPe30gADOEqOAW0/NeprK+jq2IRxx3NdYKUBa/kZAg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.2.1.tgz",
+      "integrity": "sha512-m2Kt6rSZgXw1t7hRLT11eyyCRXXD2xEATqVJH37Q1qMMid4VCCCY88AFaYH+E965UAgMkTVqVyk2ydsDb9gMAg==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.0.0-beta.76",
-        "@percy/config": "1.0.0-beta.76"
+        "@percy/cli-command": "1.2.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/cli-exec": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.0.0-beta.76.tgz",
-      "integrity": "sha512-SJWZ8m3duNWJZzqd0m34Gnydn5vTS84jwt4+nhZ3/gqSmNN9QLX0fJJNGpRjuB7oVzEzdh1pAhaxyIM7+0pV8A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.2.1.tgz",
+      "integrity": "sha512-7K6SOt/ORsr1PQ9hp16xkPWaR9IF0Z2bZfOjGw4dr3pqVYZu/sW9gCttiOH9ONG9fjA2faDuXuS91NW0EkABAQ==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.0.0-beta.76",
-        "@percy/core": "1.0.0-beta.76",
+        "@percy/cli-command": "1.2.1",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/cli-snapshot": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.0.0-beta.76.tgz",
-      "integrity": "sha512-C981wuC0lm0i4plbRqtlOMHx+/0lIyGGII3ypTs7pFwY1CrNiy7+bWXfdD/PHdVCVZ+YeVuqjEB1GA9A05u8oQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.2.1.tgz",
+      "integrity": "sha512-cuem4pH6eEbaPIyOjsXM7BnfVe2sEVcRZOvhaA/P7d44TEWDgCQeTfHvCiDQM+aoXaqjJ7mq2Ezg+jxfWA19DQ==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.0.0-beta.76",
-        "@percy/config": "1.0.0-beta.76",
-        "@percy/core": "1.0.0-beta.76",
-        "globby": "^11.0.4",
-        "path-to-regexp": "^6.2.0",
-        "picomatch": "^2.3.0",
-        "serve-handler": "^6.1.3",
-        "yaml": "^1.10.0"
+        "@percy/cli-command": "1.2.1",
+        "yaml": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-snapshot/node_modules/yaml": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.0.tgz",
+      "integrity": "sha512-OuAINfTsoJrY5H7CBWnKZhX6nZciXBydrMtTHr1dC4nP40X5jyTIVlogZHxSlVZM8zSgXRfgZGsaHF4+pV+JRw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@percy/cli-upload": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.0.0-beta.76.tgz",
-      "integrity": "sha512-5hz3PCEl9MMF2Fkqn6QKUk+hJVfGZLuJLm6zYOcAF2FdLbw6CnFN8dz8K4EIrQLjH3DgTbI+YkEsr7b89V+aLA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.2.1.tgz",
+      "integrity": "sha512-yJDqFDtm3if6Ggk+XP3nkfFM/vVzoVxzlD2Vjhz387fzKHKeMPVrhAeBTr8ng8Luxi50bHlNtBVzHeQf1BWfDg==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.0.0-beta.76",
-        "@percy/client": "1.0.0-beta.76",
-        "@percy/logger": "1.0.0-beta.76",
-        "globby": "^11.0.4",
+        "@percy/cli-command": "1.2.1",
+        "fast-glob": "^3.2.11",
         "image-size": "^1.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/client": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.0.0-beta.76.tgz",
-      "integrity": "sha512-vq0npya/YobIwbqrhiCXF7liwHJNmMEiAkefv5AXLmhCxIJ9eWjvgYew4xssuf+QPHfdv10EVa5kkMSr8INxeA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.2.1.tgz",
+      "integrity": "sha512-YmpCgISEyiyGxeLKVuq0zPWn2SeHeg/pO2T17MKp2VxtEFxEtjul5mV/5qZ7QdN7EsWz47nzuENEBRWX0pDxxQ==",
       "dev": true,
       "dependencies": {
-        "@percy/env": "1.0.0-beta.76",
-        "@percy/logger": "1.0.0-beta.76"
+        "@percy/env": "1.2.1",
+        "@percy/logger": "1.2.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/config": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.0.0-beta.76.tgz",
-      "integrity": "sha512-e3sLzcrVlsax5q1RwO8sek2Qjqb617WFpa1+wnXqPSMSxiEBlr+lbUC/C5a1hHKEWdFz4RKSJC+2mjhT8ylm3g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.2.1.tgz",
+      "integrity": "sha512-uv8tTMUFlFwQoYdV+Zxn6UoeuHXws9nfu8e7tQC7oQyg+AXYq06cqgxhFyHAyfGIhLZqyH5f4E+qCCCeTDJVqQ==",
       "dev": true,
       "dependencies": {
-        "@percy/logger": "1.0.0-beta.76",
+        "@percy/logger": "1.2.1",
         "ajv": "^8.6.2",
         "cosmiconfig": "^7.0.0",
-        "yaml": "^1.10.0"
+        "yaml": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/config/node_modules/yaml": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.0.tgz",
+      "integrity": "sha512-OuAINfTsoJrY5H7CBWnKZhX6nZciXBydrMtTHr1dC4nP40X5jyTIVlogZHxSlVZM8zSgXRfgZGsaHF4+pV+JRw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@percy/core": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.0.0-beta.76.tgz",
-      "integrity": "sha512-sTtwdNBmhX/IvKrNGT3TWrZ0ngJZ2Kh6Y4m9M9H4pciGHmiSFcMqsBB0tK6IMbfIsGqFz8ePOTj++4RLSMlK/g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-jvSW+5O1Ijlvg8pJl9BRMhj7GHHrTCFlvH7A5hl750sdpqYVKI/blOJKjKIapYDIGbGKBp8KRRM/xqXVQM5k3g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@percy/client": "1.0.0-beta.76",
-        "@percy/config": "1.0.0-beta.76",
-        "@percy/dom": "1.0.0-beta.76",
-        "@percy/logger": "1.0.0-beta.76",
+        "@percy/client": "1.2.1",
+        "@percy/config": "1.2.1",
+        "@percy/dom": "1.2.1",
+        "@percy/logger": "1.2.1",
         "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
+        "fast-glob": "^3.2.11",
+        "micromatch": "^4.0.4",
         "mime-types": "^2.1.34",
         "path-to-regexp": "^6.2.0",
         "rimraf": "^3.0.2",
         "ws": "^8.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/dom": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.0.0-beta.76.tgz",
-      "integrity": "sha512-9v/yXjIe2UhAkjnO2pWT0Ki4rzgIl0Z6YyWcn1b5NfsBcMm99Hcse+otDsQJF8z0MkU4ZykiPY63zmjs45wChQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.2.1.tgz",
+      "integrity": "sha512-C3U95vTiJGDllGJFkKpKRyUC39acze0nUxY/BSZCVFPL2tYmW6QTUr+y0+HXbYUmglylzaWWHRsc5+HtDyMfTw==",
       "dev": true
     },
     "node_modules/@percy/env": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.0.0-beta.76.tgz",
-      "integrity": "sha512-+Mx9K3wjFriMT0cMD5l+VRo6mhQ/XssKy77SUeWrOaGIk7Xs/FsnDUpLOCXAGUeJr1AznZM76ng99IOBM6pY4w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.2.1.tgz",
+      "integrity": "sha512-vXBX0xKGzEaygGFAlQkuv9/IemiulDK/YTWtza53HTAoEfRsITpOsx5KGckbVrNd1l3zOh/bonDzAHneLaCDGw==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/logger": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.0-beta.76.tgz",
-      "integrity": "sha512-v5zIMNv1xqdcWBAOK5A6ZEO99ZBwzWS3phLEfkKbIlGIUxvjkJHSfZv/k1dnt2RRfpDNkM6X5pMg2yI8j1+d+g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.2.1.tgz",
+      "integrity": "sha512-Yo/Df6w1O+IV8mTMfcObk2DZK2BrNAC1yx3UBAcbPV/vGkg+vJa/lRVtJl2rGBO0yh3n5HSFlPjkhadrc/h7/g==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@percy/puppeteer": {
@@ -25830,128 +25840,135 @@
       }
     },
     "@percy/cli": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.0.0-beta.76.tgz",
-      "integrity": "sha512-X3I+28KNedv2vlitVnhu751QdxC0JMmFN51gOBNHkh4gy5rU372oQk1Y6XUQHYjq69BvZMHJnv4Pxhh2RFDZgg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.2.1.tgz",
+      "integrity": "sha512-UClQXESfjQlfOsJ4pBrYF6nvOjIHvlRLWBfYj0SuLE2aRTO03Ehis+40dNlMUHVzbywdaXC0EAqyQqk6YBOTlg==",
       "dev": true,
       "requires": {
-        "@percy/cli-build": "1.0.0-beta.76",
-        "@percy/cli-command": "1.0.0-beta.76",
-        "@percy/cli-config": "1.0.0-beta.76",
-        "@percy/cli-exec": "1.0.0-beta.76",
-        "@percy/cli-snapshot": "1.0.0-beta.76",
-        "@percy/cli-upload": "1.0.0-beta.76",
-        "@percy/client": "1.0.0-beta.76",
-        "@percy/logger": "1.0.0-beta.76"
+        "@percy/cli-build": "1.2.1",
+        "@percy/cli-command": "1.2.1",
+        "@percy/cli-config": "1.2.1",
+        "@percy/cli-exec": "1.2.1",
+        "@percy/cli-snapshot": "1.2.1",
+        "@percy/cli-upload": "1.2.1",
+        "@percy/client": "1.2.1",
+        "@percy/logger": "1.2.1"
       }
     },
     "@percy/cli-build": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.0.0-beta.76.tgz",
-      "integrity": "sha512-8NRos48C/CL8s8SahKIx/c65P6rBsSxWYojqzIL73dOCwEsWf/X8/r7Jf4DS6oK8A56g7F1KfDLsaMFdRQi5YA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.2.1.tgz",
+      "integrity": "sha512-Xs7N0Z2Yzj9/cZ5ii0jimO8HYtuKxSlj9/pR7n3IjtXhmW9oThNMCjYfNiOiQ/MigzVJgLMnnbgsyhm8/+9X3w==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.0.0-beta.76",
-        "@percy/logger": "1.0.0-beta.76"
+        "@percy/cli-command": "1.2.1"
       }
     },
     "@percy/cli-command": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.0.0-beta.76.tgz",
-      "integrity": "sha512-/ceDY2Y+l7uv+ttIxbS0+VPY4/EJpL64oXblCwz1Ecd+5yFE1Ud+wWpdAWJxqc8Vipt+eMC+E7swB1U5X99ZEA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.2.1.tgz",
+      "integrity": "sha512-jW7p8MJ3+ZCXCbB0Pv2gUifAzGdY+RhS45a/1jpCj68VHXen6FynPX0XNNnzl1CbYDZ6wkqis3IMIuNdbsKSlw==",
       "dev": true,
       "requires": {
-        "@percy/config": "1.0.0-beta.76",
-        "@percy/core": "1.0.0-beta.76",
-        "@percy/logger": "1.0.0-beta.76"
+        "@percy/config": "1.2.1",
+        "@percy/core": "1.2.1",
+        "@percy/logger": "1.2.1"
       }
     },
     "@percy/cli-config": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.0.0-beta.76.tgz",
-      "integrity": "sha512-quYr2hYqeafDnHFPKZQlncy5qPkmjfPg22mv/HmABqH+GPe30gADOEqOAW0/NeprK+jq2IRxx3NdYKUBa/kZAg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.2.1.tgz",
+      "integrity": "sha512-m2Kt6rSZgXw1t7hRLT11eyyCRXXD2xEATqVJH37Q1qMMid4VCCCY88AFaYH+E965UAgMkTVqVyk2ydsDb9gMAg==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.0.0-beta.76",
-        "@percy/config": "1.0.0-beta.76"
+        "@percy/cli-command": "1.2.1"
       }
     },
     "@percy/cli-exec": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.0.0-beta.76.tgz",
-      "integrity": "sha512-SJWZ8m3duNWJZzqd0m34Gnydn5vTS84jwt4+nhZ3/gqSmNN9QLX0fJJNGpRjuB7oVzEzdh1pAhaxyIM7+0pV8A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.2.1.tgz",
+      "integrity": "sha512-7K6SOt/ORsr1PQ9hp16xkPWaR9IF0Z2bZfOjGw4dr3pqVYZu/sW9gCttiOH9ONG9fjA2faDuXuS91NW0EkABAQ==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.0.0-beta.76",
-        "@percy/core": "1.0.0-beta.76",
+        "@percy/cli-command": "1.2.1",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       }
     },
     "@percy/cli-snapshot": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.0.0-beta.76.tgz",
-      "integrity": "sha512-C981wuC0lm0i4plbRqtlOMHx+/0lIyGGII3ypTs7pFwY1CrNiy7+bWXfdD/PHdVCVZ+YeVuqjEB1GA9A05u8oQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.2.1.tgz",
+      "integrity": "sha512-cuem4pH6eEbaPIyOjsXM7BnfVe2sEVcRZOvhaA/P7d44TEWDgCQeTfHvCiDQM+aoXaqjJ7mq2Ezg+jxfWA19DQ==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.0.0-beta.76",
-        "@percy/config": "1.0.0-beta.76",
-        "@percy/core": "1.0.0-beta.76",
-        "globby": "^11.0.4",
-        "path-to-regexp": "^6.2.0",
-        "picomatch": "^2.3.0",
-        "serve-handler": "^6.1.3",
-        "yaml": "^1.10.0"
+        "@percy/cli-command": "1.2.1",
+        "yaml": "^2.0.0"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.0.tgz",
+          "integrity": "sha512-OuAINfTsoJrY5H7CBWnKZhX6nZciXBydrMtTHr1dC4nP40X5jyTIVlogZHxSlVZM8zSgXRfgZGsaHF4+pV+JRw==",
+          "dev": true
+        }
       }
     },
     "@percy/cli-upload": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.0.0-beta.76.tgz",
-      "integrity": "sha512-5hz3PCEl9MMF2Fkqn6QKUk+hJVfGZLuJLm6zYOcAF2FdLbw6CnFN8dz8K4EIrQLjH3DgTbI+YkEsr7b89V+aLA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.2.1.tgz",
+      "integrity": "sha512-yJDqFDtm3if6Ggk+XP3nkfFM/vVzoVxzlD2Vjhz387fzKHKeMPVrhAeBTr8ng8Luxi50bHlNtBVzHeQf1BWfDg==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.0.0-beta.76",
-        "@percy/client": "1.0.0-beta.76",
-        "@percy/logger": "1.0.0-beta.76",
-        "globby": "^11.0.4",
+        "@percy/cli-command": "1.2.1",
+        "fast-glob": "^3.2.11",
         "image-size": "^1.0.0"
       }
     },
     "@percy/client": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.0.0-beta.76.tgz",
-      "integrity": "sha512-vq0npya/YobIwbqrhiCXF7liwHJNmMEiAkefv5AXLmhCxIJ9eWjvgYew4xssuf+QPHfdv10EVa5kkMSr8INxeA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.2.1.tgz",
+      "integrity": "sha512-YmpCgISEyiyGxeLKVuq0zPWn2SeHeg/pO2T17MKp2VxtEFxEtjul5mV/5qZ7QdN7EsWz47nzuENEBRWX0pDxxQ==",
       "dev": true,
       "requires": {
-        "@percy/env": "1.0.0-beta.76",
-        "@percy/logger": "1.0.0-beta.76"
+        "@percy/env": "1.2.1",
+        "@percy/logger": "1.2.1"
       }
     },
     "@percy/config": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.0.0-beta.76.tgz",
-      "integrity": "sha512-e3sLzcrVlsax5q1RwO8sek2Qjqb617WFpa1+wnXqPSMSxiEBlr+lbUC/C5a1hHKEWdFz4RKSJC+2mjhT8ylm3g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.2.1.tgz",
+      "integrity": "sha512-uv8tTMUFlFwQoYdV+Zxn6UoeuHXws9nfu8e7tQC7oQyg+AXYq06cqgxhFyHAyfGIhLZqyH5f4E+qCCCeTDJVqQ==",
       "dev": true,
       "requires": {
-        "@percy/logger": "1.0.0-beta.76",
+        "@percy/logger": "1.2.1",
         "ajv": "^8.6.2",
         "cosmiconfig": "^7.0.0",
-        "yaml": "^1.10.0"
+        "yaml": "^2.0.0"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.0.tgz",
+          "integrity": "sha512-OuAINfTsoJrY5H7CBWnKZhX6nZciXBydrMtTHr1dC4nP40X5jyTIVlogZHxSlVZM8zSgXRfgZGsaHF4+pV+JRw==",
+          "dev": true
+        }
       }
     },
     "@percy/core": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.0.0-beta.76.tgz",
-      "integrity": "sha512-sTtwdNBmhX/IvKrNGT3TWrZ0ngJZ2Kh6Y4m9M9H4pciGHmiSFcMqsBB0tK6IMbfIsGqFz8ePOTj++4RLSMlK/g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-jvSW+5O1Ijlvg8pJl9BRMhj7GHHrTCFlvH7A5hl750sdpqYVKI/blOJKjKIapYDIGbGKBp8KRRM/xqXVQM5k3g==",
       "dev": true,
       "requires": {
-        "@percy/client": "1.0.0-beta.76",
-        "@percy/config": "1.0.0-beta.76",
-        "@percy/dom": "1.0.0-beta.76",
-        "@percy/logger": "1.0.0-beta.76",
+        "@percy/client": "1.2.1",
+        "@percy/config": "1.2.1",
+        "@percy/dom": "1.2.1",
+        "@percy/logger": "1.2.1",
         "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
+        "fast-glob": "^3.2.11",
+        "micromatch": "^4.0.4",
         "mime-types": "^2.1.34",
         "path-to-regexp": "^6.2.0",
         "rimraf": "^3.0.2",
@@ -25959,21 +25976,21 @@
       }
     },
     "@percy/dom": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.0.0-beta.76.tgz",
-      "integrity": "sha512-9v/yXjIe2UhAkjnO2pWT0Ki4rzgIl0Z6YyWcn1b5NfsBcMm99Hcse+otDsQJF8z0MkU4ZykiPY63zmjs45wChQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.2.1.tgz",
+      "integrity": "sha512-C3U95vTiJGDllGJFkKpKRyUC39acze0nUxY/BSZCVFPL2tYmW6QTUr+y0+HXbYUmglylzaWWHRsc5+HtDyMfTw==",
       "dev": true
     },
     "@percy/env": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.0.0-beta.76.tgz",
-      "integrity": "sha512-+Mx9K3wjFriMT0cMD5l+VRo6mhQ/XssKy77SUeWrOaGIk7Xs/FsnDUpLOCXAGUeJr1AznZM76ng99IOBM6pY4w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.2.1.tgz",
+      "integrity": "sha512-vXBX0xKGzEaygGFAlQkuv9/IemiulDK/YTWtza53HTAoEfRsITpOsx5KGckbVrNd1l3zOh/bonDzAHneLaCDGw==",
       "dev": true
     },
     "@percy/logger": {
-      "version": "1.0.0-beta.76",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.0-beta.76.tgz",
-      "integrity": "sha512-v5zIMNv1xqdcWBAOK5A6ZEO99ZBwzWS3phLEfkKbIlGIUxvjkJHSfZv/k1dnt2RRfpDNkM6X5pMg2yI8j1+d+g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.2.1.tgz",
+      "integrity": "sha512-Yo/Df6w1O+IV8mTMfcObk2DZK2BrNAC1yx3UBAcbPV/vGkg+vJa/lRVtJl2rGBO0yh3n5HSFlPjkhadrc/h7/g==",
       "dev": true
     },
     "@percy/puppeteer": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@babel/plugin-transform-runtime": "^7.9.0",
     "@babel/preset-env": "^7.13.10",
     "@babel/runtime-corejs3": "^7.13.10",
-    "@percy/cli": "1.0.0-beta.76",
+    "@percy/cli": "^1.2.1",
     "@percy/puppeteer": "^2.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@size-limit/file": "^4.9.0",
@@ -103,6 +103,7 @@
     "rollup-plugin-node-resolve": "^4.0.1",
     "rollup-plugin-svg": "^2.0.0",
     "sass": "^1.34.0",
+    "serve-handler": "^6.1.3",
     "size-limit": "^4.9.0",
     "stylelint": "^14.5.3",
     "stylelint-config-standard-scss": "^3.0.0",
@@ -176,7 +177,7 @@
   "author": "Yext",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "exports": {
     "./css": "./dist/answers.css",


### PR DESCRIPTION
This PR adds back in the `@percy/cli` upgrade changes that were originally made in PR #1721 and reverted in #1741 due to failing Netlify checks. Since the Netlify checks are no longer needed, we can proceed with the upgrade. The version of `@percy/cli` is now the latest (v1.2.1) and, as noted in the original PR, node versions older than 14 will no longer be supported.

J=SLAP-2045, SLAP-2102
TEST=manual

Check that the Percy snapshots are generated correctly.