### PR TITLE
Update GH workflows to remove deprecation warnings

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -13,15 +13,15 @@ jobs:
     name: Headless Acceptance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'npm'
       - run: npm ci
       - name: Download build-output artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-output
           path: dist/
@@ -31,15 +31,15 @@ jobs:
     name: Browserstack Acceptance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'npm'
       - run: npm ci
       - name: Download build-output artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-output
           path: dist/

--- a/.github/workflows/acceptance_search_bar.yml
+++ b/.github/workflows/acceptance_search_bar.yml
@@ -13,15 +13,15 @@ jobs:
     name: Headless Acceptance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'npm'
       - run: npm ci
       - name: Download build-output artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-output
           path: dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,18 +13,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Use Node.js 16
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 16
         cache: 'npm'
     - run: npm ci
     - run: npm run ${{ inputs.build_script }}
     - name: Create build-output artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: build-output
         path: dist/

--- a/.github/workflows/build_i18n.yml
+++ b/.github/workflows/build_i18n.yml
@@ -14,16 +14,16 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: 16
         cache: 'npm'
     - id: set-matrix
       run: |
-        echo ::set-output name=matrix::$(node -e 'console.log(require("./conf/i18n/constants").ALL_LANGUAGES)')
+        echo matrix=$(node -e 'console.log(require("./conf/i18n/constants").ALL_LANGUAGES)') >> $GITHUB_OUTPUT
 
   build:
     needs: create_language_matrix
@@ -32,11 +32,11 @@ jobs:
       matrix:
         language: ${{ fromJson(needs.create_language_matrix.outputs.matrix) }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Use Node.js 16
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 16
         cache: 'npm'
@@ -47,7 +47,7 @@ jobs:
           npm run size
         fi
     - name: Create build-output artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: build-output
         path: dist/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,14 +26,14 @@ jobs:
   deploy-aws:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download build-output artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-output
           path: dist/
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download build-output artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-output
           path: dist/

--- a/.github/workflows/deploy_hold.yml
+++ b/.github/workflows/deploy_hold.yml
@@ -27,14 +27,14 @@ jobs:
     runs-on: ubuntu-latest
     environment: production # sets in github repo with reviewer requirement protection rule
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download build-output artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-output
           path: dist/
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download build-output artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-output
           path: dist/

--- a/.github/workflows/extract_versions.yml
+++ b/.github/workflows/extract_versions.yml
@@ -28,10 +28,10 @@ jobs:
         run: |
           MAJOR_VERSION="$(echo "${GITHUB_REF_NAME##${{ inputs.ignore_prefix }}}" | cut -d '.' -f 1)"
           echo "Major version: $MAJOR_VERSION"
-          echo ::set-output name=major_version::${MAJOR_VERSION}
+          echo major_version=${MAJOR_VERSION} >> $GITHUB_OUTPUT
           MINOR_VERSION="$(echo "${GITHUB_REF_NAME##${{ inputs.ignore_prefix }}}" | cut -d '.' -f 1,2)"  
           echo "Minor version: $MINOR_VERSION"
-          echo ::set-output name=minor_version::${MINOR_VERSION}
+          echo minor_version=${MINOR_VERSION} >> $GITHUB_OUTPUT
           FULL_VERSION="${GITHUB_REF_NAME##${{ inputs.ignore_prefix }}}"
           echo "Full version: $FULL_VERSION"
-          echo ::set-output name=full_version::${FULL_VERSION}
+          echo full_version=${FULL_VERSION} >> $GITHUB_OUTPUT

--- a/.github/workflows/format_branch_name.yml
+++ b/.github/workflows/format_branch_name.yml
@@ -18,4 +18,4 @@ jobs:
         run: |
           FORMATTED_BRANCH="$(echo ${GITHUB_REF_NAME} | sed "s/\//-/g")" 
           echo $FORMATTED_BRANCH
-          echo ::set-output name=formatted_branch::${FORMATTED_BRANCH}
+          echo formatted_branch=${FORMATTED_BRANCH} >> $GITHUB_OUTPUT

--- a/.github/workflows/miscellaneous_tests.yml
+++ b/.github/workflows/miscellaneous_tests.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'npm'

--- a/.github/workflows/should_deploy_major_version.yml
+++ b/.github/workflows/should_deploy_major_version.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       should_deploy_major_version: ${{ steps.vars.outputs.should_deploy_major_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: allow for major version deployment if the next minor version from current tag does not exist
@@ -30,7 +30,7 @@ jobs:
           if [ -z "$TAGS_FOR_NEXT_MINOR" ]
           then
             echo 'Major version should be deployed.'
-            echo ::set-output name=should_deploy_major_version::true
+            echo should_deploy_major_version=true >> $GITHUB_OUTPUT
           else
             echo 'Major version should not be deployed.'
           fi

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'npm'
       - run: npm ci
       - name: Download build-output artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-output
           path: dist/


### PR DESCRIPTION
Upgrade GitHub actions (`actions/checkout`, `actions/setup-node`, `actions/upload-artifact`, `actions/download-artifact`, and `aws-actions/configure-aws-credentials`) and update `set-output` calls to remove all deprecation warnings from the workflows. These warnings were for the deprecation of [Node 12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) and for the `set-output` and `save-state` [commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

J=SLAP-2427
TEST=manual

Test in this PR as well as on `dev/test-output-changes`. See that the warnings are no longer present (except for the exception mentioned in [this PR](https://github.com/yext/slapshot-reusable-workflows/pull/25)).

Note: The Browserstack acceptance test is failing because the Google Maps JS API dropped support for IE11 recently (see Oliver's [post](https://yext.slack.com/archives/C016ZKY42CF/p1668808136926099) on Slack).