### PR TITLE
acceptance test static filter fixtures, dummy api key, remove `skipJsErrors`

### DIFF
--- a/.github/testcafe.json
+++ b/.github/testcafe.json
@@ -1,6 +1,5 @@
 {
   "src": ["tests/acceptance/acceptancesuites/*.js", "!tests/acceptance/acceptancesuites/searchbaronlysuite.js"],
   "appCommand": "npx serve -l tcp://0.0.0.0:9999",
-  "appInitDelay": 4000,
-  "skipJsErrors": true
+  "appInitDelay": 4000
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
         "size-limit": "^4.9.0",
         "stylelint": "^14.5.3",
         "stylelint-config-standard-scss": "^3.0.0",
-        "testcafe": "^1.18.4",
+        "testcafe": "^1.19.0",
         "vinyl-buffer": "^1.0.1",
         "vinyl-source-stream": "^2.0.0"
       },
@@ -4213,7 +4213,7 @@
     "node_modules/async-exit-hook": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-1.1.2.tgz",
-      "integrity": "sha1-gJXXXkiMKazuBVH+hyUhadeJz7o=",
+      "integrity": "sha512-CeTSWB5Bou31xSHeO45ZKgLPRaJbV4I8csRcFYETDBehX7H+1GDO/v+v8G7fZmar1gOmYa6UTXn6d/WIiJbslw==",
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
@@ -5092,7 +5092,7 @@
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "dev": true
     },
     "node_modules/buffer-es6": {
@@ -6921,6 +6921,15 @@
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true
     },
+    "node_modules/email-validator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
+      "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==",
+      "dev": true,
+      "engines": {
+        "node": ">4.0"
+      }
+    },
     "node_modules/emittery": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.4.1.tgz",
@@ -8703,7 +8712,8 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.1.tgz",
       "integrity": "sha512-oxvgqUYR6O9VkKXrxkJ0NOyU0FrE705MeqgBUMEPWyTu6Pwn768cJbHChw2XOBlgFLKfIHxjr2OOBFpv2mUGZw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/fraction.js": {
       "version": "4.2.0",
@@ -13389,13 +13399,13 @@
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
       "dev": true
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
       "dev": true
     },
     "node_modules/lodash.isequal": {
@@ -13406,25 +13416,25 @@
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
       "dev": true
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
       "dev": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "dev": true
     },
     "node_modules/lodash.memoize": {
@@ -13442,7 +13452,7 @@
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true
     },
     "node_modules/lodash.sortby": {
@@ -13494,25 +13504,49 @@
       }
     },
     "node_modules/log-update-async-hook": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/log-update-async-hook/-/log-update-async-hook-2.0.6.tgz",
-      "integrity": "sha512-UIFPlCpCxrSVL38TXzk34JhhDnvvhsjzuyqooCYy9TtTaVdBLNsuJiTWX9unO/wzBF7RwY1WTCmEmBSI3iPDCA==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/log-update-async-hook/-/log-update-async-hook-2.0.7.tgz",
+      "integrity": "sha512-V9KpD1AZUBd/oiZ+/Xsgd5rRP9awhgtRiDv5Am4VQCixiDnAbXMdt/yKz41kCzYZtVbwC6YCxnWEF3zjNEwktA==",
       "dev": true,
       "dependencies": {
-        "ansi-escapes": "^2.0.0",
+        "ansi-escapes": "^4.3.2",
         "async-exit-hook": "^1.1.2",
         "onetime": "^2.0.1",
-        "wrap-ansi": "^2.1.0"
+        "wrap-ansi": "^7.0.0"
       }
     },
-    "node_modules/log-update-async-hook/node_modules/ansi-escapes": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
-      "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+    "node_modules/log-update-async-hook/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/log-update-async-hook/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/log-update-async-hook/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/log-update-async-hook/node_modules/mimic-fn": {
       "version": "1.2.0",
@@ -13526,13 +13560,30 @@
     "node_modules/log-update-async-hook/node_modules/onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
       "dev": true,
       "dependencies": {
         "mimic-fn": "^1.0.0"
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/log-update-async-hook/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/longest": {
@@ -20195,9 +20246,9 @@
       }
     },
     "node_modules/testcafe": {
-      "version": "1.18.6",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.18.6.tgz",
-      "integrity": "sha512-5X/Chn5zbHy8TftyB/iXfKOizrYM8vrNLSjjyRQCW2IpYh//7EUJ0MZmBKRcXye9//eLaOoUBs/FDvAW55j4Lw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.19.0.tgz",
+      "integrity": "sha512-HH6Z60N51SPw7WcNFhvbrcV1a6Dri1T0npFmE8BvxQEjsYog2whtdxj01yfaYrE87AZK/ep6lOwrqy0P6WmsfQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.12.1",
@@ -20229,13 +20280,14 @@
         "chalk": "^2.3.0",
         "chrome-remote-interface": "^0.30.0",
         "coffeescript": "^2.3.1",
-        "commander": "^8.0.0",
+        "commander": "^8.3.0",
         "debug": "^4.3.1",
         "dedent": "^0.4.0",
         "del": "^3.0.0",
         "device-specs": "^1.0.0",
         "diff": "^4.0.2",
         "elegant-spinner": "^1.0.1",
+        "email-validator": "^2.0.4",
         "emittery": "^0.4.1",
         "endpoint-utils": "^1.0.2",
         "error-stack-parser": "^1.3.6",
@@ -20252,10 +20304,10 @@
         "is-stream": "^2.0.0",
         "json5": "^2.1.0",
         "lodash": "^4.17.13",
-        "log-update-async-hook": "^2.0.6",
+        "log-update-async-hook": "^2.0.7",
         "make-dir": "^3.0.0",
         "mime-db": "^1.41.0",
-        "moment": "^2.10.3",
+        "moment": "^2.29.3",
         "moment-duration-format-commonjs": "^1.0.0",
         "mustache": "^2.1.2",
         "nanoid": "^3.1.31",
@@ -20266,6 +20318,7 @@
         "pngjs": "^3.3.1",
         "pretty-hrtime": "^1.0.3",
         "promisify-event": "^1.0.0",
+        "prompts": "^2.4.2",
         "qrcode-terminal": "^0.10.0",
         "read-file-relative": "^1.2.0",
         "replicator": "^1.0.5",
@@ -20276,14 +20329,15 @@
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
         "testcafe-browser-tools": "2.0.23",
-        "testcafe-hammerhead": "24.5.18",
+        "testcafe-hammerhead": "24.5.19",
         "testcafe-legacy-api": "5.1.4",
-        "testcafe-reporter-dashboard": "0.2.5",
+        "testcafe-reporter-dashboard": "1.0.0-rc.1",
         "testcafe-reporter-json": "^2.1.0",
         "testcafe-reporter-list": "^2.1.0",
         "testcafe-reporter-minimal": "^2.1.0",
         "testcafe-reporter-spec": "^2.1.1",
         "testcafe-reporter-xunit": "^2.2.1",
+        "testcafe-safe-storage": "^1.1.1",
         "time-limit-promise": "^1.0.2",
         "tmp": "0.0.28",
         "tree-kill": "^1.2.2",
@@ -20294,7 +20348,7 @@
         "testcafe": "bin/testcafe-with-v8-flag-filter.js"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/testcafe-browser-tools": {
@@ -20471,9 +20525,9 @@
       }
     },
     "node_modules/testcafe-hammerhead": {
-      "version": "24.5.18",
-      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.5.18.tgz",
-      "integrity": "sha512-ae7ikqW4SzKY81BDaCc5eVyTmiiqbq8qGpr484GyVobRb4stPUKCDVyYm05t7BiO60Lhhh9Fm0w5o3oNHqQxQg==",
+      "version": "24.5.19",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.5.19.tgz",
+      "integrity": "sha512-P6Io/wh0kpNhwqLGwKxBnpiUjDfSM8a0IwTvFQskjvmazlt9OCBb6a0gMZQGNmC7G6pG+XTktjMd9ZsO7FDgag==",
       "dev": true,
       "dependencies": {
         "acorn-hammerhead": "0.6.1",
@@ -20691,13 +20745,12 @@
       }
     },
     "node_modules/testcafe-reporter-dashboard": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard/-/testcafe-reporter-dashboard-0.2.5.tgz",
-      "integrity": "sha512-vbK8XrpbcFAEgnfWJOfqAnlmj/wt5pXXER/OSYI9RzSw+uwu8voLWbKcUAcnjltk0AM4c0wvI0DhjKmops2y2Q==",
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard/-/testcafe-reporter-dashboard-1.0.0-rc.1.tgz",
+      "integrity": "sha512-VWFVo8kmG3OICD1RFdjvDCsEltGcHqTYN9X0aDyXg+0PqioYuAGUKQxqRA31dnG+2/RnaET4VJhhEvcbKzwhTw==",
       "dev": true,
       "dependencies": {
         "es6-promise": "^4.2.8",
-        "fp-ts": "^2.9.5",
         "io-ts": "^2.2.14",
         "io-ts-types": "^0.5.15",
         "isomorphic-fetch": "^3.0.0",
@@ -20764,6 +20817,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/testcafe-reporter-xunit/-/testcafe-reporter-xunit-2.2.1.tgz",
       "integrity": "sha512-ge1msi8RyNVyK0QrsmC79zedV7jHasKpBPeOUZd/ORpbYLeYDnprjIeOuIukw0knnTieeYsOK29/ZD+UI7/tdw==",
+      "dev": true
+    },
+    "node_modules/testcafe-safe-storage": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/testcafe-safe-storage/-/testcafe-safe-storage-1.1.2.tgz",
+      "integrity": "sha512-6km7D26+KCQGeFlSQ9fVEU7tD8qdioSpqzxU8CCZkd2KzBS0jTFkqaJ54rPaLdd5+wdhgO3+as3LMm4F0EDeYA==",
       "dev": true
     },
     "node_modules/testcafe/node_modules/@types/node": {
@@ -25861,7 +25920,7 @@
     "async-exit-hook": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-1.1.2.tgz",
-      "integrity": "sha1-gJXXXkiMKazuBVH+hyUhadeJz7o=",
+      "integrity": "sha512-CeTSWB5Bou31xSHeO45ZKgLPRaJbV4I8csRcFYETDBehX7H+1GDO/v+v8G7fZmar1gOmYa6UTXn6d/WIiJbslw==",
       "dev": true
     },
     "async-limiter": {
@@ -26538,7 +26597,7 @@
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "dev": true
     },
     "buffer-es6": {
@@ -28015,6 +28074,12 @@
         }
       }
     },
+    "email-validator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
+      "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==",
+      "dev": true
+    },
     "emittery": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.4.1.tgz",
@@ -29419,7 +29484,8 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.1.tgz",
       "integrity": "sha512-oxvgqUYR6O9VkKXrxkJ0NOyU0FrE705MeqgBUMEPWyTu6Pwn768cJbHChw2XOBlgFLKfIHxjr2OOBFpv2mUGZw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "fraction.js": {
       "version": "4.2.0",
@@ -33167,13 +33233,13 @@
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
       "dev": true
     },
     "lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
       "dev": true
     },
     "lodash.isequal": {
@@ -33184,25 +33250,25 @@
     "lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
       "dev": true
     },
     "lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
       "dev": true
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "dev": true
     },
     "lodash.memoize": {
@@ -33220,7 +33286,7 @@
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true
     },
     "lodash.sortby": {
@@ -33269,21 +33335,39 @@
       }
     },
     "log-update-async-hook": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/log-update-async-hook/-/log-update-async-hook-2.0.6.tgz",
-      "integrity": "sha512-UIFPlCpCxrSVL38TXzk34JhhDnvvhsjzuyqooCYy9TtTaVdBLNsuJiTWX9unO/wzBF7RwY1WTCmEmBSI3iPDCA==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/log-update-async-hook/-/log-update-async-hook-2.0.7.tgz",
+      "integrity": "sha512-V9KpD1AZUBd/oiZ+/Xsgd5rRP9awhgtRiDv5Am4VQCixiDnAbXMdt/yKz41kCzYZtVbwC6YCxnWEF3zjNEwktA==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^2.0.0",
+        "ansi-escapes": "^4.3.2",
         "async-exit-hook": "^1.1.2",
         "onetime": "^2.0.1",
-        "wrap-ansi": "^2.1.0"
+        "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
-        "ansi-escapes": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
-          "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "mimic-fn": {
@@ -33295,10 +33379,21 @@
         "onetime": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
           "dev": true,
           "requires": {
             "mimic-fn": "^1.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
           }
         }
       }
@@ -38467,9 +38562,9 @@
       }
     },
     "testcafe": {
-      "version": "1.18.6",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.18.6.tgz",
-      "integrity": "sha512-5X/Chn5zbHy8TftyB/iXfKOizrYM8vrNLSjjyRQCW2IpYh//7EUJ0MZmBKRcXye9//eLaOoUBs/FDvAW55j4Lw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.19.0.tgz",
+      "integrity": "sha512-HH6Z60N51SPw7WcNFhvbrcV1a6Dri1T0npFmE8BvxQEjsYog2whtdxj01yfaYrE87AZK/ep6lOwrqy0P6WmsfQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.1",
@@ -38501,13 +38596,14 @@
         "chalk": "^2.3.0",
         "chrome-remote-interface": "^0.30.0",
         "coffeescript": "^2.3.1",
-        "commander": "^8.0.0",
+        "commander": "^8.3.0",
         "debug": "^4.3.1",
         "dedent": "^0.4.0",
         "del": "^3.0.0",
         "device-specs": "^1.0.0",
         "diff": "^4.0.2",
         "elegant-spinner": "^1.0.1",
+        "email-validator": "^2.0.4",
         "emittery": "^0.4.1",
         "endpoint-utils": "^1.0.2",
         "error-stack-parser": "^1.3.6",
@@ -38524,10 +38620,10 @@
         "is-stream": "^2.0.0",
         "json5": "^2.1.0",
         "lodash": "^4.17.13",
-        "log-update-async-hook": "^2.0.6",
+        "log-update-async-hook": "^2.0.7",
         "make-dir": "^3.0.0",
         "mime-db": "^1.41.0",
-        "moment": "^2.10.3",
+        "moment": "^2.29.3",
         "moment-duration-format-commonjs": "^1.0.0",
         "mustache": "^2.1.2",
         "nanoid": "^3.1.31",
@@ -38538,6 +38634,7 @@
         "pngjs": "^3.3.1",
         "pretty-hrtime": "^1.0.3",
         "promisify-event": "^1.0.0",
+        "prompts": "^2.4.2",
         "qrcode-terminal": "^0.10.0",
         "read-file-relative": "^1.2.0",
         "replicator": "^1.0.5",
@@ -38548,14 +38645,15 @@
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
         "testcafe-browser-tools": "2.0.23",
-        "testcafe-hammerhead": "24.5.18",
+        "testcafe-hammerhead": "24.5.19",
         "testcafe-legacy-api": "5.1.4",
-        "testcafe-reporter-dashboard": "0.2.5",
+        "testcafe-reporter-dashboard": "1.0.0-rc.1",
         "testcafe-reporter-json": "^2.1.0",
         "testcafe-reporter-list": "^2.1.0",
         "testcafe-reporter-minimal": "^2.1.0",
         "testcafe-reporter-spec": "^2.1.1",
         "testcafe-reporter-xunit": "^2.2.1",
+        "testcafe-safe-storage": "^1.1.1",
         "time-limit-promise": "^1.0.2",
         "tmp": "0.0.28",
         "tree-kill": "^1.2.2",
@@ -38951,9 +39049,9 @@
       }
     },
     "testcafe-hammerhead": {
-      "version": "24.5.18",
-      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.5.18.tgz",
-      "integrity": "sha512-ae7ikqW4SzKY81BDaCc5eVyTmiiqbq8qGpr484GyVobRb4stPUKCDVyYm05t7BiO60Lhhh9Fm0w5o3oNHqQxQg==",
+      "version": "24.5.19",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.5.19.tgz",
+      "integrity": "sha512-P6Io/wh0kpNhwqLGwKxBnpiUjDfSM8a0IwTvFQskjvmazlt9OCBb6a0gMZQGNmC7G6pG+XTktjMd9ZsO7FDgag==",
       "dev": true,
       "requires": {
         "acorn-hammerhead": "0.6.1",
@@ -39137,13 +39235,12 @@
       }
     },
     "testcafe-reporter-dashboard": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard/-/testcafe-reporter-dashboard-0.2.5.tgz",
-      "integrity": "sha512-vbK8XrpbcFAEgnfWJOfqAnlmj/wt5pXXER/OSYI9RzSw+uwu8voLWbKcUAcnjltk0AM4c0wvI0DhjKmops2y2Q==",
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard/-/testcafe-reporter-dashboard-1.0.0-rc.1.tgz",
+      "integrity": "sha512-VWFVo8kmG3OICD1RFdjvDCsEltGcHqTYN9X0aDyXg+0PqioYuAGUKQxqRA31dnG+2/RnaET4VJhhEvcbKzwhTw==",
       "dev": true,
       "requires": {
         "es6-promise": "^4.2.8",
-        "fp-ts": "^2.9.5",
         "io-ts": "^2.2.14",
         "io-ts-types": "^0.5.15",
         "isomorphic-fetch": "^3.0.0",
@@ -39202,6 +39299,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/testcafe-reporter-xunit/-/testcafe-reporter-xunit-2.2.1.tgz",
       "integrity": "sha512-ge1msi8RyNVyK0QrsmC79zedV7jHasKpBPeOUZd/ORpbYLeYDnprjIeOuIukw0knnTieeYsOK29/ZD+UI7/tdw==",
+      "dev": true
+    },
+    "testcafe-safe-storage": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/testcafe-safe-storage/-/testcafe-safe-storage-1.1.2.tgz",
+      "integrity": "sha512-6km7D26+KCQGeFlSQ9fVEU7tD8qdioSpqzxU8CCZkd2KzBS0jTFkqaJ54rPaLdd5+wdhgO3+as3LMm4F0EDeYA==",
       "dev": true
     },
     "text-table": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "size-limit": "^4.9.0",
     "stylelint": "^14.5.3",
     "stylelint-config-standard-scss": "^3.0.0",
-    "testcafe": "^1.18.4",
+    "testcafe": "^1.19.0",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0"
   },

--- a/tests/acceptance/acceptancesuites/experiencelinkssuite.js
+++ b/tests/acceptance/acceptancesuites/experiencelinkssuite.js
@@ -9,10 +9,11 @@ import { MockedUniversalAutoCompleteRequest } from '../fixtures/responses/univer
 fixture`Experience links work as expected`
   .requestHooks([
     MockedVerticalSearchRequest,
+    MockedVerticalAutoCompleteRequest,
     MockedUniversalSearchRequest,
     MockedUniversalAutoCompleteRequest
   ])
-  .page`${FACETS_PAGE}`;
+  .page(`${FACETS_PAGE}`);
 
 test('When you land, nav links should be clean', async t => {
   const universalUrl = await Selector('.js-yxt-navItem').nth(0).getAttribute('href');

--- a/tests/acceptance/acceptancesuites/experiencelinkssuite.js
+++ b/tests/acceptance/acceptancesuites/experiencelinkssuite.js
@@ -3,10 +3,15 @@ import FacetsPage from '../pageobjects/facetspage';
 import { Selector } from 'testcafe';
 import { MockedVerticalSearchRequest } from '../fixtures/responses/vertical/search';
 import StorageKeys from '../../../src/core/storage/storagekeys';
-import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
+import { MockedUniversalSearchRequest } from '../fixtures/responses/universal/search';
+import { MockedUniversalAutoCompleteRequest } from '../fixtures/responses/universal/autocomplete';
 
 fixture`Experience links work as expected`
-  .requestHooks([MockedVerticalSearchRequest, MockedVerticalAutoCompleteRequest])
+  .requestHooks([
+    MockedVerticalSearchRequest,
+    MockedUniversalSearchRequest,
+    MockedUniversalAutoCompleteRequest
+  ])
   .page`${FACETS_PAGE}`;
 
 test('When you land, nav links should be clean', async t => {
@@ -40,7 +45,7 @@ test('When you apply sort options, nav links should be clean', async t => {
 });
 
 test('When you apply static filters, nav links should be clean', async t => {
-  await t.click(await Selector('.filterbox-container .js-yext-filter-option').nth(2)); // Click static filter
+  await t.click(await Selector('.filterbox-container .js-yext-filter-option').nth(2));
   const universalUrl = await Selector('.js-yxt-navItem').nth(0).getAttribute('href');
   await verifyCleanLink(t, universalUrl);
 });

--- a/tests/acceptance/acceptancesuites/experiencelinkssuite.js
+++ b/tests/acceptance/acceptancesuites/experiencelinkssuite.js
@@ -5,14 +5,15 @@ import { MockedVerticalSearchRequest } from '../fixtures/responses/vertical/sear
 import StorageKeys from '../../../src/core/storage/storagekeys';
 import { MockedUniversalSearchRequest } from '../fixtures/responses/universal/search';
 import { MockedUniversalAutoCompleteRequest } from '../fixtures/responses/universal/autocomplete';
+import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 fixture`Experience links work as expected`
-  .requestHooks([
+  .requestHooks(
     MockedVerticalSearchRequest,
     MockedVerticalAutoCompleteRequest,
     MockedUniversalSearchRequest,
     MockedUniversalAutoCompleteRequest
-  ])
+  )
   .page(`${FACETS_PAGE}`);
 
 test('When you land, nav links should be clean', async t => {

--- a/tests/acceptance/acceptancesuites/facetsonload.js
+++ b/tests/acceptance/acceptancesuites/facetsonload.js
@@ -12,10 +12,10 @@ import { MockedVerticalSearchRequest } from '../fixtures/responses/vertical/sear
 import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 fixture`Facets on page load`
-  .requestHooks([
+  .requestHooks(
     MockedVerticalSearchRequest,
     MockedVerticalAutoCompleteRequest
-  ])
+  )
   .page`${FACETS_ON_LOAD_PAGE}`;
 
 test('Facets work with back/forward navigation and page refresh', async t => {

--- a/tests/acceptance/acceptancesuites/facetsonload.js
+++ b/tests/acceptance/acceptancesuites/facetsonload.js
@@ -12,7 +12,10 @@ import { MockedVerticalSearchRequest } from '../fixtures/responses/vertical/sear
 import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 fixture`Facets on page load`
-  .requestHooks([MockedVerticalSearchRequest, MockedVerticalAutoCompleteRequest])
+  .requestHooks([
+    MockedVerticalSearchRequest,
+    MockedVerticalAutoCompleteRequest
+  ])
   .page`${FACETS_ON_LOAD_PAGE}`;
 
 test('Facets work with back/forward navigation and page refresh', async t => {

--- a/tests/acceptance/acceptancesuites/facetssuite.js
+++ b/tests/acceptance/acceptancesuites/facetssuite.js
@@ -11,11 +11,11 @@ import SearchRequestLogger from '../searchrequestlogger';
 import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 fixture`Facets page`
-  .requestHooks([
+  .requestHooks(
     SearchRequestLogger.createVerticalSearchLogger(),
     MockedVerticalSearchRequest,
     MockedVerticalAutoCompleteRequest
-  ])
+  )
   .beforeEach(async t => {
     await registerIE11NoCacheHook(t, VERTICAL_SEARCH_URL_REGEX);
   })

--- a/tests/acceptance/acceptancesuites/facetssuite.js
+++ b/tests/acceptance/acceptancesuites/facetssuite.js
@@ -11,13 +11,11 @@ import SearchRequestLogger from '../searchrequestlogger';
 import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 fixture`Facets page`
-  .requestHooks(
-    [
-      SearchRequestLogger.createVerticalSearchLogger(),
-      MockedVerticalSearchRequest,
-      MockedVerticalAutoCompleteRequest
-    ]
-  )
+  .requestHooks([
+    SearchRequestLogger.createVerticalSearchLogger(),
+    MockedVerticalSearchRequest,
+    MockedVerticalAutoCompleteRequest
+  ])
   .beforeEach(async t => {
     await registerIE11NoCacheHook(t, VERTICAL_SEARCH_URL_REGEX);
   })

--- a/tests/acceptance/acceptancesuites/filterboxsuite.js
+++ b/tests/acceptance/acceptancesuites/filterboxsuite.js
@@ -14,9 +14,14 @@ import {
 } from '../requestUtils';
 import SearchRequestLogger from '../searchrequestlogger';
 import { MockedVerticalSearchRequest } from '../fixtures/responses/vertical/search';
+import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 fixture`FilterBox page`
-  .requestHooks(SearchRequestLogger.createVerticalSearchLogger(), MockedVerticalSearchRequest)
+  .requestHooks(
+    SearchRequestLogger.createVerticalSearchLogger(),
+    MockedVerticalSearchRequest,
+    MockedVerticalAutoCompleteRequest
+  )
   .beforeEach(async t => {
     await registerIE11NoCacheHook(t, VERTICAL_SEARCH_URL_REGEX);
   })

--- a/tests/acceptance/acceptancesuites/filterboxsuite.js
+++ b/tests/acceptance/acceptancesuites/filterboxsuite.js
@@ -13,10 +13,10 @@ import {
   expectRequestDoesNotContainParam
 } from '../requestUtils';
 import SearchRequestLogger from '../searchrequestlogger';
-import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
+import { MockedVerticalSearchRequest } from '../fixtures/responses/vertical/search';
 
 fixture`FilterBox page`
-  .requestHooks([SearchRequestLogger.createVerticalSearchLogger(), MockedVerticalAutoCompleteRequest])
+  .requestHooks(SearchRequestLogger.createVerticalSearchLogger(), MockedVerticalSearchRequest)
   .beforeEach(async t => {
     await registerIE11NoCacheHook(t, VERTICAL_SEARCH_URL_REGEX);
   })

--- a/tests/acceptance/acceptancesuites/filtersearchsuite.js
+++ b/tests/acceptance/acceptancesuites/filtersearchsuite.js
@@ -10,13 +10,15 @@ import {
 import { MockedFilterSearchRequest } from '../fixtures/responses/filtersearch/search';
 import { MockedVerticalSearchRequest } from '../fixtures/responses/vertical/search';
 import SearchRequestLogger from '../searchrequestlogger';
+import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 fixture`FilterSearch suite`
-  .requestHooks([
+  .requestHooks(
     SearchRequestLogger.createVerticalSearchLogger(),
     MockedFilterSearchRequest,
-    MockedVerticalSearchRequest
-  ])
+    MockedVerticalSearchRequest,
+    MockedVerticalAutoCompleteRequest
+  )
   .beforeEach(async t => {
     await registerIE11NoCacheHook(t, VERTICAL_SEARCH_URL_REGEX);
   })

--- a/tests/acceptance/acceptancesuites/performancemarkssuite.js
+++ b/tests/acceptance/acceptancesuites/performancemarkssuite.js
@@ -1,10 +1,9 @@
 import { FACETS_PAGE } from '../constants';
 import FacetsPage from '../pageobjects/facetspage';
 import { MockedVerticalSearchRequest } from '../fixtures/responses/vertical/search';
-import { waitForResults } from '../utils';
+import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 fixture`Performance marks on search`
-  .requestHooks(MockedVerticalSearchRequest)
   .page`${FACETS_PAGE}`;
 
 test('window.performance calls are marked for a normal search', async t => {

--- a/tests/acceptance/acceptancesuites/performancemarkssuite.js
+++ b/tests/acceptance/acceptancesuites/performancemarkssuite.js
@@ -2,8 +2,13 @@ import { FACETS_PAGE } from '../constants';
 import FacetsPage from '../pageobjects/facetspage';
 import { MockedVerticalSearchRequest } from '../fixtures/responses/vertical/search';
 import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
+import { waitForResults } from '../utils';
 
 fixture`Performance marks on search`
+  .requestHooks(
+    MockedVerticalSearchRequest,
+    MockedVerticalAutoCompleteRequest
+  )
   .page`${FACETS_PAGE}`;
 
 test('window.performance calls are marked for a normal search', async t => {

--- a/tests/acceptance/acceptancesuites/sortoptionssuite.js
+++ b/tests/acceptance/acceptancesuites/sortoptionssuite.js
@@ -7,8 +7,7 @@ import { MockedVerticalSearchRequest } from '../fixtures/responses/vertical/sear
 import { Selector } from 'testcafe';
 import {
   browserRefreshPage,
-  registerIE11NoCacheHook,
-  waitForResults
+  registerIE11NoCacheHook
 } from '../utils';
 import SearchRequestLogger from '../searchrequestlogger';
 import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';

--- a/tests/acceptance/acceptancesuites/sortoptionssuite.js
+++ b/tests/acceptance/acceptancesuites/sortoptionssuite.js
@@ -13,10 +13,10 @@ import SearchRequestLogger from '../searchrequestlogger';
 import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 fixture`SortOptions suite`
-  .requestHooks([
+  .requestHooks(
     MockedVerticalSearchRequest,
     MockedVerticalAutoCompleteRequest
-  ])
+  )
   .beforeEach(async t => {
     await registerIE11NoCacheHook(t, VERTICAL_SEARCH_URL_REGEX);
   })

--- a/tests/acceptance/acceptancesuites/sortoptionssuite.js
+++ b/tests/acceptance/acceptancesuites/sortoptionssuite.js
@@ -10,9 +10,13 @@ import {
   registerIE11NoCacheHook
 } from '../utils';
 import SearchRequestLogger from '../searchrequestlogger';
+import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 fixture`SortOptions suite`
-  .requestHooks([SearchRequestLogger.createVerticalSearchLogger(), MockedVerticalSearchRequest])
+  .requestHooks([
+    MockedVerticalSearchRequest,
+    MockedVerticalAutoCompleteRequest
+  ])
   .beforeEach(async t => {
     await registerIE11NoCacheHook(t, VERTICAL_SEARCH_URL_REGEX);
   })
@@ -26,6 +30,9 @@ test('selecting a sort option and refreshing maintains that sort selection', asy
   const thirdSortOption = await Selector('.yxt-SortOptions-optionSelector').nth(2);
   await t.click(thirdSortOption);
   await browserRefreshPage();
+
+  const resultsSelector = await Selector('.yxt-Results');
+  await resultsSelector.with({ visibilityCheck: true })();
 
   await t.expect(thirdSortOption.checked).ok();
 });

--- a/tests/acceptance/acceptancesuites/sortoptionssuite.js
+++ b/tests/acceptance/acceptancesuites/sortoptionssuite.js
@@ -7,7 +7,8 @@ import { MockedVerticalSearchRequest } from '../fixtures/responses/vertical/sear
 import { Selector } from 'testcafe';
 import {
   browserRefreshPage,
-  registerIE11NoCacheHook
+  registerIE11NoCacheHook,
+  waitForResults
 } from '../utils';
 import SearchRequestLogger from '../searchrequestlogger';
 import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
@@ -30,9 +31,6 @@ test('selecting a sort option and refreshing maintains that sort selection', asy
   const thirdSortOption = await Selector('.yxt-SortOptions-optionSelector').nth(2);
   await t.click(thirdSortOption);
   await browserRefreshPage();
-
-  const resultsSelector = await Selector('.yxt-Results');
-  await resultsSelector.with({ visibilityCheck: true })();
 
   await t.expect(thirdSortOption.checked).ok();
 });

--- a/tests/acceptance/acceptancesuites/universalinitialsearch.js
+++ b/tests/acceptance/acceptancesuites/universalinitialsearch.js
@@ -19,4 +19,3 @@ test('referrerPageUrl is added to the URL on default initial searches', async t 
   const referrerPageUrl = currentSearchParams.has(StorageKeys.REFERRER_PAGE_URL);
   await t.expect(referrerPageUrl).ok();
 });
-

--- a/tests/acceptance/acceptancesuites/universalinitialsearch.js
+++ b/tests/acceptance/acceptancesuites/universalinitialsearch.js
@@ -19,3 +19,4 @@ test('referrerPageUrl is added to the URL on default initial searches', async t 
   const referrerPageUrl = currentSearchParams.has(StorageKeys.REFERRER_PAGE_URL);
   await t.expect(referrerPageUrl).ok();
 });
+

--- a/tests/acceptance/acceptancesuites/universalinitialsearch.js
+++ b/tests/acceptance/acceptancesuites/universalinitialsearch.js
@@ -6,10 +6,10 @@ import { MockedUniversalSearchRequest } from '../fixtures/responses/universal/se
 import { MockedUniversalAutoCompleteRequest } from '../fixtures/responses/universal/autocomplete';
 
 fixture`Universal page with default initial search`
-  .requestHooks([
+  .requestHooks(
     MockedUniversalSearchRequest,
     MockedUniversalAutoCompleteRequest
-  ])
+  )
   .page`${UNIVERSAL_INITIAL_SEARCH_PAGE}`;
 
 test('blank defaultInitialSearch will fire on universal if allowEmptySearch is true', async t => {

--- a/tests/acceptance/acceptancesuites/universalinitialsearch.js
+++ b/tests/acceptance/acceptancesuites/universalinitialsearch.js
@@ -3,9 +3,13 @@ import { Selector } from 'testcafe';
 import { getCurrentUrlParams, waitForResults } from '../utils';
 import StorageKeys from '../../../src/core/storage/storagekeys';
 import { MockedUniversalSearchRequest } from '../fixtures/responses/universal/search';
+import { MockedUniversalAutoCompleteRequest } from '../fixtures/responses/universal/autocomplete';
 
 fixture`Universal page with default initial search`
-  .requestHooks(MockedUniversalSearchRequest)
+  .requestHooks([
+    MockedUniversalSearchRequest,
+    MockedUniversalAutoCompleteRequest
+  ])
   .page`${UNIVERSAL_INITIAL_SEARCH_PAGE}`;
 
 test('blank defaultInitialSearch will fire on universal if allowEmptySearch is true', async t => {

--- a/tests/acceptance/acceptancesuites/universalsuite.js
+++ b/tests/acceptance/acceptancesuites/universalsuite.js
@@ -18,11 +18,11 @@ import SearchRequestLogger from '../searchrequestlogger';
  */
 
 fixture`Universal search page works as expected`
-  .requestHooks([
+  .requestHooks(
     SearchRequestLogger.createUniversalSearchLogger(),
     MockedUniversalSearchRequest,
     MockedUniversalAutoCompleteRequest
-  ])
+  )
   .beforeEach(async t => {
     await registerIE11NoCacheHook(t, UNIVERSAL_SEARCH_URL_REGEX);
   })

--- a/tests/acceptance/acceptancesuites/universalsuite.js
+++ b/tests/acceptance/acceptancesuites/universalsuite.js
@@ -1,0 +1,48 @@
+import UniversalPage from '../pageobjects/universalpage';
+import {
+  UNIVERSAL_PAGE,
+  UNIVERSAL_SEARCH_URL_REGEX
+} from '../constants';
+import { MockedUniversalAutoCompleteRequest } from '../fixtures/responses/universal/autocomplete';
+import { MockedUniversalSearchRequest } from '../fixtures/responses/universal/search';
+import {
+  registerIE11NoCacheHook
+} from '../utils';
+import SearchRequestLogger from '../searchrequestlogger';
+
+/**
+ * This file contains acceptance tests for a universal search page.
+ * Note that before any tests are run, a local HTTP server is spun
+ * up to serve the search page and the dist directory of Answers.
+ * This server is closed once all tests have completed.
+ */
+
+fixture`Universal search page works as expected`
+  .requestHooks(
+    [
+      SearchRequestLogger.createUniversalSearchLogger(),
+      MockedUniversalSearchRequest,
+      MockedUniversalAutoCompleteRequest
+    ]
+  )
+  .beforeEach(async t => {
+    await registerIE11NoCacheHook(t, UNIVERSAL_SEARCH_URL_REGEX);
+  })
+  .page`${UNIVERSAL_PAGE}`;
+
+test('Basic universal flow', async t => {
+  const searchComponent = UniversalPage.getSearchComponent();
+  await searchComponent.enterQuery('Tom');
+  await searchComponent.clearQuery();
+
+  await searchComponent.enterQuery('ama');
+  await searchComponent.getAutoComplete().selectOption('amani farooque phone number');
+  await SearchRequestLogger.waitOnSearchComplete(t);
+
+  const sections =
+    await UniversalPage.getUniversalResultsComponent().getSections();
+  await t.expect(sections.length).eql(2);
+
+  const faqsSectionTitle = await sections[1].getTitle();
+  await t.expect(faqsSectionTitle.toUpperCase()).contains('FAQ');
+});

--- a/tests/acceptance/acceptancesuites/universalsuite.js
+++ b/tests/acceptance/acceptancesuites/universalsuite.js
@@ -18,13 +18,11 @@ import SearchRequestLogger from '../searchrequestlogger';
  */
 
 fixture`Universal search page works as expected`
-  .requestHooks(
-    [
-      SearchRequestLogger.createUniversalSearchLogger(),
-      MockedUniversalSearchRequest,
-      MockedUniversalAutoCompleteRequest
-    ]
-  )
+  .requestHooks([
+    SearchRequestLogger.createUniversalSearchLogger(),
+    MockedUniversalSearchRequest,
+    MockedUniversalAutoCompleteRequest
+  ])
   .beforeEach(async t => {
     await registerIE11NoCacheHook(t, UNIVERSAL_SEARCH_URL_REGEX);
   })

--- a/tests/acceptance/acceptancesuites/verticalinitialsearch.js
+++ b/tests/acceptance/acceptancesuites/verticalinitialsearch.js
@@ -2,9 +2,10 @@ import { FILTERBOX_PAGE } from '../constants';
 import { getCurrentUrlParams, waitForResults } from '../utils';
 import StorageKeys from '../../../src/core/storage/storagekeys';
 import { MockedVerticalSearchRequest } from '../fixtures/responses/vertical/search';
+import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 fixture`Vertical page with default initial search`
-  .requestHooks(MockedVerticalSearchRequest)
+  .requestHooks(MockedVerticalSearchRequest, MockedVerticalAutoCompleteRequest)
   .page`${FILTERBOX_PAGE}`;
 
 test('referrerPageUrl is added to the URL on default initial searches', async t => {

--- a/tests/acceptance/acceptancesuites/verticalsuite.js
+++ b/tests/acceptance/acceptancesuites/verticalsuite.js
@@ -1,13 +1,8 @@
-import UniversalPage from '../pageobjects/universalpage';
 import VerticalPage from '../pageobjects/verticalpage';
 import {
-  UNIVERSAL_PAGE,
   VERTICAL_PAGE,
-  UNIVERSAL_SEARCH_URL_REGEX,
   VERTICAL_SEARCH_URL_REGEX
 } from '../constants';
-import { MockedUniversalAutoCompleteRequest } from '../fixtures/responses/universal/autocomplete';
-import { MockedUniversalSearchRequest } from '../fixtures/responses/universal/search';
 import { MockedVerticalSearchRequest } from '../fixtures/responses/vertical/search';
 import { RequestLogger } from 'testcafe';
 import {

--- a/tests/acceptance/acceptancesuites/verticalsuite.js
+++ b/tests/acceptance/acceptancesuites/verticalsuite.js
@@ -18,43 +18,6 @@ import {
 import SearchRequestLogger from '../searchrequestlogger';
 import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
-/**
- * This file contains acceptance tests for a universal search page.
- * Note that before any tests are run, a local HTTP server is spun
- * up to serve the search page and the dist directory of Answers.
- * This server is closed once all tests have completed.
- */
-
-fixture`Universal search page works as expected`
-  .requestHooks(
-    [
-      SearchRequestLogger.createUniversalSearchLogger(),
-      MockedUniversalSearchRequest,
-      MockedUniversalAutoCompleteRequest
-    ]
-  )
-  .beforeEach(async t => {
-    await registerIE11NoCacheHook(t, UNIVERSAL_SEARCH_URL_REGEX);
-  })
-  .page`${UNIVERSAL_PAGE}`;
-
-test('Basic universal flow', async t => {
-  const searchComponent = UniversalPage.getSearchComponent();
-  await searchComponent.enterQuery('Tom');
-  await searchComponent.clearQuery();
-
-  await searchComponent.enterQuery('ama');
-  await searchComponent.getAutoComplete().selectOption('amani farooque phone number');
-  await SearchRequestLogger.waitOnSearchComplete(t);
-
-  const sections =
-    await UniversalPage.getUniversalResultsComponent().getSections();
-  await t.expect(sections.length).eql(2);
-
-  const faqsSectionTitle = await sections[1].getTitle();
-  await t.expect(faqsSectionTitle.toUpperCase()).contains('FAQ');
-});
-
 fixture`Vertical search page works as expected`
   .requestHooks(
     [

--- a/tests/acceptance/acceptancesuites/verticalsuite.js
+++ b/tests/acceptance/acceptancesuites/verticalsuite.js
@@ -14,13 +14,11 @@ import SearchRequestLogger from '../searchrequestlogger';
 import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 fixture`Vertical search page works as expected`
-  .requestHooks(
-    [
-      SearchRequestLogger.createVerticalSearchLogger(),
-      MockedVerticalSearchRequest,
-      MockedVerticalAutoCompleteRequest
-    ]
-  )
+  .requestHooks([
+    SearchRequestLogger.createVerticalSearchLogger(),
+    MockedVerticalSearchRequest,
+    MockedVerticalAutoCompleteRequest
+  ])
   .beforeEach(async t => {
     await registerIE11NoCacheHook(t, VERTICAL_SEARCH_URL_REGEX);
   })

--- a/tests/acceptance/acceptancesuites/verticalsuite.js
+++ b/tests/acceptance/acceptancesuites/verticalsuite.js
@@ -14,11 +14,11 @@ import SearchRequestLogger from '../searchrequestlogger';
 import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 fixture`Vertical search page works as expected`
-  .requestHooks([
+  .requestHooks(
     SearchRequestLogger.createVerticalSearchLogger(),
     MockedVerticalSearchRequest,
     MockedVerticalAutoCompleteRequest
-  ])
+  )
   .beforeEach(async t => {
     await registerIE11NoCacheHook(t, VERTICAL_SEARCH_URL_REGEX);
   })

--- a/tests/acceptance/acceptancesuites/xss.js
+++ b/tests/acceptance/acceptancesuites/xss.js
@@ -5,8 +5,13 @@ import {
 import { ClientFunction } from 'testcafe';
 import UniversalPage from '../pageobjects/universalpage';
 import VerticalPage from '../pageobjects/verticalpage';
+import { MockedUniversalAutoCompleteRequest } from '../fixtures/responses/universal/autocomplete';
+import { MockedUniversalSearchRequest } from '../fixtures/responses/universal/search';
+import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
+import { MockedVerticalSearchRequest } from '../fixtures/responses/vertical/search';
 
 fixture`Universal page`
+  .requestHooks(MockedUniversalAutoCompleteRequest, MockedUniversalSearchRequest)
   .page`${UNIVERSAL_PAGE}`;
 
 test('a universal page\'s search bar is protected against xss', async t => {
@@ -20,6 +25,7 @@ test('a universal page\'s search bar is protected against xss', async t => {
 });
 
 fixture`Vertical page`
+  .requestHooks(MockedVerticalAutoCompleteRequest, MockedVerticalSearchRequest)
   .page`${VERTICAL_PAGE}`;
 
 test('a vertical page\'s search bar is protected against xss', async t => {

--- a/tests/acceptance/fixtures/html/facets.html
+++ b/tests/acceptance/fixtures/html/facets.html
@@ -37,9 +37,9 @@
 
   <script>
     ANSWERS.init({
-      apiKey: '2d8c550071a64ea23e263118a2b0680b',
-      experienceKey: 'slanswers',
-      businessId: '3350634',
+      apiKey: '<apiKey>',
+      experienceKey: '<experienceKey>',
+      businessId: '<businessId>',
       experienceVersion: 'PRODUCTION',
       templateBundle: TemplateBundle.default,
       search: {

--- a/tests/acceptance/fixtures/html/facetsonload.html
+++ b/tests/acceptance/fixtures/html/facetsonload.html
@@ -37,9 +37,9 @@
 
   <script>
     ANSWERS.init({
-      apiKey: '2d8c550071a64ea23e263118a2b0680b',
-      experienceKey: 'slanswers',
-      businessId: '3350634',
+      apiKey: '<apiKey>',
+      experienceKey: '<experienceKey>',
+      businessId: '<businessId>',
       experienceVersion: 'PRODUCTION',
       templateBundle: TemplateBundle.default,
       search: {

--- a/tests/acceptance/fixtures/html/filterbox.html
+++ b/tests/acceptance/fixtures/html/filterbox.html
@@ -39,9 +39,9 @@
 
   <script>
     ANSWERS.init({
-      apiKey: '2d8c550071a64ea23e263118a2b0680b',
-      experienceKey: 'slanswers',
-      businessId: '3350634',
+      apiKey: '<apiKey>',
+      experienceKey: '<experienceKey>',
+      businessId: '<businessId>',
       experienceVersion: 'PRODUCTION',
       templateBundle: TemplateBundle.default,
       search: {

--- a/tests/acceptance/fixtures/html/no-unsafe-eval.html
+++ b/tests/acceptance/fixtures/html/no-unsafe-eval.html
@@ -17,9 +17,9 @@
 
   <script>
     ANSWERS.init({
-      apiKey: '2d8c550071a64ea23e263118a2b0680b',
-      experienceKey: 'slanswers',
-      businessId: '3350634',
+      apiKey: '<apiKey>',
+      experienceKey: '<experienceKey>',
+      businessId: '<businessId>',
       experienceVersion: 'PRODUCTION',
       templateBundle: TemplateBundle.default,
       search: {

--- a/tests/acceptance/fixtures/html/searchbaronly.html
+++ b/tests/acceptance/fixtures/html/searchbaronly.html
@@ -13,9 +13,9 @@
     </div>
     <script>
       ANSWERS.init({
-        apiKey: '2d8c550071a64ea23e263118a2b0680b',
-        experienceKey: 'slanswers',
-        businessId: '3350634',
+        apiKey: '<apiKey>',
+        experienceKey: '<experienceKey>',
+        businessId: '<businessId>',
         experienceVersion: 'PRODUCTION',
         templateBundle: TemplateBundle.default,
         onReady: function() {

--- a/tests/acceptance/fixtures/html/universal.html
+++ b/tests/acceptance/fixtures/html/universal.html
@@ -1,78 +1,78 @@
 <html>
 
 <head>
-    <meta charset="utf-8" />
+  <meta charset="utf-8" />
 
-    <script src="http://localhost:9999/dist/answerstemplates.compiled.min.js"></script>
-    <script src="http://localhost:9999/dist/answers.js"></script>
-    <link rel="stylesheet" type="text/css" href="http://localhost:9999/dist/answers.css">
+  <script src="http://localhost:9999/dist/answerstemplates.compiled.min.js"></script>
+  <script src="http://localhost:9999/dist/answers.js"></script>
+  <link rel="stylesheet" type="text/css" href="http://localhost:9999/dist/answers.css">
 </head>
 
 <body>
-    <div class="answers-container">
-        <div class="search-bar-container"></div>
-        <div class="navigation-container"></div>
-        <div class="results-container"></div>
-    </div>
+  <div class="answers-container">
+    <div class="search-bar-container"></div>
+    <div class="navigation-container"></div>
+    <div class="results-container"></div>
+  </div>
 
-    <script>
-        ANSWERS.init({
-            apiKey: '<apiKey>',
-            experienceKey: '<experienceKey>',
-            businessId: '<businessId>',
-            experienceVersion: 'PRODUCTION',
-            templateBundle: TemplateBundle.default,
-            onReady: function () {
-                this.setGeolocation(38.8955, -77.0699);
+  <script>
+    ANSWERS.init({
+      apiKey: '<apiKey>',
+      experienceKey: '<experienceKey>',
+      businessId: '<businessId>',
+      experienceVersion: 'PRODUCTION',
+      templateBundle: TemplateBundle.default,
+      onReady: function () {
+        this.setGeolocation(38.8955, -77.0699);
 
-                this.addComponent('SearchBar', {
-                    container: '.search-bar-container',
-                    clearButton: true,
-                    promptForLocation: true
-                });
+        this.addComponent('SearchBar', {
+          container: '.search-bar-container',
+          clearButton: true,
+          promptForLocation: true
+        });
 
-                this.addComponent('Navigation', {
-                    container: '.navigation-container',
-                    verticalPages: [
-                        {
-                            label: 'Home',
-                            url: './universal',
-                            isFirst: true,
-                            isActive: true
-                        },
-                        {
-                            label: 'Facets',
-                            url: './facets',
-                        },
-                        {
-                            label: 'Vertical',
-                            url: './vertical',
-                        }
-                    ],
-                });
-
-                this.addComponent('UniversalResults', {
-                    container: '.results-container',
-                    appliedFilters: {
-                        showChangeFilters: true,
-                    },
-                    config: {
-                        "people": {
-                            includeMap: true,
-                            mapConfig: {
-                                mapProvider: 'google',
-                                apiKey: 'AIzaSyB5D45ghF1YMfqTLSzWubmlCN1euBVPhFw',
-                            }
-                        },
-                        "faq": {
-                            viewAllText: "View More faqs",
-                            sectionTitleIconName: 'briefcase',
-                        },
-                    }
-                });
+        this.addComponent('Navigation', {
+          container: '.navigation-container',
+          verticalPages: [
+            {
+              label: 'Home',
+              url: './universal',
+              isFirst: true,
+              isActive: true
+            },
+            {
+              label: 'Facets',
+              url: './facets',
+            },
+            {
+              label: 'Vertical',
+              url: './vertical',
             }
-        })
-    </script>
+          ],
+        });
+
+        this.addComponent('UniversalResults', {
+          container: '.results-container',
+          appliedFilters: {
+            showChangeFilters: true,
+          },
+          config: {
+            "people": {
+              includeMap: true,
+              mapConfig: {
+                mapProvider: 'google',
+                apiKey: 'AIzaSyB5D45ghF1YMfqTLSzWubmlCN1euBVPhFw',
+              }
+            },
+            "faq": {
+              viewAllText: "View More faqs",
+              sectionTitleIconName: 'briefcase',
+            },
+          }
+        });
+      }
+    })
+  </script>
 </body>
 
 </html>

--- a/tests/acceptance/fixtures/html/universal.html
+++ b/tests/acceptance/fixtures/html/universal.html
@@ -1,75 +1,78 @@
 <html>
-    <head>
-        <meta charset="utf-8" />
-    
-        <script src="http://localhost:9999/dist/answerstemplates.compiled.min.js"></script>
-        <script src="http://localhost:9999/dist/answers.js"></script>
-        <link rel="stylesheet" type="text/css" href="http://localhost:9999/dist/answers.css">
-    </head>
-    <body>
-        <div class="answers-container">
-            <div class="search-bar-container"></div>
-            <div class="navigation-container"></div>
-            <div class="results-container"></div>
-        </div>
-    
-        <script>
-            ANSWERS.init({
-                apiKey: '2d8c550071a64ea23e263118a2b0680b',
-                experienceKey: 'slanswers',
-                businessId: '3350634',
-                experienceVersion: 'PRODUCTION',
-                templateBundle: TemplateBundle.default,
-                onReady: function() {
-                    this.setGeolocation(38.8955, -77.0699);
 
-                    this.addComponent('SearchBar', {
-                        container: '.search-bar-container',
-                        clearButton: true,
-                        promptForLocation: true
-                    });
+<head>
+    <meta charset="utf-8" />
 
-                    this.addComponent('Navigation', {
-                      container: '.navigation-container',
-                      verticalPages: [
+    <script src="http://localhost:9999/dist/answerstemplates.compiled.min.js"></script>
+    <script src="http://localhost:9999/dist/answers.js"></script>
+    <link rel="stylesheet" type="text/css" href="http://localhost:9999/dist/answers.css">
+</head>
+
+<body>
+    <div class="answers-container">
+        <div class="search-bar-container"></div>
+        <div class="navigation-container"></div>
+        <div class="results-container"></div>
+    </div>
+
+    <script>
+        ANSWERS.init({
+            apiKey: '<apiKey>',
+            experienceKey: '<experienceKey>',
+            businessId: '<businessId>',
+            experienceVersion: 'PRODUCTION',
+            templateBundle: TemplateBundle.default,
+            onReady: function () {
+                this.setGeolocation(38.8955, -77.0699);
+
+                this.addComponent('SearchBar', {
+                    container: '.search-bar-container',
+                    clearButton: true,
+                    promptForLocation: true
+                });
+
+                this.addComponent('Navigation', {
+                    container: '.navigation-container',
+                    verticalPages: [
                         {
-                          label: 'Home',
-                          url: './universal',
-                          isFirst: true,
-                          isActive: true
+                            label: 'Home',
+                            url: './universal',
+                            isFirst: true,
+                            isActive: true
                         },
                         {
-                          label: 'Facets',
-                          url: './facets',
+                            label: 'Facets',
+                            url: './facets',
                         },
                         {
-                          label: 'Vertical',
-                          url: './vertical',
+                            label: 'Vertical',
+                            url: './vertical',
                         }
-                      ],
-                    });
+                    ],
+                });
 
-                    this.addComponent('UniversalResults', {
-                        container: '.results-container',
-                        appliedFilters: {
-                          showChangeFilters: true,
+                this.addComponent('UniversalResults', {
+                    container: '.results-container',
+                    appliedFilters: {
+                        showChangeFilters: true,
+                    },
+                    config: {
+                        "people": {
+                            includeMap: true,
+                            mapConfig: {
+                                mapProvider: 'google',
+                                apiKey: 'AIzaSyB5D45ghF1YMfqTLSzWubmlCN1euBVPhFw',
+                            }
                         },
-                        config: {
-                            "people": {
-                                includeMap: true,
-                                mapConfig: {
-                                    mapProvider: 'google',
-                                    apiKey: 'AIzaSyB5D45ghF1YMfqTLSzWubmlCN1euBVPhFw',
-                                }
-                            },
-                            "faq": {
-                                viewAllText: "View More faqs",
-                                sectionTitleIconName: 'briefcase',
-                            },
-                        }
-                    });
-                }
-            })
-        </script>
-    </body>
+                        "faq": {
+                            viewAllText: "View More faqs",
+                            sectionTitleIconName: 'briefcase',
+                        },
+                    }
+                });
+            }
+        })
+    </script>
+</body>
+
 </html>

--- a/tests/acceptance/fixtures/html/universalinitialsearch.html
+++ b/tests/acceptance/fixtures/html/universalinitialsearch.html
@@ -17,8 +17,8 @@
 
   <script>
     ANSWERS.init({
-      apiKey: 'df4b24f4075800e5e9705090c54c6c13',
-      experienceKey: 'sdkacceptancetests',
+      apiKey: '<apiKey>',
+      experienceKey: '<experienceKey>',
       experienceVersion: 'PRODUCTION',
       templateBundle: TemplateBundle.default,
       search: {

--- a/tests/acceptance/fixtures/html/vertical.html
+++ b/tests/acceptance/fixtures/html/vertical.html
@@ -17,12 +17,11 @@
     
         <script>
             ANSWERS.init({
-                apiKey: '2d8c550071a64ea23e263118a2b0680b',
-                experienceKey: 'slanswers',
-                businessId: '3350634',
+                apiKey: '<apiKey>',
+                experienceKey: '<experienceKey>',
+                businessId: '<businessId>',
                 experienceVersion: 'PRODUCTION',
                 templateBundle: TemplateBundle.default,
-                experienceVersion: 'PRODUCTION',
                 search: {
                   verticalKey: 'KM',
                   limit: 1,

--- a/tests/acceptance/fixtures/responses/universal/search.js
+++ b/tests/acceptance/fixtures/responses/universal/search.js
@@ -480,7 +480,7 @@ const UniversalSearchResponse = {
 
 export const MockedUniversalSearchRequest = RequestMock()
   .onRequestTo(async request => {
-    const urlRegex = /^https:\/\/liveapi.yext.com\/v2\/accounts\/me\/answers\/query\?input=amani\+farooque\+phone\+number/;
+    const urlRegex = /^https:\/\/liveapi.yext.com\/v2\/accounts\/me\/answers\/query/;
     return urlRegex.test(request.url) && request.method === 'get';
   })
   .respond(UniversalSearchResponse, 200, CORSHeaders);

--- a/tests/acceptance/fixtures/responses/universal/search.js
+++ b/tests/acceptance/fixtures/responses/universal/search.js
@@ -480,7 +480,6 @@ const UniversalSearchResponse = {
 };
 
 function generateUniversalSearchResponse (input) {
-  console.log('generating res for', input);
   if (input === 'virginia') {
     return virginiaRes;
   } else {
@@ -491,7 +490,6 @@ function generateUniversalSearchResponse (input) {
 export const MockedUniversalSearchRequest = RequestMock()
   .onRequestTo(async request => {
     const urlRegex = /^https:\/\/liveapi.yext.com\/v2\/accounts\/me\/answers\/query/;
-    urlRegex.test(request.url) && console.log('catching universal req for', urlRegex.test(request.url) && request.method === 'get', request.url, request.method);
     return urlRegex.test(request.url) && request.method === 'get';
   })
   .respond((req, res) => {

--- a/tests/acceptance/fixtures/responses/universal/search.js
+++ b/tests/acceptance/fixtures/responses/universal/search.js
@@ -1,5 +1,6 @@
 import { RequestMock } from 'testcafe';
 import { CORSHeaders } from '../cors';
+import { virginiaRes } from './virginiaRes';
 
 const UniversalSearchResponse = {
   meta: {
@@ -478,9 +479,27 @@ const UniversalSearchResponse = {
   }
 };
 
+function generateUniversalSearchResponse (input) {
+  console.log('generating res for', input);
+  if (input === 'virginia') {
+    return virginiaRes;
+  } else {
+    return UniversalSearchResponse;
+  }
+}
+
 export const MockedUniversalSearchRequest = RequestMock()
   .onRequestTo(async request => {
     const urlRegex = /^https:\/\/liveapi.yext.com\/v2\/accounts\/me\/answers\/query/;
+    urlRegex.test(request.url) && console.log('catching universal req for', urlRegex.test(request.url) && request.method === 'get', request.url, request.method);
     return urlRegex.test(request.url) && request.method === 'get';
   })
-  .respond(UniversalSearchResponse, 200, CORSHeaders);
+  .respond((req, res) => {
+    const parsedUrl = new URL(req.url);
+
+    res.body = JSON.stringify(generateUniversalSearchResponse(
+      parsedUrl.searchParams.get('input')
+    ));
+    res.headers = CORSHeaders;
+    res.statusCode = 200;
+  });

--- a/tests/acceptance/fixtures/responses/universal/virginiaRes.js
+++ b/tests/acceptance/fixtures/responses/universal/virginiaRes.js
@@ -1,0 +1,1872 @@
+export const virginiaRes = {
+  meta: {
+    uuid: '01819229-154d-552f-358b-ff12a09fb32a',
+    errors: []
+  },
+  response: {
+    businessId: 3350634,
+    modules: [
+      {
+        verticalConfigId: 'KM',
+        resultsCount: 821,
+        encodedState: '',
+        results: [
+          {
+            data: {
+              id: '2917513710699998040',
+              type: 'location',
+              website: 'https://locations.yext.com/us/va/mclean/7900-westpark-drive.html',
+              address: {
+                line1: '7900 Westpark Drive',
+                line2: 'Suite T200',
+                city: 'McLean',
+                region: 'VA',
+                postalCode: '22102',
+                countryCode: 'US'
+              },
+              addressHidden: false,
+              description: 'Yext is the global digital knowledge management leader, and our Knowledge Engine puts businesses in control of their digital knowledge.',
+              hours: {
+                monday: {
+                  openIntervals: [
+                    {
+                      start: '01:00',
+                      end: '14:00'
+                    }
+                  ]
+                },
+                tuesday: {
+                  openIntervals: [
+                    {
+                      start: '02:00',
+                      end: '15:00'
+                    },
+                    {
+                      start: '16:00',
+                      end: '17:00'
+                    }
+                  ]
+                },
+                wednesday: {
+                  openIntervals: [
+                    {
+                      start: '00:00',
+                      end: '23:59'
+                    }
+                  ]
+                },
+                thursday: {
+                  isClosed: true
+                },
+                friday: {
+                  openIntervals: [
+                    {
+                      start: '12:00',
+                      end: '14:00'
+                    }
+                  ]
+                },
+                saturday: {
+                  openIntervals: [
+                    {
+                      start: '12:00',
+                      end: '13:00'
+                    }
+                  ]
+                },
+                sunday: {
+                  isClosed: true
+                }
+              },
+              name: 'Office Space',
+              cityCoordinate: {
+                latitude: 38.936519622802734,
+                longitude: -77.18428039550781
+              },
+              c_names: [
+                'my name is Steve',
+                'your name is Rose'
+              ],
+              displayCoordinate: {
+                latitude: 38.9246498,
+                longitude: -77.2169181
+              },
+              facebookPageUrl: 'https://www.facebook.com/Yext-Cafe-2073644659328705/',
+              geocodedCoordinate: {
+                latitude: 38.9246498,
+                longitude: -77.2169181
+              },
+              isoRegionCode: 'VA',
+              localPhone: '+16467624579',
+              mainPhone: '+18884442988',
+              routableCoordinate: {
+                latitude: 38.9243984,
+                longitude: -77.2178386
+              },
+              services: [
+                'Dogs',
+                'Cats',
+                'Sleep'
+              ],
+              timezone: 'America/New_York',
+              websiteUrl: {
+                url: 'https://locations.yext.com/us/va/mclean/7900-westpark-drive.html',
+                preferDisplayUrl: false
+              },
+              yextDisplayCoordinate: {
+                latitude: 38.9246498,
+                longitude: -77.2169181
+              },
+              yextRoutableCoordinate: {
+                latitude: 38.9243984,
+                longitude: -77.2178386
+              },
+              categoryIds: [
+                '668'
+              ],
+              timeZoneUtcOffset: '-04:00',
+              uid: '18714998'
+            },
+            highlightedFields: {},
+            distance: 13128,
+            distanceFromFilter: 184935
+          },
+          {
+            data: {
+              id: '03037',
+              type: 'location',
+              address: {
+                line1: '1009 Park Avenue West',
+                city: 'Mansfield',
+                region: 'OH',
+                postalCode: '44906',
+                countryCode: 'US'
+              },
+              hours: {
+                monday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '21:00'
+                    }
+                  ]
+                },
+                tuesday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '21:00'
+                    }
+                  ]
+                },
+                wednesday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '21:00'
+                    }
+                  ]
+                },
+                thursday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '21:00'
+                    }
+                  ]
+                },
+                friday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '21:00'
+                    }
+                  ]
+                },
+                saturday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '21:00'
+                    }
+                  ]
+                },
+                sunday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '21:00'
+                    }
+                  ]
+                }
+              },
+              name: 'Mansfield',
+              cityCoordinate: {
+                latitude: 40.761307,
+                longitude: -82.522964
+              },
+              displayCoordinate: {
+                latitude: 40.758865,
+                longitude: -82.5523833
+              },
+              geocodedCoordinate: {
+                latitude: 40.758754,
+                longitude: -82.552084
+              },
+              isoRegionCode: 'OH',
+              mainPhone: '+14195257300',
+              routableCoordinate: {
+                latitude: 40.7591657,
+                longitude: -82.5523709
+              },
+              timezone: 'America/New_York',
+              yextDisplayCoordinate: {
+                latitude: 40.758865,
+                longitude: -82.5523833
+              },
+              yextRoutableCoordinate: {
+                latitude: 40.7591657,
+                longitude: -82.5523709
+              },
+              timeZoneUtcOffset: '-04:00',
+              uid: '18715000'
+            },
+            highlightedFields: {},
+            distance: 511885,
+            distanceFromFilter: 481803
+          },
+          {
+            data: {
+              id: '07886',
+              type: 'location',
+              address: {
+                line1: '115 Leader Heights Road',
+                city: 'York',
+                region: 'PA',
+                postalCode: '17403',
+                countryCode: 'US'
+              },
+              hours: {
+                monday: {
+                  openIntervals: [
+                    {
+                      start: '07:00',
+                      end: '23:00'
+                    }
+                  ]
+                },
+                tuesday: {
+                  openIntervals: [
+                    {
+                      start: '07:00',
+                      end: '23:00'
+                    }
+                  ]
+                },
+                wednesday: {
+                  openIntervals: [
+                    {
+                      start: '07:00',
+                      end: '23:00'
+                    }
+                  ]
+                },
+                thursday: {
+                  openIntervals: [
+                    {
+                      start: '07:00',
+                      end: '23:00'
+                    }
+                  ]
+                },
+                friday: {
+                  openIntervals: [
+                    {
+                      start: '07:00',
+                      end: '23:00'
+                    }
+                  ]
+                },
+                saturday: {
+                  openIntervals: [
+                    {
+                      start: '07:00',
+                      end: '23:00'
+                    }
+                  ]
+                },
+                sunday: {
+                  openIntervals: [
+                    {
+                      start: '07:00',
+                      end: '23:00'
+                    }
+                  ]
+                }
+              },
+              name: 'York',
+              cityCoordinate: {
+                latitude: 39.961265,
+                longitude: -76.731612
+              },
+              displayCoordinate: {
+                latitude: 39.91028,
+                longitude: -76.70615
+              },
+              geocodedCoordinate: {
+                latitude: 39.91067,
+                longitude: -76.706121
+              },
+              isoRegionCode: 'PA',
+              mainPhone: '+17177410823',
+              routableCoordinate: {
+                latitude: 39.9098764,
+                longitude: -76.7060546
+              },
+              timezone: 'America/New_York',
+              yextDisplayCoordinate: {
+                latitude: 39.91028,
+                longitude: -76.70615
+              },
+              yextRoutableCoordinate: {
+                latitude: 39.9098764,
+                longitude: -76.7060546
+              },
+              timeZoneUtcOffset: '-04:00',
+              uid: '18715019'
+            },
+            highlightedFields: {},
+            distance: 117094,
+            distanceFromFilter: 298527
+          },
+          {
+            data: {
+              id: '07884',
+              type: 'location',
+              address: {
+                line1: '320 York Road',
+                city: 'Carlisle',
+                region: 'PA',
+                postalCode: '17013',
+                countryCode: 'US'
+              },
+              hours: {
+                monday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                tuesday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                wednesday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                thursday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                friday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                saturday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                sunday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '18:00'
+                    }
+                  ]
+                }
+              },
+              name: 'Carlisle',
+              cityCoordinate: {
+                latitude: 40.168495,
+                longitude: -77.228817
+              },
+              displayCoordinate: {
+                latitude: 40.19132,
+                longitude: -77.161437
+              },
+              geocodedCoordinate: {
+                latitude: 40.191324,
+                longitude: -77.161451
+              },
+              isoRegionCode: 'PA',
+              mainPhone: '+17172450116',
+              routableCoordinate: {
+                latitude: 40.1919244,
+                longitude: -77.1610043
+              },
+              timezone: 'America/New_York',
+              yextDisplayCoordinate: {
+                latitude: 40.19132,
+                longitude: -77.161437
+              },
+              yextRoutableCoordinate: {
+                latitude: 40.1919244,
+                longitude: -77.1610043
+              },
+              timeZoneUtcOffset: '-04:00',
+              uid: '18715044'
+            },
+            highlightedFields: {},
+            distance: 144311,
+            distanceFromFilter: 306638
+          },
+          {
+            data: {
+              id: '07880',
+              type: 'location',
+              address: {
+                line1: '277 Dekalb Pike',
+                city: 'North Wales',
+                region: 'PA',
+                postalCode: '19454',
+                countryCode: 'US'
+              },
+              hours: {
+                monday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                tuesday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                wednesday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                thursday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                friday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                saturday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                sunday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                }
+              },
+              name: 'North Wales',
+              cityCoordinate: {
+                latitude: 40.210925,
+                longitude: -75.278283
+              },
+              displayCoordinate: {
+                latitude: 40.222693,
+                longitude: -75.249654
+              },
+              geocodedCoordinate: {
+                latitude: 40.222689,
+                longitude: -75.249766
+              },
+              isoRegionCode: 'PA',
+              mainPhone: '+12156610141',
+              routableCoordinate: {
+                latitude: 40.222842,
+                longitude: -75.2487984
+              },
+              timezone: 'America/New_York',
+              yextDisplayCoordinate: {
+                latitude: 40.222693,
+                longitude: -75.249654
+              },
+              yextRoutableCoordinate: {
+                latitude: 40.222842,
+                longitude: -75.2487984
+              },
+              timeZoneUtcOffset: '-04:00',
+              uid: '18715049'
+            },
+            highlightedFields: {},
+            distance: 214781,
+            distanceFromFilter: 406148
+          },
+          {
+            data: {
+              id: '03028',
+              type: 'location',
+              address: {
+                line1: '1955 Cleveland Road',
+                city: 'Wooster',
+                region: 'OH',
+                postalCode: '44691',
+                countryCode: 'US'
+              },
+              hours: {
+                monday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                tuesday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                wednesday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                thursday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                friday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                saturday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                sunday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                }
+              },
+              name: 'Wooster',
+              cityCoordinate: {
+                latitude: 40.830699,
+                longitude: -81.895377
+              },
+              displayCoordinate: {
+                latitude: 40.823634,
+                longitude: -81.933392
+              },
+              geocodedCoordinate: {
+                latitude: 40.823663,
+                longitude: -81.933386
+              },
+              isoRegionCode: 'OH',
+              mainPhone: '+13302629045',
+              routableCoordinate: {
+                latitude: 40.8237606,
+                longitude: -81.9339091
+              },
+              timezone: 'America/New_York',
+              yextDisplayCoordinate: {
+                latitude: 40.823634,
+                longitude: -81.933392
+              },
+              yextRoutableCoordinate: {
+                latitude: 40.8237606,
+                longitude: -81.9339091
+              },
+              timeZoneUtcOffset: '-04:00',
+              uid: '18715063'
+            },
+            highlightedFields: {},
+            distance: 467150,
+            distanceFromFilter: 451419
+          },
+          {
+            data: {
+              id: '11918',
+              type: 'location',
+              address: {
+                line1: '4501 News Road',
+                city: 'Williamsburg',
+                region: 'VA',
+                postalCode: '23188',
+                countryCode: 'US'
+              },
+              hours: {
+                monday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                tuesday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                wednesday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                thursday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                friday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                saturday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '21:00'
+                    }
+                  ]
+                },
+                sunday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '20:00'
+                    }
+                  ]
+                }
+              },
+              name: 'Williamsburg',
+              cityCoordinate: {
+                latitude: 37.270697,
+                longitude: -76.70741
+              },
+              displayCoordinate: {
+                latitude: 37.269769,
+                longitude: -76.761948
+              },
+              geocodedCoordinate: {
+                latitude: 37.269752,
+                longitude: -76.76199
+              },
+              isoRegionCode: 'VA',
+              mainPhone: '+17572201287',
+              routableCoordinate: {
+                latitude: 37.2702963,
+                longitude: -76.7618494
+              },
+              timezone: 'America/New_York',
+              yextDisplayCoordinate: {
+                latitude: 37.269769,
+                longitude: -76.761948
+              },
+              yextRoutableCoordinate: {
+                latitude: 37.2702963,
+                longitude: -76.7618494
+              },
+              timeZoneUtcOffset: '-04:00',
+              uid: '18715138'
+            },
+            highlightedFields: {},
+            distance: 182782,
+            distanceFromFilter: 170051
+          },
+          {
+            data: {
+              id: '11916',
+              type: 'location',
+              address: {
+                line1: '4770 McKnight Road',
+                line2: 'Ste A',
+                city: 'Pittsburgh',
+                region: 'PA',
+                postalCode: '15237',
+                countryCode: 'US'
+              },
+              hours: {
+                monday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                tuesday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                wednesday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                thursday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                friday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                saturday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                sunday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '18:00'
+                    }
+                  ]
+                }
+              },
+              name: 'Pittsburgh',
+              cityCoordinate: {
+                latitude: 40.438355,
+                longitude: -80.001983
+              },
+              displayCoordinate: {
+                latitude: 40.5203953,
+                longitude: -80.0044938
+              },
+              geocodedCoordinate: {
+                latitude: 40.5203953,
+                longitude: -80.0044938
+              },
+              isoRegionCode: 'PA',
+              mainPhone: '+14123648100',
+              routableCoordinate: {
+                latitude: 40.5203418,
+                longitude: -80.0050673
+              },
+              timezone: 'America/New_York',
+              yextDisplayCoordinate: {
+                latitude: 40.5203953,
+                longitude: -80.0044938
+              },
+              yextRoutableCoordinate: {
+                latitude: 40.5203418,
+                longitude: -80.0050673
+              },
+              timeZoneUtcOffset: '-04:00',
+              uid: '18715145'
+            },
+            highlightedFields: {},
+            distance: 309285,
+            distanceFromFilter: 337966
+          },
+          {
+            data: {
+              id: '03061',
+              type: 'location',
+              address: {
+                line1: '4332 Cleveland Avenue NW',
+                city: 'Canton',
+                region: 'OH',
+                postalCode: '44709',
+                countryCode: 'US'
+              },
+              hours: {
+                monday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                tuesday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                wednesday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                thursday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                friday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                saturday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                },
+                sunday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '22:00'
+                    }
+                  ]
+                }
+              },
+              name: 'Canton',
+              cityCoordinate: {
+                latitude: 40.809302,
+                longitude: -81.376113
+              },
+              displayCoordinate: {
+                latitude: 40.8459208,
+                longitude: -81.3914875
+              },
+              geocodedCoordinate: {
+                latitude: 40.845907,
+                longitude: -81.391371
+              },
+              isoRegionCode: 'OH',
+              mainPhone: '+13306499709',
+              routableCoordinate: {
+                latitude: 40.8458676,
+                longitude: -81.3919028
+              },
+              timezone: 'America/New_York',
+              yextDisplayCoordinate: {
+                latitude: 40.8459208,
+                longitude: -81.3914875
+              },
+              yextRoutableCoordinate: {
+                latitude: 40.8458676,
+                longitude: -81.3919028
+              },
+              timeZoneUtcOffset: '-04:00',
+              uid: '18715146'
+            },
+            highlightedFields: {},
+            distance: 427799,
+            distanceFromFilter: 425516
+          },
+          {
+            data: {
+              id: '03060',
+              type: 'location',
+              address: {
+                line1: '614 Bradshaw Avenue',
+                city: 'East Liverpool',
+                region: 'OH',
+                postalCode: '43920',
+                countryCode: 'US'
+              },
+              hours: {
+                monday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '21:00'
+                    }
+                  ]
+                },
+                tuesday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '21:00'
+                    }
+                  ]
+                },
+                wednesday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '21:00'
+                    }
+                  ]
+                },
+                thursday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '21:00'
+                    }
+                  ]
+                },
+                friday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '21:00'
+                    }
+                  ]
+                },
+                saturday: {
+                  openIntervals: [
+                    {
+                      start: '08:00',
+                      end: '21:00'
+                    }
+                  ]
+                },
+                sunday: {
+                  openIntervals: [
+                    {
+                      start: '09:00',
+                      end: '18:00'
+                    }
+                  ]
+                }
+              },
+              name: 'East Liverpool',
+              cityCoordinate: {
+                latitude: 40.677372,
+                longitude: -80.600629
+              },
+              displayCoordinate: {
+                latitude: 40.620325,
+                longitude: -80.576325
+              },
+              geocodedCoordinate: {
+                latitude: 40.620345,
+                longitude: -80.576349
+              },
+              isoRegionCode: 'OH',
+              mainPhone: '+13303866210',
+              routableCoordinate: {
+                latitude: 40.6208137,
+                longitude: -80.5762928
+              },
+              timezone: 'America/New_York',
+              yextDisplayCoordinate: {
+                latitude: 40.620325,
+                longitude: -80.576325
+              },
+              yextRoutableCoordinate: {
+                latitude: 40.6208137,
+                longitude: -80.5762928
+              },
+              timeZoneUtcOffset: '-04:00',
+              uid: '18715147'
+            },
+            highlightedFields: {},
+            distance: 355820,
+            distanceFromFilter: 368178
+          }
+        ],
+        appliedQueryFilters: [
+          {
+            displayKey: 'Location',
+            displayValue: 'Virginia',
+            filter: {
+              'builtin.location': {
+                $eq: 'P-region.7919684583758790'
+              }
+            },
+            type: 'PLACE',
+            details: {
+              latitude: 37.677592044,
+              longitude: -78.6190526172645,
+              placeName: 'Virginia, United States',
+              featureTypes: [
+                'region'
+              ],
+              boundingBox: {
+                minLatitude: 36.540855,
+                minLongitude: -83.6753959969438,
+                maxLatitude: 39.4660129984577,
+                maxLongitude: -75.165704098375
+              }
+            }
+          }
+        ],
+        queryDurationMillis: 138,
+        facets: [],
+        source: 'KNOWLEDGE_MANAGER'
+      },
+      {
+        verticalConfigId: 'financial_professionals',
+        resultsCount: 1,
+        encodedState: '',
+        results: [
+          {
+            data: {
+              id: '3723515499403010611',
+              type: 'financialProfessional',
+              address: {
+                line1: '1101 Wilson Boulevard',
+                city: 'Arlington',
+                region: 'VA',
+                postalCode: '22209',
+                countryCode: 'US'
+              },
+              addressHidden: false,
+              name: 'Connor Anderson',
+              cityCoordinate: {
+                latitude: 38.881579,
+                longitude: -77.103339
+              },
+              c_hierarchicalFacet: [
+                'Appliances',
+                'Appliances > Large Appliances',
+                'Appliances > Large Appliances > Outdoors'
+              ],
+              c_primaryCTA: {
+                label: 'Call now',
+                linkType: 'Phone',
+                link: '+18888888888'
+              },
+              featuredMessage: {
+                description: 'Ask Connor a financial question!'
+              },
+              geocodedCoordinate: {
+                latitude: 38.895467,
+                longitude: -77.069889
+              },
+              isoRegionCode: 'VA',
+              timezone: 'America/New_York',
+              yextDisplayCoordinate: {
+                latitude: 38.895467,
+                longitude: -77.069889
+              },
+              yextRoutableCoordinate: {
+                latitude: 38.895032,
+                longitude: -77.070102
+              },
+              timeZoneUtcOffset: '-04:00',
+              uid: '24359942'
+            },
+            highlightedFields: {},
+            distance: 4,
+            distanceFromFilter: 191371
+          }
+        ],
+        appliedQueryFilters: [
+          {
+            displayKey: 'Location',
+            displayValue: 'Virginia',
+            filter: {
+              'builtin.location': {
+                $eq: 'P-region.7919684583758790'
+              }
+            },
+            type: 'PLACE',
+            details: {
+              latitude: 37.677592044,
+              longitude: -78.6190526172645,
+              placeName: 'Virginia, United States',
+              featureTypes: [
+                'region'
+              ],
+              boundingBox: {
+                minLatitude: 36.540855,
+                minLongitude: -83.6753959969438,
+                maxLatitude: 39.4660129984577,
+                maxLongitude: -75.165704098375
+              }
+            }
+          }
+        ],
+        queryDurationMillis: 115,
+        facets: [],
+        source: 'KNOWLEDGE_MANAGER'
+      },
+      {
+        verticalConfigId: 'healthcare_professionals',
+        resultsCount: 1,
+        encodedState: '',
+        results: [
+          {
+            data: {
+              id: '555601076612488113',
+              type: 'healthcareProfessional',
+              landingPageUrl: 'https://www.youtube.com/channel/UCiPW7OlzTfQjR_vLlkYPZCg',
+              address: {
+                line1: '1101 Wilson Boulevard',
+                city: 'Arlington',
+                region: 'VA',
+                postalCode: '22209',
+                countryCode: 'US'
+              },
+              addressHidden: false,
+              description: 'An Interventional Radiologist and a Youtuber',
+              name: 'Bob Cellini',
+              cityCoordinate: {
+                latitude: 38.881579,
+                longitude: -77.103339
+              },
+              firstName: 'Bob',
+              photoGallery: [
+                {
+                  image: {
+                    url: 'https://a.mktgcdn.com/p/rH7u6enn8thbrCVgI5a9ydxcGhcY3LIlu35nd1prLHs/310x310.jpg',
+                    alternateText: 'Photo of a doctor',
+                    width: 310,
+                    height: 310,
+                    thumbnails: [
+                      {
+                        url: 'https://a.mktgcdn.com/p/rH7u6enn8thbrCVgI5a9ydxcGhcY3LIlu35nd1prLHs/310x310.jpg',
+                        width: 310,
+                        height: 310
+                      }
+                    ]
+                  }
+                }
+              ],
+              geocodedCoordinate: {
+                latitude: 38.895467,
+                longitude: -77.069889
+              },
+              headshot: {
+                url: 'https://a.mktgcdn.com/p/rH7u6enn8thbrCVgI5a9ydxcGhcY3LIlu35nd1prLHs/310x310.jpg',
+                alternateText: 'Photo of a doctor',
+                width: 310,
+                height: 310,
+                thumbnails: [
+                  {
+                    url: 'https://a.mktgcdn.com/p/rH7u6enn8thbrCVgI5a9ydxcGhcY3LIlu35nd1prLHs/310x310.jpg',
+                    width: 310,
+                    height: 310
+                  }
+                ]
+              },
+              isoRegionCode: 'VA',
+              lastName: 'Cellini',
+              localPhone: '+17034567890',
+              timezone: 'America/New_York',
+              yextDisplayCoordinate: {
+                latitude: 38.895467,
+                longitude: -77.069889
+              },
+              yextRoutableCoordinate: {
+                latitude: 38.895032,
+                longitude: -77.070102
+              },
+              categoryIds: [
+                '1545906',
+                '1120591'
+              ],
+              timeZoneUtcOffset: '-04:00',
+              uid: '24360867'
+            },
+            highlightedFields: {},
+            distance: 4,
+            distanceFromFilter: 191371
+          }
+        ],
+        appliedQueryFilters: [
+          {
+            displayKey: 'Location',
+            displayValue: 'Virginia',
+            filter: {
+              'builtin.location': {
+                $eq: 'P-region.7919684583758790'
+              }
+            },
+            type: 'PLACE',
+            details: {
+              latitude: 37.677592044,
+              longitude: -78.6190526172645,
+              placeName: 'Virginia, United States',
+              featureTypes: [
+                'region'
+              ],
+              boundingBox: {
+                minLatitude: 36.540855,
+                minLongitude: -83.6753959969438,
+                maxLatitude: 39.4660129984577,
+                maxLongitude: -75.165704098375
+              }
+            }
+          }
+        ],
+        queryDurationMillis: 115,
+        facets: [],
+        source: 'KNOWLEDGE_MANAGER'
+      },
+      {
+        verticalConfigId: 'jobs',
+        resultsCount: 1,
+        encodedState: '',
+        results: [
+          {
+            data: {
+              id: '3948245816880139515',
+              type: 'job',
+              landingPageUrl: 'https://www.yext.com/careers/',
+              location: {
+                externalLocation: 'Yext, 7900 Westpark Drive, Suite T200, McLean, Virginia 22102, United States'
+              },
+              description: 'Making decisions',
+              name: 'Product Manager',
+              c_department: 'Product',
+              yextDisplayCoordinate: {
+                latitude: 38.9246498,
+                longitude: -77.2169181
+              },
+              locationString: 'Yext, 7900 Westpark Drive, Suite T200, McLean, Virginia 22102, United States',
+              uid: '24359946'
+            },
+            highlightedFields: {},
+            distance: 13128,
+            distanceFromFilter: 184935
+          }
+        ],
+        appliedQueryFilters: [
+          {
+            displayKey: 'Location',
+            displayValue: 'Virginia',
+            filter: {
+              'builtin.location': {
+                $eq: 'P-region.7919684583758790'
+              }
+            },
+            type: 'PLACE',
+            details: {
+              latitude: 37.677592044,
+              longitude: -78.6190526172645,
+              placeName: 'Virginia, United States',
+              featureTypes: [
+                'region'
+              ],
+              boundingBox: {
+                minLatitude: 36.540855,
+                minLongitude: -83.6753959969438,
+                maxLatitude: 39.4660129984577,
+                maxLongitude: -75.165704098375
+              }
+            }
+          }
+        ],
+        queryDurationMillis: 122,
+        facets: [],
+        source: 'KNOWLEDGE_MANAGER'
+      },
+      {
+        verticalConfigId: 'people',
+        resultsCount: 4,
+        encodedState: '',
+        results: [
+          {
+            data: {
+              id: 'Employee-2116',
+              type: 'ce_person',
+              website: 'http://www.test.com',
+              address: {
+                line1: '7900 Westpark Drive',
+                city: 'Mclean',
+                region: 'VA',
+                postalCode: '22102',
+                countryCode: 'US'
+              },
+              associations: [
+                'Runners Association'
+              ],
+              description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Mollis nunc sed id semper risus. Commodo elit at imperdiet dui accumsan sit amet nulla facilisi. Scelerisque viverra mauris in aliquam. A erat nam at lectus. Egestas purus viverra accumsan in nisl nisi scelerisque. Habitant morbi tristique senectus et netus. Congue nisi vitae suscipit tellus mauris a diam maecenas sed.',
+              name: 'Amani Farooque',
+              cityCoordinate: {
+                latitude: 38.936519622802734,
+                longitude: -77.18428039550781
+              },
+              c_allstateLadyCTA: {
+                label: 'Learn More',
+                linkType: 'URL',
+                link: 'http://yext.com'
+              },
+              c_employeeCity: 'Tysons Corner',
+              c_employeeCountry: 'United States',
+              c_employeeDepartment: 'Consulting',
+              c_employeeRegion: 'Virginia',
+              c_employeeTitle: 'Associate Technical Project Manager',
+              c_oliverCta: {
+                url: 'https://www.yext.com/s/2287528/entity/edit2?entityIds=13411251',
+                icon: 'yext',
+                label: 'test cta'
+              },
+              c_startDate: '2017-09-18',
+              displayCoordinate: {
+                latitude: 38.924648,
+                longitude: -77.216859
+              },
+              emails: [
+                'afarooque@yext.com',
+                'af@yext.com',
+                'aplomb@yext.com'
+              ],
+              firstName: 'Amani',
+              geocodedCoordinate: {
+                latitude: 38.924654,
+                longitude: -77.216891
+              },
+              headshot: {
+                url: 'https://a.mktgcdn.com/p/bmc3W88h2mMRXk-wHQ7dB0Em4rR_dfia6OVrAK3LjYU/192x191.png',
+                width: 192,
+                height: 191,
+                sourceUrl: 'http://a.mktgcdn.com/p/bmc3W88h2mMRXk-wHQ7dB0Em4rR_dfia6OVrAK3LjYU/192x191.png'
+              },
+              languages: [
+                'German'
+              ],
+              lastName: 'Farooque',
+              mainPhone: '+18003332222',
+              routableCoordinate: {
+                latitude: 38.9242966,
+                longitude: -77.2177549
+              },
+              specialities: [
+                'Documentation',
+                'Coding'
+              ],
+              websiteUrl: {
+                url: 'http://www.test.com',
+                displayUrl: 'http://www.testdisplay.com',
+                preferDisplayUrl: true
+              },
+              yextDisplayCoordinate: {
+                latitude: 38.924648,
+                longitude: -77.216859
+              },
+              yextRoutableCoordinate: {
+                latitude: 38.9242966,
+                longitude: -77.2177549
+              },
+              uid: '18716057'
+            },
+            highlightedFields: {},
+            distance: 13123,
+            distanceFromFilter: 184938
+          },
+          {
+            data: {
+              id: 'Employee-2143',
+              type: 'ce_person',
+              address: {
+                line1: '7900 Westpark Drive',
+                city: 'Mclean',
+                region: 'VA',
+                postalCode: '22102',
+                countryCode: 'US'
+              },
+              description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Tristique senectus et netus et malesuada fames ac turpis. Porttitor eget dolor morbi non arcu risus quis. Tempor orci dapibus ultrices in iaculis. Viverra tellus in hac habitasse platea dictumst vestibulum rhoncus est. Eleifend donec pretium vulputate sapien nec. Ornare suspendisse sed nisi lacus sed viverra tellus in hac. Morbi tristique senectus et netus et malesuada. Vel pharetra vel turpis nunc eget lorem dolor sed viverra. Sapien nec sagittis aliquam malesuada.\n\nAt lectus urna duis convallis convallis tellus. Luctus venenatis lectus magna fringilla urna porttitor rhoncus. Blandit volutpat maecenas volutpat blandit aliquam etiam erat velit. Amet dictum sit amet justo donec enim diam vulputate ut. Ultrices in iaculis nunc sed augue lacus viverra. Feugiat sed lectus vestibulum mattis ullamcorper velit. Euismod quis viverra nibh cras pulvinar mattis nunc sed blandit. In hac habitasse platea dictumst quisque. In aliquam sem fringilla ut morbi tincidunt augue interdum velit. At erat pellentesque adipiscing commodo elit at.\n\nNunc aliquet bibendum enim facilisis gravida neque. Libero id faucibus nisl tincidunt eget nullam. Ullamcorper dignissim cras tincidunt lobortis. Condimentum id venenatis a condimentum. Sit amet dictum sit amet justo. Ac placerat vestibulum lectus mauris ultrices eros in. Cras sed felis eget velit aliquet sagittis id consectetur purus. Auctor urna nunc id cursus. Arcu non odio euismod lacinia at. Neque convallis a cras semper auctor neque vitae. Adipiscing elit pellentesque habitant morbi tristique. Commodo sed egestas egestas fringilla phasellus faucibus scelerisque eleifend. Scelerisque eu ultrices vitae auctor eu augue ut lectus. In vitae turpis massa sed elementum. Nibh sit amet commodo nulla facilisi nullam vehicula ipsum a. Vitae suscipit tellus mauris a diam maecenas sed enim. Volutpat blandit aliquam etiam erat velit scelerisque.',
+              name: 'Tom Meyer',
+              cityCoordinate: {
+                latitude: 38.936519622802734,
+                longitude: -77.18428039550781
+              },
+              c_allstateLadyCTA: {
+                label: 'Learn More',
+                linkType: 'URL',
+                link: 'http://yext.com'
+              },
+              c_employeeCity: 'Tysons Corner',
+              c_employeeCountry: 'United States',
+              c_employeeDepartment: 'Technology',
+              c_employeeRegion: 'Virginia',
+              c_employeeTitle: 'Software Engineer',
+              c_hierarchicalFacet: [
+                'Appliances',
+                'Appliances > Medium Appliances',
+                'Appliances > Medium Appliances > Cooking',
+                'Computer & Tablets',
+                'Computer & Tablets > Laptops'
+              ],
+              c_myRichTextField: '++Underlined stuff++  \n**Bold stuff**\n\n1. One\n2. Two\n3. *Three*',
+              c_popularity: '1.0',
+              c_startDate: '2017-09-05',
+              displayCoordinate: {
+                latitude: 38.924648,
+                longitude: -77.216859
+              },
+              emails: [
+                'tmeyer@yext.com'
+              ],
+              firstName: 'Tom',
+              geocodedCoordinate: {
+                latitude: 38.924654,
+                longitude: -77.216891
+              },
+              headshot: {
+                url: 'https://a.mktgcdn.com/p/cb9jR0A19ADuKc7ExlWmHaDchPW_61IR5TZ5G7NApjY/139x140.jpg',
+                width: 139,
+                height: 140,
+                sourceUrl: 'https://a.mktgcdn.com/p/cb9jR0A19ADuKc7ExlWmHaDchPW_61IR5TZ5G7NApjY/139x140.jpg'
+              },
+              lastName: 'Meyer',
+              routableCoordinate: {
+                latitude: 38.9242966,
+                longitude: -77.2177549
+              },
+              yextDisplayCoordinate: {
+                latitude: 38.924648,
+                longitude: -77.216859
+              },
+              yextRoutableCoordinate: {
+                latitude: 38.9242966,
+                longitude: -77.2177549
+              },
+              uid: '18716864'
+            },
+            highlightedFields: {},
+            distance: 13123,
+            distanceFromFilter: 184938
+          },
+          {
+            data: {
+              id: '4880570941877725281',
+              type: 'ce_person',
+              outdoorPoolCount: 5,
+              time: {
+                start: '2020-04-08T13:00',
+                end: '2020-04-15T14:00'
+              },
+              address: {
+                line1: '7900 Westpark Drive',
+                city: 'Mclean',
+                region: 'VA',
+                postalCode: '22102',
+                countryCode: 'US'
+              },
+              description: 'hai hai kazuma-desu the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team',
+              name: 'Oliver Shi',
+              cityCoordinate: {
+                latitude: 38.936519622802734,
+                longitude: -77.18428039550781
+              },
+              c_allstateLadyCTA: {
+                label: 'Learn More',
+                linkType: 'URL',
+                link: 'http://yext.com'
+              },
+              c_hierarchicalFacet: [
+                'Appliances',
+                'Appliances > Medium Appliances',
+                'Appliances > Medium Appliances > Cooking',
+                'Appliances > Medium Appliances > Air Purification',
+                'Computer & Tablets',
+                'Computer & Tablets > Cables & Connectors',
+                'Computer & Tablets > Desktop',
+                'Computer & Tablets > Desktop > Refurbished Desktops',
+                'Computer & Tablets > Desktop > Refurbished Desktops > 1990s Desktops'
+              ],
+              c_myRichTextField: '++Underlined++  \n**Bolded**\n\n1. **One**\n2. *Two*\n3. Three\n\n\\<div\\>Dang\\</div\\>',
+              c_nestedBoy: {
+                waifus: {
+                  anime: {
+                    a: 'waifu',
+                    b: 'koko'
+                  },
+                  games: {
+                    c: 'waifu',
+                    d: 'hi'
+                  },
+                  life: {
+                    e: 'kaga',
+                    f: 'baba'
+                  }
+                },
+                husbandos: {
+                  a: {
+                    a: 'yaga',
+                    b: 'haha'
+                  },
+                  b: {
+                    c: 'lala',
+                    d: 'kaka'
+                  },
+                  c: {
+                    e: 'kaga',
+                    f: 'lala'
+                  }
+                }
+              },
+              c_nestedTextLists: [
+                {
+                  textlist: [
+                    'weeb',
+                    'lord',
+                    'poggers'
+                  ],
+                  struct: {
+                    nested_list1: [
+                      'weeber',
+                      'weeb'
+                    ],
+                    nested_list2: [
+                      'weeb',
+                      'weweb weeb weeb',
+                      'haha ohaiyo',
+                      'weeber'
+                    ]
+                  }
+                }
+              ],
+              c_oliverCta: {
+                url: 'https://google.com',
+                icon: 'yext',
+                label: 'please update'
+              },
+              c_secondCTA: true,
+              c_startDate: '2019-08-05',
+              c_string1: 'stringy',
+              c_terminationDate: '2020-01-01',
+              displayCoordinate: {
+                latitude: 38.924648,
+                longitude: -77.216859
+              },
+              firstName: 'Oliver',
+              gender: 'Male',
+              geocodedCoordinate: {
+                latitude: 38.924654,
+                longitude: -77.216891
+              },
+              headshot: {
+                url: 'https://a.mktgcdn.com/p/3Obc6RedOylBSTOj_DOT8BHMwp6_-ltsE0lCrZS6PGc/1200x1200.jpg',
+                width: 1200,
+                height: 1200,
+                sourceUrl: 'https://a.mktgcdn.com/p/3Obc6RedOylBSTOj_DOT8BHMwp6_-ltsE0lCrZS6PGc/1200x1200.jpg',
+                thumbnails: [
+                  {
+                    url: 'https://a.mktgcdn.com/p/3Obc6RedOylBSTOj_DOT8BHMwp6_-ltsE0lCrZS6PGc/619x619.jpg',
+                    width: 619,
+                    height: 619
+                  },
+                  {
+                    url: 'https://a.mktgcdn.com/p/3Obc6RedOylBSTOj_DOT8BHMwp6_-ltsE0lCrZS6PGc/450x450.jpg',
+                    width: 450,
+                    height: 450
+                  },
+                  {
+                    url: 'https://a.mktgcdn.com/p/3Obc6RedOylBSTOj_DOT8BHMwp6_-ltsE0lCrZS6PGc/196x196.jpg',
+                    width: 196,
+                    height: 196
+                  }
+                ]
+              },
+              keywords: [
+                'otaku',
+                'aKeyword',
+                'highlight me!'
+              ],
+              languages: [
+                'english',
+                'englangdo',
+                'chinese'
+              ],
+              lastName: 'Shi',
+              routableCoordinate: {
+                latitude: 38.9242966,
+                longitude: -77.2177549
+              },
+              yextDisplayCoordinate: {
+                latitude: 38.924648,
+                longitude: -77.216859
+              },
+              yextRoutableCoordinate: {
+                latitude: 38.9242966,
+                longitude: -77.2177549
+              },
+              uid: '18717130'
+            },
+            highlightedFields: {},
+            distance: 13123,
+            distanceFromFilter: 184938
+          },
+          {
+            data: {
+              id: 'Employee-718',
+              type: 'ce_person',
+              address: {
+                line1: '1481 N Dupont Hwy',
+                city: 'Dover',
+                region: 'DE',
+                postalCode: '19901',
+                countryCode: 'US'
+              },
+              name: 'Mike Peralta',
+              cityCoordinate: {
+                latitude: 39.161544,
+                longitude: -75.513578
+              },
+              c_allstateLadyCTA: {
+                label: 'Learn More',
+                linkType: 'URL',
+                link: 'http://yext.com'
+              },
+              c_employeeCountry: 'United States',
+              c_employeeDepartment: 'Business Applications',
+              c_employeeRegion: 'New York',
+              c_employeeTitle: 'Program Manager, Business Insights',
+              c_startDate: '2013-07-30',
+              displayCoordinate: {
+                latitude: 39.1940793,
+                longitude: -75.5465376
+              },
+              emails: [
+                'mperalta@yext.com'
+              ],
+              firstName: 'Mike',
+              geocodedCoordinate: {
+                latitude: 39.1940793,
+                longitude: -75.5465376
+              },
+              headshot: {
+                url: 'https://a.mktgcdn.com/p/8a6ix28DnWPS4CrO0GTRs3WFjvlBdLAkTs8UqgXZdQI/400x400.jpg',
+                width: 400,
+                height: 400,
+                sourceUrl: 'http://a.mktgcdn.com/p/8a6ix28DnWPS4CrO0GTRs3WFjvlBdLAkTs8UqgXZdQI/400x400.jpg',
+                thumbnails: [
+                  {
+                    url: 'https://a.mktgcdn.com/p/8a6ix28DnWPS4CrO0GTRs3WFjvlBdLAkTs8UqgXZdQI/196x196.jpg',
+                    width: 196,
+                    height: 196
+                  }
+                ]
+              },
+              lastName: 'Peralta',
+              routableCoordinate: {
+                latitude: 39.1938245,
+                longitude: -75.54686
+              },
+              yextDisplayCoordinate: {
+                latitude: 39.1940793,
+                longitude: -75.5465376
+              },
+              yextRoutableCoordinate: {
+                latitude: 39.1938245,
+                longitude: -75.54686
+              },
+              uid: '18717550'
+            },
+            highlightedFields: {},
+            distance: 135689,
+            distanceFromFilter: 316300
+          }
+        ],
+        appliedQueryFilters: [
+          {
+            displayKey: 'Location',
+            displayValue: 'Virginia',
+            filter: {
+              'builtin.location': {
+                $eq: 'P-region.7919684583758790'
+              }
+            },
+            type: 'PLACE',
+            details: {
+              latitude: 37.677592044,
+              longitude: -78.6190526172645,
+              placeName: 'Virginia, United States',
+              featureTypes: [
+                'region'
+              ],
+              boundingBox: {
+                minLatitude: 36.540855,
+                minLongitude: -83.6753959969438,
+                maxLatitude: 39.4660129984577,
+                maxLongitude: -75.165704098375
+              }
+            }
+          }
+        ],
+        queryDurationMillis: 148,
+        facets: [],
+        source: 'KNOWLEDGE_MANAGER'
+      },
+      {
+        verticalConfigId: 'links',
+        resultsCount: 194,
+        encodedState: 'virginia',
+        results: [
+          {
+            htmlTitle: 'Women&#39;s Vionic <b>Virginia</b> Driving Moc | Shoes.com',
+            link: 'https://www.shoes.com/womens-vionic-virginia-driving-moc/16933324.html',
+            displayLink: 'www.shoes.com',
+            htmlSnippet: 'Elevate your casual style wearing the Vionic Honor <b>Virginia</b> Driving Moc. This moccasin features an adjustable front bow detail for a perfect fit,&nbsp;...'
+          },
+          {
+            htmlTitle: 'Shoes: Women&#39;s, Men&#39;s &amp; Kids Shoes from Top Brands | DSW',
+            link: 'https://www.shoes.com/',
+            displayLink: 'www.shoes.com',
+            htmlSnippet: 'Shop DSW for the best athletic shoes, sneakers, boots, sandals, accessories and more. Free shipping, low prices, and extra perks for VIPs.'
+          },
+          {
+            htmlTitle: 'Men&#39;s Rockport Works RK6736 | Shoes.com',
+            link: 'https://www.shoes.com/mens-rockport-works-rk6736/5833949.html',
+            displayLink: 'www.shoes.com',
+            htmlSnippet: 'Aug 28, 2019 <b>...</b> From <b>Virginia</b> Beach <b>Virginia</b>. Verified Buyer Verified Buyer. I buy these shoes annually for work as a Landscape Manager for a local&nbsp;...'
+          },
+          {
+            htmlTitle: 'Men&#39;s Rockport Zaden CVO Sneaker | Shoes.com',
+            link: 'https://www.shoes.com/mens-rockport-zaden-cvo-sneaker/17937313.html',
+            displayLink: 'www.shoes.com',
+            htmlSnippet: 'From <b>Virginia</b> Beach <b>Virginia</b>. Reviewed at. Rockport - BV. Have since bought 5 more pairs. Fit perfect look nice and pretty affordable. Highly recommend.'
+          },
+          {
+            htmlTitle: 'Men&#39;s Clarks Rendell Rise Ankle Boot | Shoes.com',
+            link: 'https://www.shoes.com/mens-clarks-rendell-rise-ankle-boot/17294581.html',
+            displayLink: 'www.shoes.com',
+            htmlSnippet: 'From Roane West <b>Virginia</b>. Verified Buyer Verified Buyer. I have worn these in good weather and snow and they feel warm and comfortable.'
+          },
+          {
+            htmlTitle: 'Men&#39;s Ariat Groundbreaker Wide Square Toe Boot | Shoes.com',
+            link: 'https://www.shoes.com/mens-ariat-groundbreaker-wide-square-toe-boot/14504867.html',
+            displayLink: 'www.shoes.com',
+            htmlSnippet: 'From Arvonia, <b>Virginia</b>. Verified Buyer Verified Reviewer. Reviewed at. Ariat - BV. Great product, as described! Quick shipping and great service!'
+          },
+          {
+            htmlTitle: 'Women&#39;s SoftWalk Sicily Ballet Flat | Shoes.com',
+            link: 'https://www.shoes.com/womens-softwalk-sicily-ballet-flat/16165989.html?pr_rd_page=2',
+            displayLink: 'www.shoes.com',
+            htmlSnippet: 'From West <b>Virginia</b>. Verified Buyer Verified Buyer. Reviewed at. SoftWalk. I have worn Softwalk lace-ups for several years, so when I ordered these flats I&nbsp;...'
+          },
+          {
+            htmlTitle: 'Women&#39;s Sperry Top-Sider Saltwater Nylon Quilted Duck Boot ...',
+            link: 'https://www.shoes.com/womens-sperry-top-sider-saltwater-nylon-quilted-duck-boot/18088767.html',
+            displayLink: 'www.shoes.com',
+            htmlSnippet: 'From <b>virginia</b> beach, <b>virginia</b>. Verified Buyer Verified Buyer. Reviewed at. Sperry - BV. bought these boots as my 3rd pair of sperry boots. my other 2 are&nbsp;...'
+          },
+          {
+            htmlTitle: 'Women&#39;s New Balance Beaya Slip On Sneaker | Shoes.com',
+            link: 'https://www.shoes.com/new-balance-beaya-slip-on-sneaker/898099',
+            displayLink: 'www.shoes.com',
+            htmlSnippet: 'From <b>Virginia</b>. Reviewed at. New Balance. One of the most comfortable sneaks I own. They are slip-ons so not really for working out, but great for walks and&nbsp;...'
+          },
+          {
+            htmlTitle: 'Infant Boys&#39; Rocky BearClaw 3D 3627 | Shoes.com',
+            link: 'https://www.shoes.com/infant-boys-rocky-bearclaw-3d-3627/P-675231.html',
+            displayLink: 'www.shoes.com',
+            htmlSnippet: 'From <b>Virginia</b>, United States. Verified Buyer Verified Buyer. Reviewed at. Rocky Boots - BV. I&#39;ve had 3 pair info the last 15 years. Never had any issues,&nbsp;...'
+          }
+        ],
+        appliedQueryFilters: [],
+        queryDurationMillis: 251,
+        facets: [],
+        source: 'GOOGLE_CSE'
+      }
+    ],
+    failedVerticals: [],
+    queryId: '01819229-1562-8e67-71bf-f4ae63b1f355',
+    searchIntents: [],
+    locationBias: {
+      latitude: 38.890396,
+      longitude: -77.084159,
+      locationDisplayName: 'Arlington, Virginia, United States',
+      accuracy: 'DEVICE'
+    }
+  }
+};

--- a/tests/acceptance/fixtures/responses/vertical/people/allRes25MileRadius.js
+++ b/tests/acceptance/fixtures/responses/vertical/people/allRes25MileRadius.js
@@ -1,0 +1,362 @@
+export const allRes25MileRadius = {
+  meta: {
+    uuid: '01819198-146a-eec1-3400-b5c5b98ffc22',
+    errors: []
+  },
+  response: {
+    businessId: 3350634,
+    queryId: '01819198-147e-ef59-84ce-6e95338e681c',
+    resultsCount: 3,
+    results: [
+      {
+        data: {
+          id: 'Employee-2116',
+          type: 'ce_person',
+          website: 'http://www.test.com',
+          address: {
+            line1: '7900 Westpark Drive',
+            city: 'Mclean',
+            region: 'VA',
+            postalCode: '22102',
+            countryCode: 'US'
+          },
+          associations: [
+            'Runners Association'
+          ],
+          description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Mollis nunc sed id semper risus. Commodo elit at imperdiet dui accumsan sit amet nulla facilisi. Scelerisque viverra mauris in aliquam. A erat nam at lectus. Egestas purus viverra accumsan in nisl nisi scelerisque. Habitant morbi tristique senectus et netus. Congue nisi vitae suscipit tellus mauris a diam maecenas sed.',
+          name: 'Amani Farooque',
+          cityCoordinate: {
+            latitude: 38.936519622802734,
+            longitude: -77.18428039550781
+          },
+          c_allstateLadyCTA: {
+            label: 'Learn More',
+            linkType: 'URL',
+            link: 'http://yext.com'
+          },
+          c_employeeCity: 'Tysons Corner',
+          c_employeeCountry: 'United States',
+          c_employeeDepartment: 'Consulting',
+          c_employeeRegion: 'Virginia',
+          c_employeeTitle: 'Associate Technical Project Manager',
+          c_oliverCta: {
+            url: 'https://www.yext.com/s/2287528/entity/edit2?entityIds=13411251',
+            icon: 'yext',
+            label: 'test cta'
+          },
+          c_startDate: '2017-09-18',
+          displayCoordinate: {
+            latitude: 38.924648,
+            longitude: -77.216859
+          },
+          emails: [
+            'afarooque@yext.com',
+            'af@yext.com',
+            'aplomb@yext.com'
+          ],
+          firstName: 'Amani',
+          geocodedCoordinate: {
+            latitude: 38.924654,
+            longitude: -77.216891
+          },
+          headshot: {
+            url: 'https://a.mktgcdn.com/p/bmc3W88h2mMRXk-wHQ7dB0Em4rR_dfia6OVrAK3LjYU/192x191.png',
+            width: 192,
+            height: 191,
+            sourceUrl: 'http://a.mktgcdn.com/p/bmc3W88h2mMRXk-wHQ7dB0Em4rR_dfia6OVrAK3LjYU/192x191.png'
+          },
+          languages: [
+            'German'
+          ],
+          lastName: 'Farooque',
+          mainPhone: '+18003332222',
+          routableCoordinate: {
+            latitude: 38.9242966,
+            longitude: -77.2177549
+          },
+          specialities: [
+            'Documentation',
+            'Coding'
+          ],
+          websiteUrl: {
+            url: 'http://www.test.com',
+            displayUrl: 'http://www.testdisplay.com',
+            preferDisplayUrl: true
+          },
+          yextDisplayCoordinate: {
+            latitude: 38.924648,
+            longitude: -77.216859
+          },
+          yextRoutableCoordinate: {
+            latitude: 38.9242966,
+            longitude: -77.2177549
+          },
+          uid: '18716057'
+        },
+        highlightedFields: {},
+        distance: 13123,
+        distanceFromFilter: 13123
+      },
+      {
+        data: {
+          id: 'Employee-2143',
+          type: 'ce_person',
+          address: {
+            line1: '7900 Westpark Drive',
+            city: 'Mclean',
+            region: 'VA',
+            postalCode: '22102',
+            countryCode: 'US'
+          },
+          description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Tristique senectus et netus et malesuada fames ac turpis. Porttitor eget dolor morbi non arcu risus quis. Tempor orci dapibus ultrices in iaculis. Viverra tellus in hac habitasse platea dictumst vestibulum rhoncus est. Eleifend donec pretium vulputate sapien nec. Ornare suspendisse sed nisi lacus sed viverra tellus in hac. Morbi tristique senectus et netus et malesuada. Vel pharetra vel turpis nunc eget lorem dolor sed viverra. Sapien nec sagittis aliquam malesuada.\n\nAt lectus urna duis convallis convallis tellus. Luctus venenatis lectus magna fringilla urna porttitor rhoncus. Blandit volutpat maecenas volutpat blandit aliquam etiam erat velit. Amet dictum sit amet justo donec enim diam vulputate ut. Ultrices in iaculis nunc sed augue lacus viverra. Feugiat sed lectus vestibulum mattis ullamcorper velit. Euismod quis viverra nibh cras pulvinar mattis nunc sed blandit. In hac habitasse platea dictumst quisque. In aliquam sem fringilla ut morbi tincidunt augue interdum velit. At erat pellentesque adipiscing commodo elit at.\n\nNunc aliquet bibendum enim facilisis gravida neque. Libero id faucibus nisl tincidunt eget nullam. Ullamcorper dignissim cras tincidunt lobortis. Condimentum id venenatis a condimentum. Sit amet dictum sit amet justo. Ac placerat vestibulum lectus mauris ultrices eros in. Cras sed felis eget velit aliquet sagittis id consectetur purus. Auctor urna nunc id cursus. Arcu non odio euismod lacinia at. Neque convallis a cras semper auctor neque vitae. Adipiscing elit pellentesque habitant morbi tristique. Commodo sed egestas egestas fringilla phasellus faucibus scelerisque eleifend. Scelerisque eu ultrices vitae auctor eu augue ut lectus. In vitae turpis massa sed elementum. Nibh sit amet commodo nulla facilisi nullam vehicula ipsum a. Vitae suscipit tellus mauris a diam maecenas sed enim. Volutpat blandit aliquam etiam erat velit scelerisque.',
+          name: 'Tom Meyer',
+          cityCoordinate: {
+            latitude: 38.936519622802734,
+            longitude: -77.18428039550781
+          },
+          c_allstateLadyCTA: {
+            label: 'Learn More',
+            linkType: 'URL',
+            link: 'http://yext.com'
+          },
+          c_employeeCity: 'Tysons Corner',
+          c_employeeCountry: 'United States',
+          c_employeeDepartment: 'Technology',
+          c_employeeRegion: 'Virginia',
+          c_employeeTitle: 'Software Engineer',
+          c_hierarchicalFacet: [
+            'Appliances',
+            'Appliances > Medium Appliances',
+            'Appliances > Medium Appliances > Cooking',
+            'Computer & Tablets',
+            'Computer & Tablets > Laptops'
+          ],
+          c_myRichTextField: '++Underlined stuff++  \n**Bold stuff**\n\n1. One\n2. Two\n3. *Three*',
+          c_popularity: '1.0',
+          c_startDate: '2017-09-05',
+          displayCoordinate: {
+            latitude: 38.924648,
+            longitude: -77.216859
+          },
+          emails: [
+            'tmeyer@yext.com'
+          ],
+          firstName: 'Tom',
+          geocodedCoordinate: {
+            latitude: 38.924654,
+            longitude: -77.216891
+          },
+          headshot: {
+            url: 'https://a.mktgcdn.com/p/cb9jR0A19ADuKc7ExlWmHaDchPW_61IR5TZ5G7NApjY/139x140.jpg',
+            width: 139,
+            height: 140,
+            sourceUrl: 'https://a.mktgcdn.com/p/cb9jR0A19ADuKc7ExlWmHaDchPW_61IR5TZ5G7NApjY/139x140.jpg'
+          },
+          lastName: 'Meyer',
+          routableCoordinate: {
+            latitude: 38.9242966,
+            longitude: -77.2177549
+          },
+          yextDisplayCoordinate: {
+            latitude: 38.924648,
+            longitude: -77.216859
+          },
+          yextRoutableCoordinate: {
+            latitude: 38.9242966,
+            longitude: -77.2177549
+          },
+          uid: '18716864'
+        },
+        highlightedFields: {},
+        distance: 13123,
+        distanceFromFilter: 13123
+      },
+      {
+        data: {
+          id: '4880570941877725281',
+          type: 'ce_person',
+          outdoorPoolCount: 5,
+          time: {
+            start: '2020-04-08T13:00',
+            end: '2020-04-15T14:00'
+          },
+          address: {
+            line1: '7900 Westpark Drive',
+            city: 'Mclean',
+            region: 'VA',
+            postalCode: '22102',
+            countryCode: 'US'
+          },
+          description: 'hai hai kazuma-desu the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team the cowboys are the best team',
+          name: 'Oliver Shi',
+          cityCoordinate: {
+            latitude: 38.936519622802734,
+            longitude: -77.18428039550781
+          },
+          c_allstateLadyCTA: {
+            label: 'Learn More',
+            linkType: 'URL',
+            link: 'http://yext.com'
+          },
+          c_hierarchicalFacet: [
+            'Appliances',
+            'Appliances > Medium Appliances',
+            'Appliances > Medium Appliances > Cooking',
+            'Appliances > Medium Appliances > Air Purification',
+            'Computer & Tablets',
+            'Computer & Tablets > Cables & Connectors',
+            'Computer & Tablets > Desktop',
+            'Computer & Tablets > Desktop > Refurbished Desktops',
+            'Computer & Tablets > Desktop > Refurbished Desktops > 1990s Desktops'
+          ],
+          c_myRichTextField: '++Underlined++  \n**Bolded**\n\n1. **One**\n2. *Two*\n3. Three\n\n\\<div\\>Dang\\</div\\>',
+          c_nestedBoy: {
+            waifus: {
+              anime: {
+                a: 'waifu',
+                b: 'koko'
+              },
+              games: {
+                c: 'waifu',
+                d: 'hi'
+              },
+              life: {
+                e: 'kaga',
+                f: 'baba'
+              }
+            },
+            husbandos: {
+              a: {
+                a: 'yaga',
+                b: 'haha'
+              },
+              b: {
+                c: 'lala',
+                d: 'kaka'
+              },
+              c: {
+                e: 'kaga',
+                f: 'lala'
+              }
+            }
+          },
+          c_nestedTextLists: [
+            {
+              textlist: [
+                'weeb',
+                'lord',
+                'poggers'
+              ],
+              struct: {
+                nested_list1: [
+                  'weeber',
+                  'weeb'
+                ],
+                nested_list2: [
+                  'weeb',
+                  'weweb weeb weeb',
+                  'haha ohaiyo',
+                  'weeber'
+                ]
+              }
+            }
+          ],
+          c_oliverCta: {
+            url: 'https://google.com',
+            icon: 'yext',
+            label: 'please update'
+          },
+          c_secondCTA: true,
+          c_startDate: '2019-08-05',
+          c_string1: 'stringy',
+          c_terminationDate: '2020-01-01',
+          displayCoordinate: {
+            latitude: 38.924648,
+            longitude: -77.216859
+          },
+          firstName: 'Oliver',
+          gender: 'Male',
+          geocodedCoordinate: {
+            latitude: 38.924654,
+            longitude: -77.216891
+          },
+          headshot: {
+            url: 'https://a.mktgcdn.com/p/3Obc6RedOylBSTOj_DOT8BHMwp6_-ltsE0lCrZS6PGc/1200x1200.jpg',
+            width: 1200,
+            height: 1200,
+            sourceUrl: 'https://a.mktgcdn.com/p/3Obc6RedOylBSTOj_DOT8BHMwp6_-ltsE0lCrZS6PGc/1200x1200.jpg',
+            thumbnails: [
+              {
+                url: 'https://a.mktgcdn.com/p/3Obc6RedOylBSTOj_DOT8BHMwp6_-ltsE0lCrZS6PGc/619x619.jpg',
+                width: 619,
+                height: 619
+              },
+              {
+                url: 'https://a.mktgcdn.com/p/3Obc6RedOylBSTOj_DOT8BHMwp6_-ltsE0lCrZS6PGc/450x450.jpg',
+                width: 450,
+                height: 450
+              },
+              {
+                url: 'https://a.mktgcdn.com/p/3Obc6RedOylBSTOj_DOT8BHMwp6_-ltsE0lCrZS6PGc/196x196.jpg',
+                width: 196,
+                height: 196
+              }
+            ]
+          },
+          keywords: [
+            'otaku',
+            'aKeyword',
+            'highlight me!'
+          ],
+          languages: [
+            'english',
+            'englangdo',
+            'chinese'
+          ],
+          lastName: 'Shi',
+          routableCoordinate: {
+            latitude: 38.9242966,
+            longitude: -77.2177549
+          },
+          yextDisplayCoordinate: {
+            latitude: 38.924648,
+            longitude: -77.216859
+          },
+          yextRoutableCoordinate: {
+            latitude: 38.9242966,
+            longitude: -77.2177549
+          },
+          uid: '18717130'
+        },
+        highlightedFields: {},
+        distance: 13123,
+        distanceFromFilter: 13123
+      }
+    ],
+    appliedQueryFilters: [
+      {
+        displayKey: 'Location',
+        displayValue: 'near me',
+        filter: {
+          'builtin.location': {
+            $near: {
+              lat: 38.8955,
+              lng: -77.0699,
+              radius: 40233.6
+            }
+          }
+        },
+        type: 'PLACE'
+      }
+    ],
+    facets: [],
+    source: 'KNOWLEDGE_MANAGER',
+    searchIntents: [],
+    locationBias: {
+      latitude: 38.890396,
+      longitude: -77.084159,
+      locationDisplayName: 'Arlington, Virginia, United States',
+      accuracy: 'DEVICE'
+    }
+  }
+};

--- a/tests/acceptance/fixtures/responses/vertical/people/allResOneStaticFilter.js
+++ b/tests/acceptance/fixtures/responses/vertical/people/allResOneStaticFilter.js
@@ -1,0 +1,157 @@
+export const allResOneStaticFilter = {
+  meta: {
+    uuid: '01819199-b4fc-0c61-2079-2e248f8bbc5d',
+    errors: []
+  },
+  response: {
+    businessId: 3350634,
+    queryId: '01819199-b50f-485c-e842-0889e263641c',
+    resultsCount: 2,
+    results: [
+      {
+        data: {
+          id: 'Employee-643',
+          type: 'ce_person',
+          address: {
+            line1: '63 Flushing Ave',
+            city: 'Brooklyn',
+            region: 'NY',
+            postalCode: '11205',
+            countryCode: 'US'
+          },
+          name: 'Liz Frailey',
+          cityCoordinate: {
+            latitude: 40.675234,
+            longitude: -73.971043
+          },
+          c_allstateLadyCTA: {
+            label: 'Learn More',
+            linkType: 'URL',
+            link: 'http://yext.com'
+          },
+          c_employeeCountry: 'United States',
+          c_employeeDepartment: 'Product',
+          c_employeeRegion: 'New York',
+          c_employeeTitle: 'Senior Manager, Product Management',
+          c_puppyPreference: [
+            'Marty'
+          ],
+          c_startDate: '2013-05-01',
+          displayCoordinate: {
+            latitude: 40.6984589,
+            longitude: -73.9777559
+          },
+          emails: [
+            'lfrailey@yext.com'
+          ],
+          firstName: 'Liz',
+          geocodedCoordinate: {
+            latitude: 40.6984715,
+            longitude: -73.9777647
+          },
+          headshot: {
+            url: 'https://a.mktgcdn.com/p/32qzB2fH1_yOd7n49ofmrjU-3zEWuAOGItxzYTa-WW4/162x216.jpg',
+            width: 162,
+            height: 216,
+            sourceUrl: 'http://a.mktgcdn.com/p/32qzB2fH1_yOd7n49ofmrjU-3zEWuAOGItxzYTa-WW4/162x216.jpg'
+          },
+          lastName: 'Frailey',
+          routableCoordinate: {
+            latitude: 40.6979771,
+            longitude: -73.9744204
+          },
+          yextDisplayCoordinate: {
+            latitude: 40.6984589,
+            longitude: -73.9777559
+          },
+          yextRoutableCoordinate: {
+            latitude: 40.6979771,
+            longitude: -73.9744204
+          },
+          uid: '18716051'
+        },
+        highlightedFields: {},
+        distance: 331613
+      },
+      {
+        data: {
+          id: 'Employee-1183',
+          type: 'ce_person',
+          address: {
+            line1: '156 5th Ave',
+            city: 'New York',
+            region: 'NY',
+            postalCode: '10010',
+            countryCode: 'US'
+          },
+          name: 'Tom Elliott',
+          cityCoordinate: {
+            latitude: 40.708601,
+            longitude: -73.876717
+          },
+          c_allstateLadyCTA: {
+            label: 'Learn More',
+            linkType: 'URL',
+            link: 'http://yext.com'
+          },
+          c_awards: [
+            'Presidents Club'
+          ],
+          c_employeeCountry: 'United States',
+          c_employeeDepartment: 'Technology',
+          c_employeeRegion: 'New York',
+          c_employeeTitle: 'Software Engineer',
+          c_popularity: '3.5',
+          c_puppyPreference: [
+            'Marty'
+          ],
+          c_startDate: '2015-06-29',
+          displayCoordinate: {
+            latitude: 40.740026,
+            longitude: -73.991289
+          },
+          emails: [
+            'telliott@yext.com'
+          ],
+          firstName: 'Tom',
+          geocodedCoordinate: {
+            latitude: 40.740026,
+            longitude: -73.991289
+          },
+          headshot: {
+            url: 'https://a.mktgcdn.com/p/P7EonnIfqYNjkejy567Vy9_a-ksKVRWvAIKOdt5Ha4k/160x213.jpg',
+            width: 160,
+            height: 213,
+            sourceUrl: 'http://a.mktgcdn.com/p/P7EonnIfqYNjkejy567Vy9_a-ksKVRWvAIKOdt5Ha4k/160x213.jpg'
+          },
+          lastName: 'Elliott',
+          routableCoordinate: {
+            latitude: 40.7398341,
+            longitude: -73.9908232
+          },
+          yextDisplayCoordinate: {
+            latitude: 40.740026,
+            longitude: -73.991289
+          },
+          yextRoutableCoordinate: {
+            latitude: 40.7398341,
+            longitude: -73.9908232
+          },
+          uid: '18718204'
+        },
+        highlightedFields: {},
+        distance: 333452
+      }
+    ],
+    appliedQueryFilters: [],
+    facets: [],
+    source: 'KNOWLEDGE_MANAGER',
+    searchIntents: [],
+    locationBias: {
+      latitude: 38.890396,
+      longitude: -77.084159,
+      locationDisplayName: 'Arlington, Virginia, United States',
+      accuracy: 'DEVICE'
+    }
+  }
+};

--- a/tests/acceptance/fixtures/responses/vertical/people/allResTwoStaticFilters.js
+++ b/tests/acceptance/fixtures/responses/vertical/people/allResTwoStaticFilters.js
@@ -1,0 +1,230 @@
+export const allResTwoStaticFilters = {
+  meta: {
+    uuid: '0181919a-3912-31bb-8167-79ae666bb00c',
+    errors: []
+  },
+  response: {
+    businessId: 3350634,
+    queryId: '0181919a-392e-3be2-f639-7af36b339e35',
+    resultsCount: 3,
+    results: [
+      {
+        data: {
+          id: 'Employee-643',
+          type: 'ce_person',
+          address: {
+            line1: '63 Flushing Ave',
+            city: 'Brooklyn',
+            region: 'NY',
+            postalCode: '11205',
+            countryCode: 'US'
+          },
+          name: 'Liz Frailey',
+          cityCoordinate: {
+            latitude: 40.675234,
+            longitude: -73.971043
+          },
+          c_allstateLadyCTA: {
+            label: 'Learn More',
+            linkType: 'URL',
+            link: 'http://yext.com'
+          },
+          c_employeeCountry: 'United States',
+          c_employeeDepartment: 'Product',
+          c_employeeRegion: 'New York',
+          c_employeeTitle: 'Senior Manager, Product Management',
+          c_puppyPreference: [
+            'Marty'
+          ],
+          c_startDate: '2013-05-01',
+          displayCoordinate: {
+            latitude: 40.6984589,
+            longitude: -73.9777559
+          },
+          emails: [
+            'lfrailey@yext.com'
+          ],
+          firstName: 'Liz',
+          geocodedCoordinate: {
+            latitude: 40.6984715,
+            longitude: -73.9777647
+          },
+          headshot: {
+            url: 'https://a.mktgcdn.com/p/32qzB2fH1_yOd7n49ofmrjU-3zEWuAOGItxzYTa-WW4/162x216.jpg',
+            width: 162,
+            height: 216,
+            sourceUrl: 'http://a.mktgcdn.com/p/32qzB2fH1_yOd7n49ofmrjU-3zEWuAOGItxzYTa-WW4/162x216.jpg'
+          },
+          lastName: 'Frailey',
+          routableCoordinate: {
+            latitude: 40.6979771,
+            longitude: -73.9744204
+          },
+          yextDisplayCoordinate: {
+            latitude: 40.6984589,
+            longitude: -73.9777559
+          },
+          yextRoutableCoordinate: {
+            latitude: 40.6979771,
+            longitude: -73.9744204
+          },
+          uid: '18716051'
+        },
+        highlightedFields: {},
+        distance: 331613
+      },
+      {
+        data: {
+          id: 'Employee-1183',
+          type: 'ce_person',
+          address: {
+            line1: '156 5th Ave',
+            city: 'New York',
+            region: 'NY',
+            postalCode: '10010',
+            countryCode: 'US'
+          },
+          name: 'Tom Elliott',
+          cityCoordinate: {
+            latitude: 40.708601,
+            longitude: -73.876717
+          },
+          c_allstateLadyCTA: {
+            label: 'Learn More',
+            linkType: 'URL',
+            link: 'http://yext.com'
+          },
+          c_awards: [
+            'Presidents Club'
+          ],
+          c_employeeCountry: 'United States',
+          c_employeeDepartment: 'Technology',
+          c_employeeRegion: 'New York',
+          c_employeeTitle: 'Software Engineer',
+          c_popularity: '3.5',
+          c_puppyPreference: [
+            'Marty'
+          ],
+          c_startDate: '2015-06-29',
+          displayCoordinate: {
+            latitude: 40.740026,
+            longitude: -73.991289
+          },
+          emails: [
+            'telliott@yext.com'
+          ],
+          firstName: 'Tom',
+          geocodedCoordinate: {
+            latitude: 40.740026,
+            longitude: -73.991289
+          },
+          headshot: {
+            url: 'https://a.mktgcdn.com/p/P7EonnIfqYNjkejy567Vy9_a-ksKVRWvAIKOdt5Ha4k/160x213.jpg',
+            width: 160,
+            height: 213,
+            sourceUrl: 'http://a.mktgcdn.com/p/P7EonnIfqYNjkejy567Vy9_a-ksKVRWvAIKOdt5Ha4k/160x213.jpg'
+          },
+          lastName: 'Elliott',
+          routableCoordinate: {
+            latitude: 40.7398341,
+            longitude: -73.9908232
+          },
+          yextDisplayCoordinate: {
+            latitude: 40.740026,
+            longitude: -73.991289
+          },
+          yextRoutableCoordinate: {
+            latitude: 40.7398341,
+            longitude: -73.9908232
+          },
+          uid: '18718204'
+        },
+        highlightedFields: {},
+        distance: 333452
+      },
+      {
+        data: {
+          id: 'Employee-1162',
+          type: 'ce_person',
+          address: {
+            line1: '1 Madison Ave',
+            city: 'NEW YORK',
+            region: 'NY',
+            postalCode: '10010',
+            countryCode: 'US'
+          },
+          name: 'Sophia Kleyman',
+          cityCoordinate: {
+            latitude: 40.708601,
+            longitude: -73.876717
+          },
+          c_allstateLadyCTA: {
+            label: 'Learn More',
+            linkType: 'URL',
+            link: 'http://yext.com'
+          },
+          c_employeeCity: 'Tysons Corner',
+          c_employeeCountry: 'United States',
+          c_employeeDepartment: 'Technology',
+          c_employeeRegion: 'Virginia',
+          c_employeeTitle: 'Software Engineer',
+          c_puppyPreference: [
+            'Frodo'
+          ],
+          c_startDate: '2015-06-02',
+          displayCoordinate: {
+            latitude: 40.7410895,
+            longitude: -73.9875092
+          },
+          emails: [
+            'skleyman@yext.com'
+          ],
+          firstName: 'Sophia',
+          geocodedCoordinate: {
+            latitude: 40.7410895,
+            longitude: -73.98750919999999
+          },
+          headshot: {
+            url: 'https://a.mktgcdn.com/p/WO_ADrscoMVTrJg9niQgwMORGrlrDzfhQzzku6GRORY/304x406.png',
+            width: 304,
+            height: 406,
+            sourceUrl: 'http://a.mktgcdn.com/p/WO_ADrscoMVTrJg9niQgwMORGrlrDzfhQzzku6GRORY/304x406.png',
+            thumbnails: [
+              {
+                url: 'https://a.mktgcdn.com/p/WO_ADrscoMVTrJg9niQgwMORGrlrDzfhQzzku6GRORY/196x261.png',
+                width: 196,
+                height: 261
+              }
+            ]
+          },
+          lastName: 'Kleyman',
+          routableCoordinate: {
+            latitude: 40.7412007,
+            longitude: -73.9878011
+          },
+          yextDisplayCoordinate: {
+            latitude: 40.7410895,
+            longitude: -73.9875092
+          },
+          yextRoutableCoordinate: {
+            latitude: 40.7412007,
+            longitude: -73.9878011
+          },
+          uid: '18718274'
+        },
+        highlightedFields: {},
+        distance: 333778
+      }
+    ],
+    appliedQueryFilters: [],
+    facets: [],
+    source: 'KNOWLEDGE_MANAGER',
+    searchIntents: [],
+    locationBias: {
+      latitude: 38.890396,
+      longitude: -77.084159,
+      locationDisplayName: 'Arlington, Virginia, United States',
+      accuracy: 'DEVICE'
+    }
+  }
+};

--- a/tests/acceptance/fixtures/responses/vertical/people/generatePeopleResponse.js
+++ b/tests/acceptance/fixtures/responses/vertical/people/generatePeopleResponse.js
@@ -6,10 +6,13 @@ import deepEquals from 'lodash.isequal';
 import { allResOneFacet } from './allResOneFacet';
 import { allResTwoFacets } from './allResTwoFacets';
 import { allResThreeFacets } from './allResThreeFacets';
+import { allRes25MileRadius } from './allRes25MileRadius';
+import { allResTwoStaticFilters } from './allResTwoStaticFilters';
+import { allResOneStaticFilter } from './allResOneStaticFilter';
 
-export function generatePeopleVerticalSearchResponse (input, offset, facetFilters) {
+export function generatePeopleVerticalSearchResponse (input, offset, filterParams) {
   if (input === 'all' || input === '') {
-    return getAllResponse(facetFilters);
+    return getAllResponse(filterParams);
   }
 
   const verticalSearchResponse = {
@@ -28,7 +31,29 @@ export function generatePeopleVerticalSearchResponse (input, offset, facetFilter
   return verticalSearchResponse;
 }
 
-function getAllResponse (facetFilters) {
+function getAllResponse (filterParams) {
+  const { facetFilters, locationRadius, filters } = filterParams;
+
+  if (locationRadius === 40233.6) {
+    return allRes25MileRadius;
+  } else if (locationRadius === 1609000) {
+    return allResNoFacets;
+  } else if (locationRadius) {
+    throw new Error('Unrecognized locationRadius when looking for fixture: ' + locationRadius);
+  }
+
+  if (deepEquals({ c_puppyPreference: { $eq: 'Marty' } }, filters)) {
+    return allResOneStaticFilter;
+  } else if (deepEquals({ $or: [{ c_puppyPreference: { $eq: 'Marty' } }, { c_puppyPreference: { $eq: 'Frodo' } }] }, filters)) {
+    return allResTwoStaticFilters;
+  } else if (filters?.['builtin.location']) {
+    // This case is for FilterSearch test - these tests don't care about the contents of the results,
+    // so they can use allResNoFacets
+    return allResNoFacets;
+  } else if (filters) {
+    throw new Error('Unrecognized static filters when looking for fixture: ' + JSON.stringify(filters));
+  }
+
   if (Object.keys(facetFilters).length === 0) {
     return allResNoFacets;
   }

--- a/tests/acceptance/fixtures/responses/vertical/search.js
+++ b/tests/acceptance/fixtures/responses/vertical/search.js
@@ -4,10 +4,10 @@ import { generateKMVerticalSearchResponse } from './KM/generateKMResponse';
 import { generatePeopleVerticalSearchResponse } from './people/generatePeopleResponse';
 import { basicResponseData } from './sharedData';
 
-function generateVerticalSearchResponse (verticalKey, input, offset, facetFilters) {
+function generateVerticalSearchResponse (verticalKey, input, offset, filterParams) {
   switch (verticalKey) {
     case 'people':
-      return generatePeopleVerticalSearchResponse(input, offset, facetFilters);
+      return generatePeopleVerticalSearchResponse(input, offset, filterParams);
     case 'KM':
       return generateKMVerticalSearchResponse(input, offset);
     default:
@@ -22,11 +22,18 @@ export const MockedVerticalSearchRequest = RequestMock()
   })
   .respond((req, res) => {
     const parsedUrl = new URL(req.url);
+
+    const filterParams = {
+      facetFilters: JSON.parse(parsedUrl.searchParams.get('facetFilters')),
+      locationRadius: parseFloat(parsedUrl.searchParams.get('locationRadius')) || null,
+      filters: JSON.parse(parsedUrl.searchParams.get('filters') || 'null')
+    };
+
     res.body = JSON.stringify(generateVerticalSearchResponse(
       parsedUrl.searchParams.get('verticalKey'),
       parsedUrl.searchParams.get('input'),
       parsedUrl.searchParams.get('offset'),
-      JSON.parse(parsedUrl.searchParams.get('facetFilters'))
+      filterParams
     ));
     res.headers = CORSHeaders;
     res.statusCode = 200;


### PR DESCRIPTION
With this PR the acceptance tests no longer run any real live api requests, other than
preflight requests. Dummy experienceKeys, apiKeys, and businessIds were added to the html test pages.
Also makes the indentation consistent on the html test pages. Before some pages were indenting by 4 spaces
instead of 2.

Also removed `skipJsErrors` from the testcafe config, which is more ideal.

J=SLAP-2171
TEST=auto

also ran acceptance tests locally