### PR TITLE
Add vertical autocomplete fixture

### DIFF
--- a/tests/acceptance/acceptancesuites/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuites/acceptancesuite.js
@@ -16,6 +16,7 @@ import {
   registerIE11NoCacheHook
 } from '../utils';
 import SearchRequestLogger from '../searchrequestlogger';
+import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 /**
  * This file contains acceptance tests for a universal search page.
@@ -55,7 +56,13 @@ test('Basic universal flow', async t => {
 });
 
 fixture`Vertical search page works as expected`
-  .requestHooks([SearchRequestLogger.createVerticalSearchLogger(), MockedVerticalSearchRequest])
+  .requestHooks(
+    [
+      SearchRequestLogger.createVerticalSearchLogger(),
+      MockedVerticalSearchRequest,
+      MockedVerticalAutoCompleteRequest
+    ]
+  )
   .beforeEach(async t => {
     await registerIE11NoCacheHook(t, VERTICAL_SEARCH_URL_REGEX);
   })

--- a/tests/acceptance/acceptancesuites/experiencelinkssuite.js
+++ b/tests/acceptance/acceptancesuites/experiencelinkssuite.js
@@ -3,9 +3,10 @@ import FacetsPage from '../pageobjects/facetspage';
 import { Selector } from 'testcafe';
 import { MockedVerticalSearchRequest } from '../fixtures/responses/vertical/search';
 import StorageKeys from '../../../src/core/storage/storagekeys';
+import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 fixture`Experience links work as expected`
-  .requestHooks(MockedVerticalSearchRequest)
+  .requestHooks([MockedVerticalSearchRequest, MockedVerticalAutoCompleteRequest])
   .page`${FACETS_PAGE}`;
 
 test('When you land, nav links should be clean', async t => {

--- a/tests/acceptance/acceptancesuites/facetsonload.js
+++ b/tests/acceptance/acceptancesuites/facetsonload.js
@@ -9,9 +9,10 @@ import {
 } from '../utils';
 import { getMostRecentQueryParamsFromLogger } from '../requestUtils';
 import { MockedVerticalSearchRequest } from '../fixtures/responses/vertical/search';
+import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 fixture`Facets on page load`
-  .requestHooks(MockedVerticalSearchRequest)
+  .requestHooks([MockedVerticalSearchRequest, MockedVerticalAutoCompleteRequest])
   .page`${FACETS_ON_LOAD_PAGE}`;
 
 test('Facets work with back/forward navigation and page refresh', async t => {

--- a/tests/acceptance/acceptancesuites/facetssuite.js
+++ b/tests/acceptance/acceptancesuites/facetssuite.js
@@ -8,9 +8,16 @@ import {
   registerIE11NoCacheHook
 } from '../utils';
 import SearchRequestLogger from '../searchrequestlogger';
+import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 fixture`Facets page`
-  .requestHooks([SearchRequestLogger.createVerticalSearchLogger(), MockedVerticalSearchRequest])
+  .requestHooks(
+    [
+      SearchRequestLogger.createVerticalSearchLogger(),
+      MockedVerticalSearchRequest,
+      MockedVerticalAutoCompleteRequest
+    ]
+  )
   .beforeEach(async t => {
     await registerIE11NoCacheHook(t, VERTICAL_SEARCH_URL_REGEX);
   })

--- a/tests/acceptance/acceptancesuites/filterboxsuite.js
+++ b/tests/acceptance/acceptancesuites/filterboxsuite.js
@@ -13,9 +13,10 @@ import {
   expectRequestDoesNotContainParam
 } from '../requestUtils';
 import SearchRequestLogger from '../searchrequestlogger';
+import { MockedVerticalAutoCompleteRequest } from '../fixtures/responses/vertical/autocomplete';
 
 fixture`FilterBox page`
-  .requestHooks(SearchRequestLogger.createVerticalSearchLogger())
+  .requestHooks([SearchRequestLogger.createVerticalSearchLogger(), MockedVerticalAutoCompleteRequest])
   .beforeEach(async t => {
     await registerIE11NoCacheHook(t, VERTICAL_SEARCH_URL_REGEX);
   })

--- a/tests/acceptance/fixtures/responses/vertical/autocomplete.js
+++ b/tests/acceptance/fixtures/responses/vertical/autocomplete.js
@@ -1,0 +1,28 @@
+import { RequestMock } from 'testcafe';
+import { CORSHeaders } from '../cors';
+import { meta } from './sharedData';
+
+function generateAutoCompleteResponse (prompt) {
+  return {
+    meta,
+    response: {
+      input: {
+        value: prompt,
+        queryIntents: []
+      },
+      results: []
+    }
+  };
+}
+
+export const MockedVerticalAutoCompleteRequest = RequestMock()
+  .onRequestTo(async request => {
+    const urlRegex = /^https:\/\/liveapi-cached.yext.com\/v2\/accounts\/me\/answers\/vertical\/autocomplete/;
+    return urlRegex.test(request.url) && request.method === 'get';
+  })
+  .respond((req, res) => {
+    const parsedUrl = new URL(req.url);
+    res.body = JSON.stringify(generateAutoCompleteResponse(parsedUrl.searchParams.get('input')));
+    res.headers = CORSHeaders;
+    res.statusCode = 200;
+  });


### PR DESCRIPTION
Add a vertical autocomplete fixture and update test suites where something is types in the search bar of a vertical page. Since no tests rely on selecting any vertical autocomplete options, the mocked response for any input returns no autocomplete options.

J=SLAP-2174
TEST=auto

Check that the fixture is used to mock the vertical autocomplete responses when expected and see that tests still pass.