### PR TITLE
switch throw to console error in analytics reporter

### DIFF
--- a/src/core/analytics/analyticsreporter.js
+++ b/src/core/analytics/analyticsreporter.js
@@ -1,7 +1,6 @@
 /** @module AnalyticsReporter */
 
 import AnalyticsEvent from './analyticsevent';
-import { AnswersAnalyticsError } from '../errors/errors';
 import { PRODUCTION } from '../constants';
 import HttpRequester from '../http/httprequester';
 import { getAnalyticsUrl } from '../utils/urlutils';

--- a/src/core/analytics/analyticsreporter.js
+++ b/src/core/analytics/analyticsreporter.js
@@ -109,11 +109,13 @@ export default class AnalyticsReporter {
       ytag('optin', true);
       cookieData = ytag('yfpc', null);
     } else if (this._conversionTrackingEnabled) {
-      throw new AnswersAnalyticsError('Tried to enable conversion tracking without including ytag');
+      console.error('Tried to enable conversion tracking without including ytag');
+      return false;
     }
 
     if (!(event instanceof AnalyticsEvent)) {
-      throw new AnswersAnalyticsError('Tried to send invalid analytics event', event);
+      console.error('Tried to send invalid analytics event', event);
+      return false;
     }
 
     if (includeQueryId) {

--- a/tests/acceptance/acceptancesuites/facetsonload.js
+++ b/tests/acceptance/acceptancesuites/facetsonload.js
@@ -69,7 +69,6 @@ test('Facets work with back/forward navigation and page refresh', async t => {
       { c_employeeDepartment: { $eq: 'Client Delivery [SO]' } },
       { c_employeeDepartment: { $eq: 'Technology' } }
     ],
-    c_popularity: [],
     languages: [],
     specialities: []
   };

--- a/tests/acceptance/acceptancesuites/facetsonload.js
+++ b/tests/acceptance/acceptancesuites/facetsonload.js
@@ -39,9 +39,9 @@ test('Facets work with back/forward navigation and page refresh', async t => {
   await options.toggleOption('Client Delivery');
   currentFacets = await getFacetsFromRequest();
   const state1 = {
+    c_cellPhone: [],
     c_puppyPreference: [],
     c_employeeDepartment: [{ c_employeeDepartment: { $eq: 'Client Delivery [SO]' } }],
-    c_popularity: [],
     languages: [],
     specialities: []
   };

--- a/tests/core/analytics/analyticsreporter.js
+++ b/tests/core/analytics/analyticsreporter.js
@@ -21,7 +21,7 @@ describe('reporting events', () => {
   });
 
   it('throws an error if given a non-AnalyticsEvent', () => {
-    const consoleErrorSpy = jest.spyOn(global.console, 'error').mockImplementation();
+    const consoleErrorSpy = jest.spyOn(console, 'error');
     expect(analyticsReporter.report({ event_type: 'fake event' })).toBeFalsy();
     expect(consoleErrorSpy).toHaveBeenLastCalledWith(
       'Tried to send invalid analytics event',
@@ -72,7 +72,7 @@ describe('reporting events', () => {
 
   it('throws error if opted in and ytag missing', () => {
     analyticsReporter.setConversionTrackingEnabled(true);
-    const consoleErrorSpy = jest.spyOn(global.console, 'error').mockImplementation();
+    const consoleErrorSpy = jest.spyOn(console, 'error');
     expect(analyticsReporter.report(new AnalyticsEvent('thumbs_up'))).toBeFalsy();
     expect(consoleErrorSpy).toHaveBeenLastCalledWith('Tried to enable conversion tracking without including ytag');
   });

--- a/tests/core/analytics/analyticsreporter.js
+++ b/tests/core/analytics/analyticsreporter.js
@@ -22,9 +22,12 @@ describe('reporting events', () => {
   });
 
   it('throws an error if given a non-AnalyticsEvent', () => {
-    expect(() => {
-      analyticsReporter.report({ event_type: 'fake event' });
-    }).toThrow(AnswersAnalyticsError);
+    const consoleErrorSpy = jest.spyOn(global.console, 'error').mockImplementation();
+    expect(analyticsReporter.report({ event_type: 'fake event' })).toBeFalsy();
+    expect(consoleErrorSpy).toHaveBeenLastCalledWith(
+      'Tried to send invalid analytics event',
+      { event_type: 'fake event' }
+    );
   });
 
   it('sends the event via beacon in the "data" property', () => {
@@ -70,9 +73,9 @@ describe('reporting events', () => {
 
   it('throws error if opted in and ytag missing', () => {
     analyticsReporter.setConversionTrackingEnabled(true);
-    expect(() => {
-      analyticsReporter.report(new AnalyticsEvent('thumbs_up'));
-    }).toThrow(AnswersAnalyticsError);
+    const consoleErrorSpy = jest.spyOn(global.console, 'error').mockImplementation();
+    expect(analyticsReporter.report(new AnalyticsEvent('thumbs_up'))).toBeFalsy();
+    expect(consoleErrorSpy).toHaveBeenLastCalledWith('Tried to enable conversion tracking without including ytag');
   });
 
   it('includes cookies if opted in and ytag present', () => {

--- a/tests/core/analytics/analyticsreporter.js
+++ b/tests/core/analytics/analyticsreporter.js
@@ -70,7 +70,7 @@ describe('reporting events', () => {
       expect.anything());
   });
 
-  it('provide a console error if opted in and ytag missing', () => {
+  it('provides a console error if opted in and ytag missing', () => {
     analyticsReporter.setConversionTrackingEnabled(true);
     const consoleErrorSpy = jest.spyOn(console, 'error');
     expect(analyticsReporter.report(new AnalyticsEvent('thumbs_up'))).toBeFalsy();

--- a/tests/core/analytics/analyticsreporter.js
+++ b/tests/core/analytics/analyticsreporter.js
@@ -20,7 +20,7 @@ describe('reporting events', () => {
     analyticsReporter = new AnalyticsReporter('abc123', null, '213412', true);
   });
 
-  it('throws an error if given a non-AnalyticsEvent', () => {
+  it('provides a console error if given a non-AnalyticsEvent', () => {
     const consoleErrorSpy = jest.spyOn(console, 'error');
     expect(analyticsReporter.report({ event_type: 'fake event' })).toBeFalsy();
     expect(consoleErrorSpy).toHaveBeenLastCalledWith(
@@ -70,7 +70,7 @@ describe('reporting events', () => {
       expect.anything());
   });
 
-  it('throws error if opted in and ytag missing', () => {
+  it('provide a console error if opted in and ytag missing', () => {
     analyticsReporter.setConversionTrackingEnabled(true);
     const consoleErrorSpy = jest.spyOn(console, 'error');
     expect(analyticsReporter.report(new AnalyticsEvent('thumbs_up'))).toBeFalsy();

--- a/tests/core/analytics/analyticsreporter.js
+++ b/tests/core/analytics/analyticsreporter.js
@@ -1,6 +1,5 @@
 import AnalyticsReporter from '../../../src/core/analytics/analyticsreporter';
 import HttpRequester from '../../../src/core/http/httprequester';
-import { AnswersAnalyticsError } from '../../../src/core/errors/errors';
 import AnalyticsEvent from '../../../src/core/analytics/analyticsevent';
 import { getAnalyticsUrl } from '../../../src/core/utils/urlutils';
 import { PRODUCTION } from '../../../src/core/constants';

--- a/tests/core/analytics/analyticsreporter.js
+++ b/tests/core/analytics/analyticsreporter.js
@@ -20,7 +20,7 @@ describe('reporting events', () => {
     analyticsReporter = new AnalyticsReporter('abc123', null, '213412', true);
   });
 
-  it('provides a console error if given a non-AnalyticsEvent', () => {
+  it('logs a console error if given a non-AnalyticsEvent', () => {
     const consoleErrorSpy = jest.spyOn(console, 'error');
     expect(analyticsReporter.report({ event_type: 'fake event' })).toBeFalsy();
     expect(consoleErrorSpy).toHaveBeenLastCalledWith(
@@ -70,7 +70,7 @@ describe('reporting events', () => {
       expect.anything());
   });
 
-  it('provides a console error if opted in and ytag missing', () => {
+  it('logs a console error if opted in and ytag missing', () => {
     analyticsReporter.setConversionTrackingEnabled(true);
     const consoleErrorSpy = jest.spyOn(console, 'error');
     expect(analyticsReporter.report(new AnalyticsEvent('thumbs_up'))).toBeFalsy();


### PR DESCRIPTION
Throw error from not having `ytag` script tag for conversion tracking opt in would prevent a search fired on load. This is an aggressive behavior as analytics shouldn't affect search behavior. This pr updated the two throw error into console error instead.

TEST=manual

Added `ANSWERS.setConversionsOptIn(true);` to a local index page with Answers setup. see that the previously uncaught throw error is now a console error and a search on load is no longer blocked.

<img width="1782" alt="Screen Shot 2022-08-30 at 5 06 28 PM" src="https://user-images.githubusercontent.com/36055303/187543204-d6acca4d-9cbc-47db-a51d-2ca88b36aa34.png">
