### PR TITLE
Use autocomplete fixture

### DIFF
--- a/.github/workflows/build_and_deploy_search_bar.yml
+++ b/.github/workflows/build_and_deploy_search_bar.yml
@@ -1,9 +1,9 @@
 name: Build and deploy search bar
 
 on:
-  push:
-    tags:
-      - 'search-bar-v*'
+  push
+    # tags:
+    #   - 'search-bar-v*'
 
 jobs:
   call_build:
@@ -21,59 +21,59 @@ jobs:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
 
-  call_extract_versions:
-    uses: ./.github/workflows/extract_versions.yml
-    with:
-      ignore_prefix: search-bar-
+  # call_extract_versions:
+  #   uses: ./.github/workflows/extract_versions.yml
+  #   with:
+  #     ignore_prefix: search-bar-
 
-  call_should_deploy_major_version:
-    uses: ./.github/workflows/should_deploy_major_version.yml
-    with:
-      ignore_prefix: search-bar-
+  # call_should_deploy_major_version:
+  #   uses: ./.github/workflows/should_deploy_major_version.yml
+  #   with:
+  #     ignore_prefix: search-bar-
 
-  call_deploy_full_version:
-    needs:
-      - call_acceptance_search_bar
-      - call_extract_versions
-      - call_misc_tests
-    uses: ./.github/workflows/deploy_hold.yml
-    with:
-      bucket: answers-search-bar
-      directory: ${{ needs.call_extract_versions.outputs.full_version }}
-      cache-control: 'max-age=31536000'
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  # call_deploy_full_version:
+  #   needs:
+  #     - call_acceptance_search_bar
+  #     - call_extract_versions
+  #     - call_misc_tests
+  #   uses: ./.github/workflows/deploy_hold.yml
+  #   with:
+  #     bucket: answers-search-bar
+  #     directory: ${{ needs.call_extract_versions.outputs.full_version }}
+  #     cache-control: 'max-age=31536000'
+  #   secrets:
+  #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-  call_deploy_major_version:
-    needs: 
-      - call_acceptance_search_bar
-      - call_extract_versions
-      - call_misc_tests
-      - call_should_deploy_major_version
-    if: ${{ needs.call_should_deploy_major_version.outputs.should_deploy_major_version }}
-    uses: ./.github/workflows/deploy_hold.yml
-    with:
-      bucket: answers-search-bar
-      directory: ${{ needs.call_extract_versions.outputs.major_version }}
-      cache-control: 'max-age=43200'
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  # call_deploy_major_version:
+  #   needs: 
+  #     - call_acceptance_search_bar
+  #     - call_extract_versions
+  #     - call_misc_tests
+  #     - call_should_deploy_major_version
+  #   if: ${{ needs.call_should_deploy_major_version.outputs.should_deploy_major_version }}
+  #   uses: ./.github/workflows/deploy_hold.yml
+  #   with:
+  #     bucket: answers-search-bar
+  #     directory: ${{ needs.call_extract_versions.outputs.major_version }}
+  #     cache-control: 'max-age=43200'
+  #   secrets:
+  #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-  call_deploy_minor_version:
-    needs: 
-      - call_acceptance_search_bar
-      - call_extract_versions
-      - call_misc_tests
-    uses: ./.github/workflows/deploy_hold.yml
-    with:
-      bucket: answers-search-bar
-      directory: ${{ needs.call_extract_versions.outputs.minor_version }}
-      cache-control: 'max-age=43200'
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  # call_deploy_minor_version:
+  #   needs: 
+  #     - call_acceptance_search_bar
+  #     - call_extract_versions
+  #     - call_misc_tests
+  #   uses: ./.github/workflows/deploy_hold.yml
+  #   with:
+  #     bucket: answers-search-bar
+  #     directory: ${{ needs.call_extract_versions.outputs.minor_version }}
+  #     cache-control: 'max-age=43200'
+  #   secrets:
+  #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 concurrency:
   group: ci-build-and-deploy-search-bars-${{ github.ref }}-1

--- a/.github/workflows/build_and_deploy_search_bar.yml
+++ b/.github/workflows/build_and_deploy_search_bar.yml
@@ -1,9 +1,9 @@
 name: Build and deploy search bar
 
 on:
-  push
-    # tags:
-    #   - 'search-bar-v*'
+  push:
+    tags:
+      - 'search-bar-v*'
 
 jobs:
   call_build:
@@ -21,59 +21,59 @@ jobs:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
 
-  # call_extract_versions:
-  #   uses: ./.github/workflows/extract_versions.yml
-  #   with:
-  #     ignore_prefix: search-bar-
+  call_extract_versions:
+    uses: ./.github/workflows/extract_versions.yml
+    with:
+      ignore_prefix: search-bar-
 
-  # call_should_deploy_major_version:
-  #   uses: ./.github/workflows/should_deploy_major_version.yml
-  #   with:
-  #     ignore_prefix: search-bar-
+  call_should_deploy_major_version:
+    uses: ./.github/workflows/should_deploy_major_version.yml
+    with:
+      ignore_prefix: search-bar-
 
-  # call_deploy_full_version:
-  #   needs:
-  #     - call_acceptance_search_bar
-  #     - call_extract_versions
-  #     - call_misc_tests
-  #   uses: ./.github/workflows/deploy_hold.yml
-  #   with:
-  #     bucket: answers-search-bar
-  #     directory: ${{ needs.call_extract_versions.outputs.full_version }}
-  #     cache-control: 'max-age=31536000'
-  #   secrets:
-  #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  call_deploy_full_version:
+    needs:
+      - call_acceptance_search_bar
+      - call_extract_versions
+      - call_misc_tests
+    uses: ./.github/workflows/deploy_hold.yml
+    with:
+      bucket: answers-search-bar
+      directory: ${{ needs.call_extract_versions.outputs.full_version }}
+      cache-control: 'max-age=31536000'
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-  # call_deploy_major_version:
-  #   needs: 
-  #     - call_acceptance_search_bar
-  #     - call_extract_versions
-  #     - call_misc_tests
-  #     - call_should_deploy_major_version
-  #   if: ${{ needs.call_should_deploy_major_version.outputs.should_deploy_major_version }}
-  #   uses: ./.github/workflows/deploy_hold.yml
-  #   with:
-  #     bucket: answers-search-bar
-  #     directory: ${{ needs.call_extract_versions.outputs.major_version }}
-  #     cache-control: 'max-age=43200'
-  #   secrets:
-  #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  call_deploy_major_version:
+    needs: 
+      - call_acceptance_search_bar
+      - call_extract_versions
+      - call_misc_tests
+      - call_should_deploy_major_version
+    if: ${{ needs.call_should_deploy_major_version.outputs.should_deploy_major_version }}
+    uses: ./.github/workflows/deploy_hold.yml
+    with:
+      bucket: answers-search-bar
+      directory: ${{ needs.call_extract_versions.outputs.major_version }}
+      cache-control: 'max-age=43200'
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-  # call_deploy_minor_version:
-  #   needs: 
-  #     - call_acceptance_search_bar
-  #     - call_extract_versions
-  #     - call_misc_tests
-  #   uses: ./.github/workflows/deploy_hold.yml
-  #   with:
-  #     bucket: answers-search-bar
-  #     directory: ${{ needs.call_extract_versions.outputs.minor_version }}
-  #     cache-control: 'max-age=43200'
-  #   secrets:
-  #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  call_deploy_minor_version:
+    needs: 
+      - call_acceptance_search_bar
+      - call_extract_versions
+      - call_misc_tests
+    uses: ./.github/workflows/deploy_hold.yml
+    with:
+      bucket: answers-search-bar
+      directory: ${{ needs.call_extract_versions.outputs.minor_version }}
+      cache-control: 'max-age=43200'
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 concurrency:
   group: ci-build-and-deploy-search-bars-${{ github.ref }}-1

--- a/tests/acceptance/acceptancesuites/filtersearchsuite.js
+++ b/tests/acceptance/acceptancesuites/filtersearchsuite.js
@@ -11,7 +11,7 @@ import { MockedFilterSearchRequest } from '../fixtures/responses/filtersearch/se
 import { MockedVerticalSearchRequest } from '../fixtures/responses/vertical/search';
 import SearchRequestLogger from '../searchrequestlogger';
 
-fixture`Facets page`
+fixture`FilterSearch suite`
   .requestHooks([
     SearchRequestLogger.createVerticalSearchLogger(),
     MockedFilterSearchRequest,

--- a/tests/acceptance/acceptancesuites/searchbaronlysuite.js
+++ b/tests/acceptance/acceptancesuites/searchbaronlysuite.js
@@ -1,6 +1,7 @@
 import { ClientFunction } from 'testcafe';
 import { SEARCH_BAR_ONLY_PAGE } from '../constants';
 import SearchBarOnlyPage from '../pageobjects/searchbaronlypage';
+import { MockedUniversalAutoCompleteRequest } from '../fixtures/responses/universal/autocomplete';
 
 /**
  * This file contains acceptance tests for a SearchBar-only page.
@@ -9,6 +10,7 @@ import SearchBarOnlyPage from '../pageobjects/searchbaronlypage';
  * is closed once all tests have completed.
  */
 fixture`SearchBar-only page works as expected`
+  .requestHooks(MockedUniversalAutoCompleteRequest)
   .page`${SEARCH_BAR_ONLY_PAGE}`;
 
 test('Basic search and redirect flow', async t => {

--- a/tests/acceptance/fixtures/responses/universal/autocomplete.js
+++ b/tests/acceptance/fixtures/responses/universal/autocomplete.js
@@ -33,7 +33,12 @@ function generateAutoCompleteResponse (prompt) {
     ];
   } else if (prompt.startsWith('a')) {
     mockedResponse.response.results = [
-      { value: 'amani farooque phone number', matchedSubstrings: [], queryIntents: [], verticalKeys: [] }
+      {
+        value: 'amani farooque phone number',
+        matchedSubstrings: [],
+        queryIntents: [],
+        verticalKeys: []
+      }
     ];
   }
 


### PR DESCRIPTION
Update the search bar only acceptance suite to use the mocked universal autocomplete fixture. Checked that none of the acceptance tests rely on vertical autocomplete responses (e.g. by selecting an autocomplete option) so a fixture is not needed.

J=SLAP-2174
TEST=auto

See that the tests in the search bar suite pass locally and on the second commit of this PR.