### PR TITLE
Remove Browserstack acceptance testing on IE11

### DIFF
--- a/.github/run_browserstack_acceptance.sh
+++ b/.github/run_browserstack_acceptance.sh
@@ -6,4 +6,4 @@ export BROWSERSTACK_BUILD_ID="${GITHUB_REF_NAME} - ${GITHUB_RUN_ID}"
 COMMIT_MSG_TITLE=$(git log -n 1 --pretty=format:%s)
 export BROWSERSTACK_TEST_RUN_NAME=$COMMIT_MSG_TITLE
 
-npx testcafe "browserstack:safari" --config-file ./.github/testcafe.json -q
+npx testcafe -c 3 "browserstack:safari" --config-file ./.github/testcafe.json -q

--- a/.github/run_browserstack_acceptance.sh
+++ b/.github/run_browserstack_acceptance.sh
@@ -6,4 +6,4 @@ export BROWSERSTACK_BUILD_ID="${GITHUB_REF_NAME} - ${GITHUB_RUN_ID}"
 COMMIT_MSG_TITLE=$(git log -n 1 --pretty=format:%s)
 export BROWSERSTACK_TEST_RUN_NAME=$COMMIT_MSG_TITLE
 
-npx testcafe -c 2 "browserstack:safari" --config-file ./.github/testcafe.json -q
+npx testcafe "browserstack:safari" --config-file ./.github/testcafe.json -q

--- a/.github/run_browserstack_acceptance.sh
+++ b/.github/run_browserstack_acceptance.sh
@@ -6,4 +6,4 @@ export BROWSERSTACK_BUILD_ID="${GITHUB_REF_NAME} - ${GITHUB_RUN_ID}"
 COMMIT_MSG_TITLE=$(git log -n 1 --pretty=format:%s)
 export BROWSERSTACK_TEST_RUN_NAME=$COMMIT_MSG_TITLE
 
-npx testcafe -c 3 "browserstack:safari" --config-file ./.github/testcafe.json -q --ssl
+npx testcafe -c 3 "browserstack:safari" --config-file ./.github/testcafe.json -q successThreshold=1

--- a/.github/run_browserstack_acceptance.sh
+++ b/.github/run_browserstack_acceptance.sh
@@ -6,4 +6,4 @@ export BROWSERSTACK_BUILD_ID="${GITHUB_REF_NAME} - ${GITHUB_RUN_ID}"
 COMMIT_MSG_TITLE=$(git log -n 1 --pretty=format:%s)
 export BROWSERSTACK_TEST_RUN_NAME=$COMMIT_MSG_TITLE
 
-npx testcafe -c 3 "browserstack:safari" --config-file ./.github/testcafe.json -q successThreshold=1
+npx testcafe "browserstack:safari" --config-file ./.github/testcafe.json -q successThreshold=1

--- a/.github/run_browserstack_acceptance.sh
+++ b/.github/run_browserstack_acceptance.sh
@@ -6,4 +6,4 @@ export BROWSERSTACK_BUILD_ID="${GITHUB_REF_NAME} - ${GITHUB_RUN_ID}"
 COMMIT_MSG_TITLE=$(git log -n 1 --pretty=format:%s)
 export BROWSERSTACK_TEST_RUN_NAME=$COMMIT_MSG_TITLE
 
-npx testcafe -c 3 "browserstack:safari" --config-file ./.github/testcafe.json -q
+npx testcafe -c 3 "browserstack:safari" --config-file ./.github/testcafe.json -q --ssl

--- a/.github/run_browserstack_acceptance.sh
+++ b/.github/run_browserstack_acceptance.sh
@@ -6,12 +6,4 @@ export BROWSERSTACK_BUILD_ID="${GITHUB_REF_NAME} - ${GITHUB_RUN_ID}"
 COMMIT_MSG_TITLE=$(git log -n 1 --pretty=format:%s)
 export BROWSERSTACK_TEST_RUN_NAME=$COMMIT_MSG_TITLE
 
-if [[ $GITHUB_REF_NAME == release/*
-  || $GITHUB_REF_NAME == hotfix/*
-  || $GITHUB_REF_NAME == master
-  || $GITHUB_REF_NAME == support/* ]]
-then
-  npx testcafe "browserstack:ie@11.0,browserstack:safari" --config-file ./.github/testcafe.json -q
-else
-  npx testcafe -c 2 "browserstack:ie@11.0" --config-file ./.github/testcafe.json -q
-fi
+npx testcafe -c 2 "browserstack:safari" --config-file ./.github/testcafe.json -q

--- a/.github/testcafe.json
+++ b/.github/testcafe.json
@@ -1,7 +1,5 @@
 {
   "src": ["tests/acceptance/acceptancesuites/*.js", "!tests/acceptance/acceptancesuites/searchbaronlysuite.js"],
   "appCommand": "npx serve -l tcp://0.0.0.0:9999",
-  "appInitDelay": 4000,
-  "retryTestPages": true,
-  "hostname": "localhost"
+  "appInitDelay": 4000
 }

--- a/.github/testcafe.json
+++ b/.github/testcafe.json
@@ -1,5 +1,7 @@
 {
   "src": ["tests/acceptance/acceptancesuites/*.js", "!tests/acceptance/acceptancesuites/searchbaronlysuite.js"],
   "appCommand": "npx serve -l tcp://0.0.0.0:9999",
-  "appInitDelay": 4000
+  "appInitDelay": 4000,
+  "retryTestPages": true,
+  "hostname": "localhost"
 }


### PR DESCRIPTION
Now that the Google Maps JS API has dropped support for IE11, Browserstack acceptance tests on IE11 fail. This PR updates the Browserstack acceptance test script to only run on Safari, and not IE11 anymore.

J=SLAP-2502
TEST=auto

See that the Browserstack check on this PR only runs on Safari and there are no more Google Maps API errors.