### PR TITLE
Update Github Actions to sync a separate EU build

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -16,7 +16,7 @@ jobs:
   call_unit_test:
     uses: ./.github/workflows/unit_test.yml
     needs: call_build
-  
+
   call_misc_tests:
     uses: ./.github/workflows/miscellaneous_tests.yml
 
@@ -28,7 +28,7 @@ jobs:
     needs: call_build
 
   call_deploy:
-    needs: 
+    needs:
       - call_unit_test
       - call_format_branch_name
       - call_acceptance
@@ -39,7 +39,6 @@ jobs:
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
 concurrency:
   group: ci-build-and-deploy-${{ github.ref }}-1

--- a/.github/workflows/build_and_deploy_hold.yml
+++ b/.github/workflows/build_and_deploy_hold.yml
@@ -8,6 +8,15 @@ on:
 jobs:
   call_build:
     uses: ./.github/workflows/build_i18n.yml
+    with:
+      cloud_region: US
+      output_dir: dist
+
+  call_build_for_eu:
+    uses: ./.github/workflows/build_i18n.yml
+    with:
+      cloud_region: EU
+      output_dir: dist-eu
 
   call_unit_test:
     uses: ./.github/workflows/unit_test.yml
@@ -19,7 +28,7 @@ jobs:
   call_acceptance:
     uses: ./.github/workflows/acceptance.yml
     needs: call_build
-  
+
   call_extract_versions:
     uses: ./.github/workflows/extract_versions.yml
 
@@ -27,7 +36,8 @@ jobs:
     uses: ./.github/workflows/should_deploy_major_version.yml
 
   call_deploy_full_version:
-    needs: 
+    needs:
+      - call_build_for_eu
       - call_unit_test
       - call_acceptance
       - call_extract_versions
@@ -42,7 +52,8 @@ jobs:
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
   call_deploy_major_version:
-    needs: 
+    needs:
+      - call_build_for_eu
       - call_unit_test
       - call_acceptance
       - call_extract_versions
@@ -59,7 +70,8 @@ jobs:
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
   call_deploy_minor_version:
-    needs: 
+    needs:
+      - call_build_for_eu
       - call_unit_test
       - call_acceptance
       - call_extract_versions

--- a/.github/workflows/build_and_deploy_i18n.yml
+++ b/.github/workflows/build_and_deploy_i18n.yml
@@ -17,7 +17,7 @@ jobs:
   call_unit_test:
     uses: ./.github/workflows/unit_test.yml
     needs: call_build
-  
+
   call_misc_tests:
     uses: ./.github/workflows/miscellaneous_tests.yml
 
@@ -27,13 +27,13 @@ jobs:
   call_acceptance:
     uses: ./.github/workflows/acceptance.yml
     needs: call_build
-  
+
   call_build_locales:
     uses: ./.github/workflows/build_i18n.yml
 
   call_deploy:
     if: github.ref_name != 'develop'
-    needs: 
+    needs:
       - call_unit_test
       - call_format_branch_name
       - call_acceptance
@@ -45,11 +45,10 @@ jobs:
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
   call_deploy_canary:
     if: github.ref_name == 'develop'
-    needs: 
+    needs:
       - call_unit_test
       - call_format_branch_name
       - call_acceptance
@@ -61,11 +60,10 @@ jobs:
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
   call_deploy_canary_sha:
     if: github.ref_name == 'develop'
-    needs: 
+    needs:
       - call_unit_test
       - call_format_branch_name
       - call_acceptance
@@ -78,7 +76,6 @@ jobs:
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
 concurrency:
   group: ci-build-and-deploy-i18n-${{ github.ref }}-1

--- a/.github/workflows/build_and_deploy_search_bar.yml
+++ b/.github/workflows/build_and_deploy_search_bar.yml
@@ -10,7 +10,16 @@ jobs:
     uses: ./.github/workflows/build_i18n.yml
     with:
       build_script: build-search-bar-only
-  
+      cloud_region: US
+      output_dir: dist
+
+  call_build_for_eu:
+    uses: ./.github/workflows/build_i18n.yml
+    with:
+      build_script: build-search-bar-only
+      cloud_region: EU
+      output_dir: dist-eu
+
   call_misc_tests:
     uses: ./.github/workflows/miscellaneous_tests.yml
 
@@ -30,6 +39,7 @@ jobs:
 
   call_deploy_full_version:
     needs:
+      - call_build_for_eu
       - call_acceptance_search_bar
       - call_extract_versions
       - call_misc_tests
@@ -44,7 +54,8 @@ jobs:
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
   call_deploy_major_version:
-    needs: 
+    needs:
+      - call_build_for_eu
       - call_acceptance_search_bar
       - call_extract_versions
       - call_misc_tests
@@ -61,7 +72,8 @@ jobs:
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
   call_deploy_minor_version:
-    needs: 
+    needs:
+      - call_build_for_eu
       - call_acceptance_search_bar
       - call_extract_versions
       - call_misc_tests

--- a/.github/workflows/build_i18n.yml
+++ b/.github/workflows/build_i18n.yml
@@ -7,6 +7,14 @@ on:
         required: false
         default: build-locales
         type: string
+      cloud_region:
+        required: false
+        default: US
+        type: string
+      output_dir:
+        required: false
+        default: dist
+        type: string
 
 jobs:
   create_language_matrix:
@@ -41,13 +49,17 @@ jobs:
         node-version: 16
         cache: 'npm'
     - run: npm ci
-    - run: LANGUAGE=${{ matrix.language }} npm run ${{ inputs.build_script }}
+    - run: LANGUAGE=${{ matrix.language }} CLOUD_REGION=${{ inputs.cloud-region }} npm run ${{ inputs.build_script }}
     - run: |
         if [ "${{ matrix.language }}" == "en" ]; then 
           npm run size
+        fi
+    - run: |
+        if [ "${{ input.output_dir }}" != "dist" ]; then 
+          mv dist ${{ input.output_dir }}
         fi
     - name: Create build-output artifact
       uses: actions/upload-artifact@v3
       with:
         name: build-output
-        path: dist/
+        path: ${{ input.output_dir }}

--- a/.github/workflows/build_i18n.yml
+++ b/.github/workflows/build_i18n.yml
@@ -55,11 +55,11 @@ jobs:
           npm run size
         fi
     - run: |
-        if [ "${{ input.output_dir }}" != "dist" ]; then 
-          mv dist ${{ input.output_dir }}
+        if [ "${{ inputs.output_dir }}" != "dist" ]; then 
+          mv dist ${{ inputs.output_dir }}
         fi
     - name: Create build-output artifact
       uses: actions/upload-artifact@v3
       with:
         name: build-output
-        path: ${{ input.output_dir }}
+        path: ${{ inputs.output_dir }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,8 +19,6 @@ on:
         required: true
       AWS_SECRET_ACCESS_KEY:
         required: true
-      GCP_SA_KEY:
-        required: true
 
 jobs:
   deploy-aws:
@@ -44,26 +42,3 @@ jobs:
           --acl public-read \
           --recursive \
           --cache-control ${{ inputs.cache-control }}
-
-  deploy-gcp:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Download build-output artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: build-output
-          path: dist/
-      - name: Authenticate to Google Cloud
-        id: auth
-        uses: google-github-actions/auth@v0
-        with:
-          credentials_json: '${{ secrets.GCP_SA_KEY }}'
-      - name: Deploy to GCP Bucket
-        uses: google-github-actions/upload-cloud-storage@v0
-        with:
-          path: dist/
-          parent: false
-          destination: assets-eu.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }}
-          headers: |-
-            cache-control: ${{ inputs.cache-control }}

--- a/.github/workflows/deploy_hold.yml
+++ b/.github/workflows/deploy_hold.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: build-output
-          path: dist/
+          path: dist-eu/
       - name: Authenticate to Google Cloud
         id: auth
         uses: google-github-actions/auth@v0
@@ -64,7 +64,7 @@ jobs:
       - name: Deploy to GCP Bucket
         uses: google-github-actions/upload-cloud-storage@v0
         with:
-          path: dist/
+          path: dist-eu/
           parent: false
           destination: assets-eu.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }}
           headers: |-


### PR DESCRIPTION
Previously the GH actions were syncing the US
assets to GCP. This change updates the actions so
that a seprate EU build is ran, and only those assets are synced to GCP. Also, remove the syncing of assets from dev branches.

J=BACK-2268
TEST=none

I will test this with a test version (e.g. 0.0.10) and confirm the build works as expected