### PR TITLE
deploy to gcp bucket

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -39,7 +39,6 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       directory: dev/${{ needs.call_format_branch_name.outputs.formatted_branch }}
-      cache-control: 'max-age=43200' #to test, will remove
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -39,6 +39,7 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       directory: dev/${{ needs.call_format_branch_name.outputs.formatted_branch }}
+      cache-control: 'max-age=43200' #to test, will remove
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -42,6 +42,7 @@ jobs:
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
 concurrency:
   group: ci-build-and-deploy-${{ github.ref }}-1

--- a/.github/workflows/build_and_deploy_hold.yml
+++ b/.github/workflows/build_and_deploy_hold.yml
@@ -42,6 +42,7 @@ jobs:
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
   call_deploy_major_version:
     needs: 
@@ -58,6 +59,7 @@ jobs:
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
   call_deploy_minor_version:
     needs: 
@@ -72,6 +74,7 @@ jobs:
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
 concurrency:
   group: ci-build-and-deploy-hold-${{ github.ref }}-1

--- a/.github/workflows/build_and_deploy_i18n.yml
+++ b/.github/workflows/build_and_deploy_i18n.yml
@@ -7,7 +7,6 @@ on:
       - hotfix/**
       - feature/**-i18n
       - release/**
-      - dev/deploy-gcp #to test
 
 jobs:
   call_build:

--- a/.github/workflows/build_and_deploy_i18n.yml
+++ b/.github/workflows/build_and_deploy_i18n.yml
@@ -7,6 +7,7 @@ on:
       - hotfix/**
       - feature/**-i18n
       - release/**
+      - dev/deploy-gcp #to test
 
 jobs:
   call_build:
@@ -48,6 +49,7 @@ jobs:
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
   call_deploy_canary:
     if: github.ref_name == 'develop'
@@ -63,6 +65,7 @@ jobs:
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
   call_deploy_canary_sha:
     if: github.ref_name == 'develop'
@@ -79,6 +82,7 @@ jobs:
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
 concurrency:
   group: ci-build-and-deploy-i18n-${{ github.ref }}-1

--- a/.github/workflows/build_and_deploy_search_bar.yml
+++ b/.github/workflows/build_and_deploy_search_bar.yml
@@ -39,41 +39,44 @@ jobs:
     uses: ./.github/workflows/deploy_hold.yml
     with:
       bucket: answers-search-bar
-      directory: ${{ needs.call_extract_versions.outputs.full_version }}
+      directory: dev/dev-deploy-gcp #to test
       cache-control: 'max-age=31536000'
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
-  call_deploy_major_version:
-    needs: 
-      - call_acceptance_search_bar
-      - call_extract_versions
-      - call_misc_tests
-      - call_should_deploy_major_version
-    if: ${{ needs.call_should_deploy_major_version.outputs.should_deploy_major_version }}
-    uses: ./.github/workflows/deploy_hold.yml
-    with:
-      bucket: answers-search-bar
-      directory: ${{ needs.call_extract_versions.outputs.major_version }}
-      cache-control: 'max-age=43200'
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  # call_deploy_major_version:
+  #   needs: 
+  #     - call_acceptance_search_bar
+  #     - call_extract_versions
+  #     - call_misc_tests
+  #     - call_should_deploy_major_version
+  #   if: ${{ needs.call_should_deploy_major_version.outputs.should_deploy_major_version }}
+  #   uses: ./.github/workflows/deploy_hold.yml
+  #   with:
+  #     bucket: answers-search-bar
+  #     directory: ${{ needs.call_extract_versions.outputs.major_version }}
+  #     cache-control: 'max-age=43200'
+  #   secrets:
+  #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #     GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
-  call_deploy_minor_version:
-    needs: 
-      - call_acceptance_search_bar
-      - call_extract_versions
-      - call_misc_tests
-    uses: ./.github/workflows/deploy_hold.yml
-    with:
-      bucket: answers-search-bar
-      directory: ${{ needs.call_extract_versions.outputs.minor_version }}
-      cache-control: 'max-age=43200'
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  # call_deploy_minor_version:
+  #   needs: 
+  #     - call_acceptance_search_bar
+  #     - call_extract_versions
+  #     - call_misc_tests
+  #   uses: ./.github/workflows/deploy_hold.yml
+  #   with:
+  #     bucket: answers-search-bar
+  #     directory: ${{ needs.call_extract_versions.outputs.minor_version }}
+  #     cache-control: 'max-age=43200'
+  #   secrets:
+  #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #     GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
 concurrency:
   group: ci-build-and-deploy-search-bars-${{ github.ref }}-1

--- a/.github/workflows/build_and_deploy_search_bar.yml
+++ b/.github/workflows/build_and_deploy_search_bar.yml
@@ -4,9 +4,8 @@ on:
   push:
     tags:
       - 'search-bar-v*'
-  branches:
+      branches:
       - dev/deploy-gcp #to test
-
 
 jobs:
   call_build:

--- a/.github/workflows/build_and_deploy_search_bar.yml
+++ b/.github/workflows/build_and_deploy_search_bar.yml
@@ -2,9 +2,9 @@ name: Build and deploy search bar
 
 on:
   push:
-    tags:
-      - 'search-bar-v*'
-      branches:
+    # tags:
+    #   - 'search-bar-v*'
+    branches:
       - dev/deploy-gcp #to test
 
 jobs:

--- a/.github/workflows/build_and_deploy_search_bar.yml
+++ b/.github/workflows/build_and_deploy_search_bar.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'search-bar-v*'
+  branches:
+      - dev/deploy-gcp #to test
+
 
 jobs:
   call_build:

--- a/.github/workflows/build_and_deploy_search_bar.yml
+++ b/.github/workflows/build_and_deploy_search_bar.yml
@@ -2,10 +2,8 @@ name: Build and deploy search bar
 
 on:
   push:
-    # tags:
-    #   - 'search-bar-v*'
-    branches:
-      - dev/deploy-gcp #to test
+    tags:
+      - 'search-bar-v*'
 
 jobs:
   call_build:
@@ -41,44 +39,44 @@ jobs:
     uses: ./.github/workflows/deploy_hold.yml
     with:
       bucket: answers-search-bar
-      directory: dev/dev-deploy-gcp #to test
+      directory: ${{ needs.call_extract_versions.outputs.full_version }}
       cache-control: 'max-age=31536000'
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
-  # call_deploy_major_version:
-  #   needs: 
-  #     - call_acceptance_search_bar
-  #     - call_extract_versions
-  #     - call_misc_tests
-  #     - call_should_deploy_major_version
-  #   if: ${{ needs.call_should_deploy_major_version.outputs.should_deploy_major_version }}
-  #   uses: ./.github/workflows/deploy_hold.yml
-  #   with:
-  #     bucket: answers-search-bar
-  #     directory: ${{ needs.call_extract_versions.outputs.major_version }}
-  #     cache-control: 'max-age=43200'
-  #   secrets:
-  #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #     GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+  call_deploy_major_version:
+    needs: 
+      - call_acceptance_search_bar
+      - call_extract_versions
+      - call_misc_tests
+      - call_should_deploy_major_version
+    if: ${{ needs.call_should_deploy_major_version.outputs.should_deploy_major_version }}
+    uses: ./.github/workflows/deploy_hold.yml
+    with:
+      bucket: answers-search-bar
+      directory: ${{ needs.call_extract_versions.outputs.major_version }}
+      cache-control: 'max-age=43200'
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
-  # call_deploy_minor_version:
-  #   needs: 
-  #     - call_acceptance_search_bar
-  #     - call_extract_versions
-  #     - call_misc_tests
-  #   uses: ./.github/workflows/deploy_hold.yml
-  #   with:
-  #     bucket: answers-search-bar
-  #     directory: ${{ needs.call_extract_versions.outputs.minor_version }}
-  #     cache-control: 'max-age=43200'
-  #   secrets:
-  #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #     GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+  call_deploy_minor_version:
+    needs: 
+      - call_acceptance_search_bar
+      - call_extract_versions
+      - call_misc_tests
+    uses: ./.github/workflows/deploy_hold.yml
+    with:
+      bucket: answers-search-bar
+      directory: ${{ needs.call_extract_versions.outputs.minor_version }}
+      cache-control: 'max-age=43200'
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
 concurrency:
   group: ci-build-and-deploy-search-bars-${{ github.ref }}-1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,4 +66,4 @@ jobs:
           destination: assets-eu.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }}
           predefinedAcl: publicRead
           headers: |-
-            Cache-Control:${{ inputs.cache-control }}
+            cache-control: ${{ inputs.cache-control }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,8 @@ on:
         required: true
       AWS_SECRET_ACCESS_KEY:
         required: true
+      GCP_SA_KEY:
+        required: true
 
 jobs:
   deploy-aws:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy assets to AWS S3
+name: Deploy assets to AWS S3 and GCP Cloud Storage
 
 on:
   workflow_call:
@@ -23,27 +23,27 @@ on:
         required: true
 
 jobs:
-  deploy-aws:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Download build-output artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: build-output
-          path: dist/
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      - name: Deploy to S3
-        run: |
-          aws s3 cp ./dist/ s3://assets.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }} \
-          --acl public-read \
-          --recursive \
-          --cache-control ${{ inputs.cache-control }}
+  # deploy-aws:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Download build-output artifact
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: build-output
+  #         path: dist/
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-east-1
+  #     - name: Deploy to S3
+  #       run: |
+  #         aws s3 cp ./dist/ s3://assets.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }} \
+  #         --acl public-read \
+  #         --recursive \
+  #         --cache-control ${{ inputs.cache-control }}
 
   deploy-gcp:
     runs-on: ubuntu-latest
@@ -65,6 +65,5 @@ jobs:
           path: dist/
           parent: false
           destination: assets-eu.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }}
-          # predefinedAcl: publicRead
           headers: |-
             cache-control: ${{ inputs.cache-control }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,9 +21,8 @@ on:
         required: true
 
 jobs:
-  deploy:
+  deploy-aws:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Download build-output artifact
@@ -43,3 +42,26 @@ jobs:
           --acl public-read \
           --recursive \
           --cache-control ${{ inputs.cache-control }}
+
+  deploy-gcp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download build-output artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: build-output
+          path: dist/
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+      - name: Deploy to GCP Bucket
+        uses: google-github-actions/upload-cloud-storage@v0
+        with:
+          path: dist/
+          destination: assets-eu.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }}
+          predefinedAcl: publicRead
+          headers: |-
+            Cache-Control:${{ inputs.cache-control }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v0
         with:
           path: dist/
+          parent: false
           destination: assets-eu.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }}
           # predefinedAcl: publicRead
           headers: |-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,6 @@ jobs:
         with:
           path: dist/
           destination: assets-eu.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }}
-          predefinedAcl: publicRead
+          # predefinedAcl: publicRead
           headers: |-
             cache-control: ${{ inputs.cache-control }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,27 +23,27 @@ on:
         required: true
 
 jobs:
-  # deploy-aws:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Download build-output artifact
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: build-output
-  #         path: dist/
-  #     - name: Configure AWS Credentials
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-east-1
-  #     - name: Deploy to S3
-  #       run: |
-  #         aws s3 cp ./dist/ s3://assets.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }} \
-  #         --acl public-read \
-  #         --recursive \
-  #         --cache-control ${{ inputs.cache-control }}
+  deploy-aws:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download build-output artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: build-output
+          path: dist/
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Deploy to S3
+        run: |
+          aws s3 cp ./dist/ s3://assets.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }} \
+          --acl public-read \
+          --recursive \
+          --cache-control ${{ inputs.cache-control }}
 
   deploy-gcp:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_hold.yml
+++ b/.github/workflows/deploy_hold.yml
@@ -1,4 +1,4 @@
-name: Deploy assets to AWS S3 with hold state setup in github's production environment
+name: Deploy assets to AWS S3 and GCP Cloud Storage with hold state setup in github's production environment
 
 on:
   workflow_call:
@@ -19,9 +19,11 @@ on:
         required: true
       AWS_SECRET_ACCESS_KEY:
         required: true
+      GCP_SA_KEY:
+        required: true
 
 jobs:
-  deploy:
+  deploy-aws:
     runs-on: ubuntu-latest
     environment: production # sets in github repo with reviewer requirement protection rule
     steps:
@@ -43,3 +45,27 @@ jobs:
           --acl public-read \
           --recursive \
           --cache-control ${{ inputs.cache-control }}
+
+  deploy-gcp:
+    runs-on: ubuntu-latest
+    environment: production # sets in github repo with reviewer requirement protection rule
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download build-output artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: build-output
+          path: dist/
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+      - name: Deploy to GCP Bucket
+        uses: google-github-actions/upload-cloud-storage@v0
+        with:
+          path: dist/
+          parent: false
+          destination: assets-eu.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }}
+          headers: |-
+            cache-control: ${{ inputs.cache-control }}

--- a/.github/workflows/deploy_hold.yml
+++ b/.github/workflows/deploy_hold.yml
@@ -23,28 +23,28 @@ on:
         required: true
 
 jobs:
-  # deploy-aws:
-  #   runs-on: ubuntu-latest
-  #   environment: production # sets in github repo with reviewer requirement protection rule
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Download build-output artifact
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: build-output
-  #         path: dist/
-  #     - name: Configure AWS Credentials
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-east-1
-  #     - name: Deploy to S3
-  #       run: |
-  #         aws s3 cp ./dist/ s3://assets.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }} \
-  #         --acl public-read \
-  #         --recursive \
-  #         --cache-control ${{ inputs.cache-control }}
+  deploy-aws:
+    runs-on: ubuntu-latest
+    environment: production # sets in github repo with reviewer requirement protection rule
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download build-output artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: build-output
+          path: dist/
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Deploy to S3
+        run: |
+          aws s3 cp ./dist/ s3://assets.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }} \
+          --acl public-read \
+          --recursive \
+          --cache-control ${{ inputs.cache-control }}
 
   deploy-gcp:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_hold.yml
+++ b/.github/workflows/deploy_hold.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: production # sets in github repo with reiewer requirement protection rule
+    environment: production # sets in github repo with reviewer requirement protection rule
     steps:
       - uses: actions/checkout@v2
       - name: Download build-output artifact

--- a/.github/workflows/deploy_hold.yml
+++ b/.github/workflows/deploy_hold.yml
@@ -23,28 +23,28 @@ on:
         required: true
 
 jobs:
-  deploy-aws:
-    runs-on: ubuntu-latest
-    environment: production # sets in github repo with reviewer requirement protection rule
-    steps:
-      - uses: actions/checkout@v2
-      - name: Download build-output artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: build-output
-          path: dist/
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      - name: Deploy to S3
-        run: |
-          aws s3 cp ./dist/ s3://assets.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }} \
-          --acl public-read \
-          --recursive \
-          --cache-control ${{ inputs.cache-control }}
+  # deploy-aws:
+  #   runs-on: ubuntu-latest
+  #   environment: production # sets in github repo with reviewer requirement protection rule
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Download build-output artifact
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: build-output
+  #         path: dist/
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-east-1
+  #     - name: Deploy to S3
+  #       run: |
+  #         aws s3 cp ./dist/ s3://assets.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }} \
+  #         --acl public-read \
+  #         --recursive \
+  #         --cache-control ${{ inputs.cache-control }}
 
   deploy-gcp:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update all deploy workflow to upload to GCP EU bucket, in addition to the AWS S3 bucket. A GCP service account key is added to the repo with upload permission for answers* objects to the gcp bucket.

publicRead access is granted through IAM configuration in terraform file by infra. Cache control is set through the gcp github action.

Note: we still can NOT use environment and reusable workflow together so I can't reuse deploy workflow directly. there would be some duplication between deploy.yml workflow and deploy_hold.yml workflow for now. (for more context from [previous pr](https://github.com/yext/answers-search-ui/pull/1661)). Also tried in github IDE:
<img width="500" alt="Screen Shot 2022-08-16 at 3 22 10 PM" src="https://user-images.githubusercontent.com/36055303/184964405-554538a5-d03a-4d17-991e-51d9991d9d2d.png">

some deployment note "error" within this pr is because I cancelled them to run with new changes

J=SLAP-2144
TEST=manual

- see that files deploy.yml workflow got deployed successfully to GCP bucket in answers/ folder. See that they are in GCP cloud storage site, and that I can access them through the [URL](https://storage.googleapis.com/assets-eu.sitescdn.net/answers/dev/dev-deploy-gcp/answers-modern.js).
- see that cache control is properly set if it's provided to the deploy workflow
- see that i18n files got uploaded successfully
- see that files get upload to answers-search-bar successfully. See that they are in GCP cloud storage site, and that I can access them through the provided URL.
- see that on hold functionality works for gcp deployment too