### PR TITLE
Update rtf-converter to v1.7.1

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -1,7 +1,4 @@
-This file was generated with the generate-license-file npm package!
-https://www.npmjs.com/package/generate-license-file
-
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - @babel/code-frame@7.16.7
  - @babel/helper-validator-identifier@7.16.7
@@ -35,7 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - @gulp-sourcemaps/identity-map@1.0.2
  - @gulp-sourcemaps/map-sources@1.0.0
@@ -66,7 +63,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/geojson-rewind@0.5.1
 
@@ -88,7 +85,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/geojson-types@1.0.2
 
@@ -118,7 +115,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/jsonlint-lines-primitives@2.0.2
 
@@ -133,7 +130,7 @@ This fork is used by Mapbox GL JS, specifically for providing helpful error mess
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/mapbox-gl-language@0.10.1
 
@@ -171,7 +168,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/mapbox-gl-supported@1.5.0
 
@@ -209,7 +206,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/point-geometry@0.1.0
 
@@ -231,7 +228,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/tiny-sdf@1.2.5
 
@@ -247,7 +244,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/unitbezier@0.0.0
 
@@ -279,7 +276,7 @@ Initialize a new bezier curve given the points
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/vector-tile@1.3.1
 
@@ -316,7 +313,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @mapbox/whoots-js@3.1.0
 
@@ -340,7 +337,7 @@ THIS SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - @nodelib/fs.scandir@2.1.5
  - @nodelib/fs.stat@2.0.5
@@ -373,7 +370,7 @@ SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - @types/minimist@1.2.2
  - @types/normalize-package-data@2.4.1
@@ -404,7 +401,7 @@ MIT License
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @types/parse-json@4.0.0
 
@@ -434,7 +431,7 @@ MIT License
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @yext/answers-core@1.6.0
 
@@ -478,7 +475,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @yext/answers-storage@1.1.1
 
@@ -516,9 +513,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
- - @yext/rtf-converter@1.7.0
+ - @yext/rtf-converter@1.7.1
 
 This package contains the following license and notice below:
 
@@ -532,7 +529,7 @@ CDN
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - acorn@5.7.4
 
@@ -560,7 +557,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - ajv@8.11.0
 
@@ -590,7 +587,7 @@ SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - align-text@0.1.4
  - right-align@0.1.3
@@ -622,7 +619,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - align-text@1.0.2
 
@@ -652,7 +649,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - ansi-regex@5.0.1
  - ansi-styles@3.2.1
@@ -710,7 +707,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - any@1.0.0
  - longest@1.0.1
@@ -742,7 +739,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - argparse@2.0.1
 
@@ -1005,7 +1002,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - arrify@1.0.1
  - decamelize@1.2.0
@@ -1042,7 +1039,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - astral-regex@2.0.0
  - dir-glob@3.0.1
@@ -1061,7 +1058,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - atob@2.1.2
 
@@ -1300,7 +1297,7 @@ SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - balanced-match@1.0.2
  - balanced-match@2.0.0
@@ -1331,7 +1328,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - bowser@2.11.0
 
@@ -1379,7 +1376,7 @@ Original Author, when distributed with the Software.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - brace-expansion@1.1.11
 
@@ -1409,7 +1406,7 @@ SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - braces@3.0.2
  - get-value@3.0.1
@@ -1441,7 +1438,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - center-align@1.0.1
 
@@ -1471,7 +1468,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - color-convert@1.9.3
  - color-convert@2.0.1
@@ -1501,7 +1498,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - color-name@1.1.3
  - color-name@1.1.4
@@ -1519,7 +1516,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - colord@2.9.2
 
@@ -1549,7 +1546,7 @@ SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - concat-map@0.0.1
  - minimist@1.2.6
@@ -1578,7 +1575,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - convert-source-map@1.8.0
 
@@ -1610,7 +1607,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - core-js-pure@3.22.5
 
@@ -1638,7 +1635,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - core-util-is@1.0.3
 
@@ -1666,7 +1663,7 @@ IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - cosmiconfig@7.0.1
 
@@ -1696,7 +1693,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - cross-fetch@3.1.5
 
@@ -1726,7 +1723,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - css-functions-list@3.0.1
 
@@ -1753,7 +1750,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - css-vars-ponyfill@2.4.7
  - get-css-data@2.1.0
@@ -1784,7 +1781,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - css@2.2.4
 
@@ -1802,7 +1799,7 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - csscolorparser@1.0.3
 
@@ -1856,7 +1853,7 @@ IN THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - cssesc@3.0.0
  - emoji-regex@8.0.0
@@ -1888,7 +1885,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - d@1.0.1
  - es6-symbol@3.1.3
@@ -1913,7 +1910,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - debug-fabulous@1.1.0
 
@@ -1943,7 +1940,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - debug@3.2.7
 
@@ -1970,7 +1967,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - debug@4.3.4
 
@@ -1998,7 +1995,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - decamelize-keys@1.1.0
 
@@ -2028,7 +2025,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - decode-uri-component@0.2.0
 
@@ -2058,7 +2055,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - earcut@2.2.3
 
@@ -2082,7 +2079,7 @@ THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - encoding@0.1.13
 
@@ -2107,7 +2104,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - entities@2.1.0
 
@@ -2127,7 +2124,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - error-ex@1.3.2
  - is-arrayish@0.2.1
@@ -2158,7 +2155,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - es5-ext@0.10.61
 
@@ -2182,7 +2179,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - es6-iterator@2.0.3
 
@@ -2212,7 +2209,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - es6-object-assign@1.1.0
 
@@ -2243,7 +2240,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - es6-weak-map@2.0.3
  - timers-ext@0.1.7
@@ -2268,7 +2265,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - event-emitter@0.3.5
 
@@ -2296,7 +2293,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - ext@1.6.0
 
@@ -2320,7 +2317,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - fast-deep-equal@3.1.3
  - json-schema-traverse@1.0.0
@@ -2351,7 +2348,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - fastest-levenshtein@1.0.12
 
@@ -2381,7 +2378,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - fastq@1.13.0
 
@@ -2403,7 +2400,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - file-entry-cache@6.0.1
  - flat-cache@3.0.4
@@ -2434,7 +2431,7 @@ SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - fill-range@7.0.1
  - is-number@7.0.0
@@ -2466,7 +2463,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - flatted@3.2.5
 
@@ -2490,7 +2487,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - for-in@1.0.2
  - kind-of@3.2.2
@@ -2524,7 +2521,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - for-own@0.1.5
 
@@ -2554,7 +2551,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - fs.realpath@1.0.0
 
@@ -2606,7 +2603,7 @@ the licensed code:
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - function-bind@1.1.1
 
@@ -2634,7 +2631,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - geojson-vt@3.2.1
 
@@ -2658,7 +2655,7 @@ THIS SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - get-stdin@8.0.0
  - get-stream@6.0.1
@@ -2682,7 +2679,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - gl-matrix@3.4.3
 
@@ -2710,7 +2707,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - glob-parent@5.1.2
 
@@ -2734,7 +2731,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - glob@7.2.0
 
@@ -2764,7 +2761,7 @@ https://creativecommons.org/licenses/by-sa/4.0/
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - global-modules@2.0.0
  - global-prefix@3.0.0
@@ -2797,7 +2794,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - globjoin@0.1.4
 
@@ -2827,7 +2824,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - graceful-fs@4.2.10
 
@@ -2851,7 +2848,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - grid-index@1.1.0
 
@@ -2873,7 +2870,7 @@ THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - gulp-sourcemaps@2.6.5
 
@@ -2897,7 +2894,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - handlebars@4.7.7
 
@@ -2925,7 +2922,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - has@1.0.3
 
@@ -2956,7 +2953,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - helper-slugify@0.2.0
 
@@ -2986,7 +2983,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - hosted-git-info@2.8.9
  - hosted-git-info@4.1.0
@@ -3009,7 +3006,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - iconv-lite@0.6.3
 
@@ -3038,7 +3035,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - ieee754@1.2.1
 
@@ -3058,7 +3055,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - ignore@5.2.0
 
@@ -3088,7 +3085,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - imurmurhash@0.1.4
 
@@ -3219,7 +3216,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - inflight@1.0.6
 
@@ -3243,7 +3240,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - inherits@2.0.4
 
@@ -3267,7 +3264,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - ini@1.3.8
  - isexe@2.0.0
@@ -3301,7 +3298,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - is-buffer@1.1.6
  - safe-buffer@5.1.2
@@ -3332,7 +3329,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - is-core-module@2.9.0
 
@@ -3361,7 +3358,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - is-extglob@2.1.1
 
@@ -3391,7 +3388,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - is-glob@4.0.3
  - is-plain-object@5.0.0
@@ -3424,7 +3421,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - is-promise@2.2.2
 
@@ -3452,7 +3449,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - isarray@1.0.0
 
@@ -3520,7 +3517,7 @@ SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - isobject@2.1.0
  - repeat-string@1.6.1
@@ -3551,7 +3548,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - isobject@3.0.1
 
@@ -3581,7 +3578,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - js-levenshtein@1.1.6
 
@@ -3611,7 +3608,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - js-tokens@4.0.0
 
@@ -3641,7 +3638,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - json-parse-even-better-errors@2.3.1
 
@@ -3675,7 +3672,7 @@ distributed under the terms of the MIT license above.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - kdbush@3.0.0
  - quickselect@2.0.0
@@ -3700,7 +3697,7 @@ THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - known-css-properties@0.25.0
 
@@ -3730,7 +3727,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - lines-and-columns@1.2.4
 
@@ -3760,7 +3757,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - linkify-it@3.0.3
 
@@ -3791,7 +3788,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - lodash.clonedeep@4.5.0
  - lodash.escaperegexp@4.1.2
@@ -3849,7 +3846,7 @@ terms above.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - lodash.isequal@4.5.0
 
@@ -3905,7 +3902,7 @@ terms above.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - lodash@4.17.21
 
@@ -3961,7 +3958,7 @@ terms above.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - lru-queue@0.1.0
 
@@ -3989,7 +3986,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - make-iterator@0.1.1
 
@@ -4022,7 +4019,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - mapbox-gl@1.13.2
 
@@ -4115,7 +4112,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - markdown-it-for-inline@0.1.1
 
@@ -4146,7 +4143,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - markdown-it-plugin-underline@0.0.1
 
@@ -4167,7 +4164,7 @@ Renderer.render('++I am underlined++')
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - markdown-it-sub@1.0.0
  - markdown-it-sup@1.0.0
@@ -4199,7 +4196,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - markdown-it@12.3.2
 
@@ -4230,7 +4227,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - mathml-tag-names@2.1.3
 
@@ -4261,7 +4258,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - mdurl@1.0.1
 
@@ -4315,7 +4312,7 @@ IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - memoizee@0.4.15
 
@@ -4339,7 +4336,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - merge2@1.4.1
 
@@ -4369,7 +4366,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - min-indent@1.0.1
 
@@ -4399,7 +4396,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - minimist-options@4.1.0
 
@@ -4429,7 +4426,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - ms@2.1.2
 
@@ -4459,7 +4456,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - murmurhash-js@1.0.0
 
@@ -4508,7 +4505,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - nanoid@3.3.4
 
@@ -4537,7 +4534,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - neo-async@2.6.2
 
@@ -4568,7 +4565,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - next-tick@1.1.0
 
@@ -4592,7 +4589,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - node-fetch@2.6.7
 
@@ -4622,7 +4619,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - normalize-package-data@2.5.0
 
@@ -4661,7 +4658,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - normalize-package-data@3.0.3
 
@@ -4685,7 +4682,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - normalize-selector@0.2.0
 
@@ -4728,7 +4725,7 @@ http://getify.mit-license.org/
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - path-parse@1.0.7
 
@@ -4758,7 +4755,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - pbf@3.2.1
 
@@ -4794,7 +4791,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - picocolors@1.0.0
 
@@ -4818,7 +4815,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - picomatch@2.3.1
 
@@ -4848,7 +4845,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - plural-forms@0.5.3
 
@@ -4878,7 +4875,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - postcss-media-query-parser@0.2.3
 
@@ -5060,7 +5057,7 @@ MIT
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - postcss-resolve-nested-selector@0.1.1
 
@@ -5090,7 +5087,7 @@ SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - postcss-safe-parser@6.0.0
  - postcss@8.4.13
@@ -5120,7 +5117,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - postcss-selector-parser@6.0.10
 
@@ -5151,7 +5148,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - postcss-value-parser@4.2.0
 
@@ -5182,7 +5179,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - potpack@1.0.2
 
@@ -5206,7 +5203,7 @@ THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - process-nextick-args@2.0.1
 
@@ -5234,7 +5231,7 @@ SOFTWARE.**
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - promise-polyfill@6.1.0
 
@@ -5263,7 +5260,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - protocol-buffers-schema@3.6.0
 
@@ -5293,7 +5290,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - queue-microtask@1.2.3
  - run-parallel@1.2.0
@@ -5323,7 +5320,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - readable-stream@2.3.7
 
@@ -5379,7 +5376,7 @@ IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - regenerator-runtime@0.13.1
 
@@ -5419,7 +5416,7 @@ require("regenerator-runtime/path").path
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - remove-trailing-separator@1.1.0
 
@@ -5431,7 +5428,7 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - require-from-string@2.0.2
 
@@ -5461,7 +5458,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - resolve-protobuf-schema@2.1.0
 
@@ -5491,7 +5488,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - resolve-url@0.2.1
  - urix@0.1.0
@@ -5522,7 +5519,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - resolve@1.22.0
 
@@ -5552,7 +5549,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - reusify@1.0.4
 
@@ -5582,7 +5579,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - rw@1.3.3
 
@@ -5617,7 +5614,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - safer-buffer@2.1.2
 
@@ -5647,7 +5644,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - signal-exit@3.0.7
 
@@ -5672,7 +5669,7 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - slice-ansi@4.0.0
 
@@ -5691,7 +5688,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - source-map-js@1.0.2
  - source-map@0.6.1
@@ -5728,7 +5725,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - source-map-resolve@0.5.3
 
@@ -5759,7 +5756,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - source-map-url@0.4.1
 
@@ -5789,7 +5786,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm packages may be included in this product:
+The following NPM packages may be included in this product:
 
  - spdx-correct@3.1.1
  - validate-npm-package-license@3.0.4
@@ -6000,7 +5997,7 @@ Apache License
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - spdx-exceptions@2.3.0
 
@@ -6045,7 +6042,7 @@ discuss the following Supreme Court decisions with their attorneys:
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - spdx-expression-parse@3.0.1
 
@@ -6076,7 +6073,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - spdx-license-ids@3.0.11
 
@@ -6137,7 +6134,7 @@ deprecatedIds.includes('GPL-3.0'); //=> true
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - specificity@0.4.1
 
@@ -6154,7 +6151,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - string_decoder@1.1.1
 
@@ -6210,7 +6207,7 @@ IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - strip-bom-string@1.0.0
 
@@ -6240,7 +6237,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - style-search@0.1.0
 
@@ -6262,7 +6259,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - stylelint-scss@4.2.0
 
@@ -6292,7 +6289,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - stylelint@14.8.2
 
@@ -6321,7 +6318,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - supercluster@7.1.5
 
@@ -6345,7 +6342,7 @@ THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - supports-hyperlinks@2.2.0
 
@@ -6363,7 +6360,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - supports-preserve-symlinks-flag@1.0.0
 
@@ -6393,7 +6390,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - svg-tags@1.0.0
 
@@ -6423,7 +6420,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - sweetalert@2.1.2
 
@@ -6453,7 +6450,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - table@6.8.0
 
@@ -6486,7 +6483,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - through2@2.0.5
 
@@ -6504,7 +6501,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - tinyqueue@2.0.3
 
@@ -6528,7 +6525,7 @@ THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - titlecase@1.1.3
 
@@ -6556,7 +6553,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - tr46@0.0.3
 
@@ -6566,7 +6563,7 @@ This package contains the following license and notice below:
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - type-fest@0.18.1
 
@@ -6584,7 +6581,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - type@1.2.0
 
@@ -6608,7 +6605,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - type@2.6.0
 
@@ -6632,7 +6629,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - uglify-js@3.15.4
 
@@ -6670,7 +6667,7 @@ SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - uri-js@4.4.1
 
@@ -6690,7 +6687,7 @@ The views and conclusions contained in the software and documentation are those 
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - util-deprecate@1.0.2
 
@@ -6723,7 +6720,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - uuid@8.3.2
 
@@ -6741,7 +6738,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - v8-compile-cache@2.3.0
 
@@ -6771,7 +6768,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - vt-pbf@3.1.3
 
@@ -6833,7 +6830,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - webidl-conversions@3.0.1
 
@@ -6854,7 +6851,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - whatwg-url@5.0.0
 
@@ -6884,7 +6881,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - write-file-atomic@4.0.1
 
@@ -6898,7 +6895,7 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - xtend@4.0.2
 
@@ -6927,7 +6924,7 @@ THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - yaml@1.10.2
 
@@ -6949,7 +6946,7 @@ THIS SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - yargs-parser@20.2.9
 
@@ -6972,5 +6969,4 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 
-This file was generated with the generate-license-file npm package!
-https://www.npmjs.com/package/generate-license-file
+This file was generated with generate-license-file! https://www.npmjs.com/package/generate-license-file

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-search-ui",
-      "version": "1.14.2",
+      "version": "1.14.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/mapbox-gl-language": "^0.10.1",
         "@yext/answers-core": "^1.6.0",
         "@yext/answers-storage": "^1.1.0",
-        "@yext/rtf-converter": "^1.7.0",
+        "@yext/rtf-converter": "^1.7.1",
         "bowser": "^2.11.0",
         "cross-fetch": "^3.1.5",
         "css-vars-ponyfill": "^2.4.3",
@@ -3757,9 +3757,9 @@
       }
     },
     "node_modules/@yext/rtf-converter": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@yext/rtf-converter/-/rtf-converter-1.7.0.tgz",
-      "integrity": "sha512-i4H2HifDfmtVJMXnGQbFnLS4kxd1ze604DHKl/wZNy2WPzWh4oTwF+3LKzKbTOnM8+dRS1msztm1EqZQ7g/bYA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@yext/rtf-converter/-/rtf-converter-1.7.1.tgz",
+      "integrity": "sha512-k62QjrBav6LKdLxqTsu5xwlR31lYCdYKWxz4AitWoa5bk94RuY4acf9hjmz/dsoOfwrLqKla0LrN63c6Dk4OaQ==",
       "dependencies": {
         "markdown-it": "^12.0.0",
         "markdown-it-plugin-underline": "0.0.1",
@@ -26262,9 +26262,9 @@
       "integrity": "sha512-xA21FoDJkl+QFpH8cCz877h+xUCdY/ENZDst+tyV/phaR8ZT63vLFWTSxHJTI/FUQm+bXHw8QWxcv3kKze37Lg=="
     },
     "@yext/rtf-converter": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@yext/rtf-converter/-/rtf-converter-1.7.0.tgz",
-      "integrity": "sha512-i4H2HifDfmtVJMXnGQbFnLS4kxd1ze604DHKl/wZNy2WPzWh4oTwF+3LKzKbTOnM8+dRS1msztm1EqZQ7g/bYA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@yext/rtf-converter/-/rtf-converter-1.7.1.tgz",
+      "integrity": "sha512-k62QjrBav6LKdLxqTsu5xwlR31lYCdYKWxz4AitWoa5bk94RuY4acf9hjmz/dsoOfwrLqKla0LrN63c6Dk4OaQ==",
       "requires": {
         "markdown-it": "^12.0.0",
         "markdown-it-plugin-underline": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "Javascript Answers Programming Interface",
   "main": "dist/answers-umd.js",
   "repository": {
@@ -26,7 +26,7 @@
     "@mapbox/mapbox-gl-language": "^0.10.1",
     "@yext/answers-core": "^1.6.0",
     "@yext/answers-storage": "^1.1.0",
-    "@yext/rtf-converter": "^1.7.0",
+    "@yext/rtf-converter": "^1.7.1",
     "bowser": "^2.11.0",
     "cross-fetch": "^3.1.5",
     "css-vars-ponyfill": "^2.4.3",


### PR DESCRIPTION
Update the version of the `rtf-converter` library to v1.7.1 to include a bug fix for an edge case where parsing bracketed text in `toTruncatedHTML` could throw an error.

J=TECHOPS-6710
TEST=manual

Use a local build of the SDK in the client's experience where this bug was seen. See that the entity that previously was throwing an error now displays successfully.