### PR TITLE
Correctly pass `searcher` in DA analytics

### DIFF
--- a/src/ui/components/results/directanswercomponent.js
+++ b/src/ui/components/results/directanswercomponent.js
@@ -235,7 +235,7 @@ export default class DirectAnswerComponent extends Component {
     }
     return JSON.stringify({
       verticalConfigId: data.relatedItem?.verticalConfigId,
-      searcher: this.getState('searcher'),
+      searcher: data.searcher,
       entityId: data.relatedItem?.data.id,
       ctaLabel: this._viewDetailsText.toUpperCase().replace(' ', '_')
     });


### PR DESCRIPTION
Update the direct answer component to correctly pass the `searcher` as part of analytics events.

For RTF and thumbs feedback analytics events, the `searcher` was passed correctly because the options for those analytics events are set from `onMount`, at which point the `searcher` has been set in state. But, for other analytics events like CTA clicks that used `eventOptions` to set the options, the `searcher` is not necessarily set in state before the options for those events are calculated. In these cases, `this.getState('searcher')` returned `undefined`, so clicking on a CTA would hit the analytics endpoint without the required `searcher` data and get an error in the response. Using `data.searcher` directly fixes this issue.

See [this Slack thread](https://yext.slack.com/archives/C016ZKY42CF/p1666202290083719) where the issue was raised for more context.

J=TECHOPS-7011
TEST=manual

Serve the SDK locally with a direct answer component on a universal and vertical page. See that without this change, CTA clicks would result in a bad request to the analytics endpoint with the error `Record missing required field: searcher`. With this change, the correct value for `searcher` was sent in the request. Thumbs feedback analytics requests continued to pass the `searcher` correctly.