### PR TITLE
Pass CloudRegion to Search Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 **/.DS_Store
+.idea/

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -487,7 +487,7 @@ CDN
 
 The following NPM package may be included in this product:
 
- - @yext/search-core@2.2.0
+ - @yext/search-core@2.3.0-beta.1
 
 This package contains the following license and notice below:
 

--- a/conf/cloud-regions/constants.js
+++ b/conf/cloud-regions/constants.js
@@ -1,10 +1,3 @@
-const CLOUD_REGION = {
-  US: 'us',
-  EU: 'eu'
-};
+const { CloudRegion } = require('@yext/search-core');
 
-exports.CLOUD_REGION = CLOUD_REGION;
-
-exports.DEFAULT_CLOUD_REGION = CLOUD_REGION.US;
-
-exports.ALL_CLOUD_REGIONS = Object.values(CLOUD_REGION);
+exports.DEFAULT_CLOUD_REGION = CloudRegion.US;

--- a/conf/gulp-tasks/library.gulpfile.js
+++ b/conf/gulp-tasks/library.gulpfile.js
@@ -86,16 +86,16 @@ function allLocaleJSBundles (isSearchBarOnly = false, languages, cloudRegion) {
     'answers-umd.min.js'];
 
   return createJSBundlesForLanguages(languages, cloudRegion, isSearchBarOnly).then(() => {
-    copyAssetsForLocales(assetNames, languages, cloudRegion);
+    copyAssetsForLocales(assetNames, languages);
   });
 }
 
 exports.default = function defaultLanguageJSBundles () {
-  return createJSBundlesForLanguages([DEFAULT_LOCALE]);
+  return createJSBundlesForLanguages([DEFAULT_LOCALE], DEFAULT_CLOUD_REGION, false);
 };
 
 exports.buildLanguages = function allLanguageJSBundles () {
-  return createJSBundlesForLanguages(ALL_LANGUAGES);
+  return createJSBundlesForLanguages(ALL_LANGUAGES, DEFAULT_CLOUD_REGION, false);
 };
 
 exports.buildLocales = function (languages = ALL_LANGUAGES, cloudRegion = DEFAULT_CLOUD_REGION) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mapbox/mapbox-gl-language": "^0.10.1",
         "@yext/answers-storage": "^1.1.0",
         "@yext/rtf-converter": "^1.7.1",
-        "@yext/search-core": "^2.2.0",
+        "@yext/search-core": "^2.3.0-beta.1",
         "bowser": "^2.11.0",
         "cross-fetch": "^3.1.5",
         "css-vars-ponyfill": "^2.4.3",
@@ -3302,9 +3302,9 @@
       }
     },
     "node_modules/@yext/search-core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.2.0.tgz",
-      "integrity": "sha512-Snx7FawwywXrGtYOtCiv0soycWtoquiNhU+fLNA8q9RRV6oajMrKub5uQR6fHQSSY7MtJVd4Wy92C1Vg/WJ1wQ==",
+      "version": "2.3.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.3.0-beta.1.tgz",
+      "integrity": "sha512-qO8OC88ZftVLVxyylG0CxM/1Jf6xCVpztwDEKnDu/3lKw9Iq/zHZA7E487y1Ja2MraU6WuiMUNFYJpzYRLOcIw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"
@@ -25214,9 +25214,9 @@
       }
     },
     "@yext/search-core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.2.0.tgz",
-      "integrity": "sha512-Snx7FawwywXrGtYOtCiv0soycWtoquiNhU+fLNA8q9RRV6oajMrKub5uQR6fHQSSY7MtJVd4Wy92C1Vg/WJ1wQ==",
+      "version": "2.3.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.3.0-beta.1.tgz",
+      "integrity": "sha512-qO8OC88ZftVLVxyylG0CxM/1Jf6xCVpztwDEKnDu/3lKw9Iq/zHZA7E487y1Ja2MraU6WuiMUNFYJpzYRLOcIw==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@mapbox/mapbox-gl-language": "^0.10.1",
     "@yext/answers-storage": "^1.1.0",
     "@yext/rtf-converter": "^1.7.1",
-    "@yext/search-core": "^2.2.0",
+    "@yext/search-core": "^2.3.0-beta.1",
     "bowser": "^2.11.0",
     "cross-fetch": "^3.1.5",
     "css-vars-ponyfill": "^2.4.3",

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -9,6 +9,7 @@ export const LOCALE = '@@LOCALE';
 /** The speech recognition locales supported by Microsoft Edge */
 export const SPEECH_RECOGNITION_LOCALES_SUPPORTED_BY_EDGE = '@@SPEECH_RECOGNITION_LOCALES_SUPPORTED_BY_EDGE';
 
+/** The cloud region being used, injected by the build process */
 export const CLOUD_REGION = '@@CLOUD_REGION';
 
 /** The identifier of the production environment */

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -1,5 +1,7 @@
 /** @module Core */
 import { provideCore } from '@yext/search-core/lib/commonjs';
+// Using the ESM build for importing the Environment enum due to an issue importing the commonjs version
+import { Environment } from '@yext/search-core';
 import { generateUUID } from './utils/uuid';
 import SearchDataTransformer from './search/searchdatatransformer';
 
@@ -17,8 +19,7 @@ import FilterRegistry from './filters/filterregistry';
 import DirectAnswer from './models/directanswer';
 import AutoCompleteResponseTransformer from './search/autocompleteresponsetransformer';
 
-import { PRODUCTION, ENDPOINTS, LIB_VERSION, CLOUD_REGION } from './constants';
-import { getCachedLiveApiUrl, getLiveApiUrl } from './utils/urlutils';
+import { PRODUCTION, LIB_VERSION, CLOUD_REGION, SANDBOX } from './constants';
 import { SearchParams } from '../ui';
 import SearchStates from './storage/searchstates';
 import Searcher from './models/searcher';
@@ -113,6 +114,10 @@ export default class Core {
      */
     this._environment = config.environment || PRODUCTION;
 
+    /**
+     * Determines the region of the api endpoints used when making search requests.
+     * @type {string}
+     */
     this._cloudRegion = CLOUD_REGION;
 
     /** @type {string} */
@@ -138,34 +143,22 @@ export default class Core {
    * Initializes the {@link Core} by providing it with an instance of the Core library.
    */
   init (config) {
+    const environment = this._environment === SANDBOX ? Environment.SANDBOX : Environment.PROD;
     const params = {
       ...(this._token && { token: this._token }),
       ...(this._apiKey && { apiKey: this._apiKey }),
       experienceKey: this._experienceKey,
       locale: this._locale,
       experienceVersion: this._experienceVersion,
-      endpoints: this._getServiceUrls(),
       additionalQueryParams: {
         jsLibVersion: LIB_VERSION
       },
+      cloudRegion: this._cloudRegion,
+      environment,
       ...config
     };
 
     this._coreLibrary = provideCore(params);
-  }
-
-  /**
-   * Get the urls for each service based on the environment.
-   */
-  _getServiceUrls () {
-    return {
-      universalSearch: getLiveApiUrl(this._environment) + ENDPOINTS.UNIVERSAL_SEARCH,
-      verticalSearch: getLiveApiUrl(this._environment) + ENDPOINTS.VERTICAL_SEARCH,
-      questionSubmission: getLiveApiUrl(this._environment) + ENDPOINTS.QUESTION_SUBMISSION,
-      universalAutocomplete: getCachedLiveApiUrl(this._environment) + ENDPOINTS.UNIVERSAL_AUTOCOMPLETE,
-      verticalAutocomplete: getCachedLiveApiUrl(this._environment) + ENDPOINTS.VERTICAL_AUTOCOMPLETE,
-      filterSearch: getCachedLiveApiUrl(this._environment) + ENDPOINTS.FILTER_SEARCH
-    };
   }
 
   /**

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -12,14 +12,6 @@ export function getLiveApiUrl (env = PRODUCTION) {
 }
 
 /**
- * Returns the base url for the live api backend in the desired environment.
- * @param {string} env The desired environment.
- */
-export function getCachedLiveApiUrl (env = PRODUCTION) {
-  return env === SANDBOX ? 'https://liveapi-sandbox.yext.com' : 'https://liveapi-cached.yext.com';
-}
-
-/**
  * Returns the base url for the analytics backend in the desired environment.
  * @param {string} env The desired environment.
  * @param {boolean} conversionTrackingEnabled If conversion tracking has been opted into.

--- a/tests/acceptance/constants.js
+++ b/tests/acceptance/constants.js
@@ -1,5 +1,5 @@
-export const VERTICAL_SEARCH_URL_REGEX = /v2\/accounts\/me\/answers\/vertical\/query/;
-export const UNIVERSAL_SEARCH_URL_REGEX = /v2\/accounts\/me\/answers\/query/;
+export const VERTICAL_SEARCH_URL_REGEX = /v2\/accounts\/me\/search\/vertical\/query/;
+export const UNIVERSAL_SEARCH_URL_REGEX = /v2\/accounts\/me\/search\/query/;
 export const PORT = 9999;
 
 const PAGE_DIR = `http://localhost:${PORT}/tests/acceptance/fixtures/html`;

--- a/tests/acceptance/fixtures/responses/filtersearch/search.js
+++ b/tests/acceptance/fixtures/responses/filtersearch/search.js
@@ -250,7 +250,7 @@ function generateFilterSearchResponse (input) {
 
 export const MockedFilterSearchRequest = RequestMock()
   .onRequestTo(async request => {
-    const urlRegex = /^https:\/\/liveapi-cached.yext.com\/v2\/accounts\/me\/answers\/filtersearch/;
+    const urlRegex = /^https:\/\/prod-cdn.us.yextapis.com\/v2\/accounts\/me\/search\/filtersearch/;
     return urlRegex.test(request.url) && request.method === 'get';
   })
   .respond((req, res) => {

--- a/tests/acceptance/fixtures/responses/universal/autocomplete.js
+++ b/tests/acceptance/fixtures/responses/universal/autocomplete.js
@@ -47,7 +47,7 @@ function generateAutoCompleteResponse (prompt) {
 
 export const MockedUniversalAutoCompleteRequest = RequestMock()
   .onRequestTo(async request => {
-    const urlRegex = /^https:\/\/liveapi-cached.yext.com\/v2\/accounts\/me\/answers\/autocomplete/;
+    const urlRegex = /^https:\/\/prod-cdn.us.yextapis.com\/v2\/accounts\/me\/search\/autocomplete/;
     return urlRegex.test(request.url) && request.method === 'get';
   })
   .respond((req, res) => {

--- a/tests/acceptance/fixtures/responses/universal/search.js
+++ b/tests/acceptance/fixtures/responses/universal/search.js
@@ -489,7 +489,7 @@ function generateUniversalSearchResponse (input) {
 
 export const MockedUniversalSearchRequest = RequestMock()
   .onRequestTo(async request => {
-    const urlRegex = /^https:\/\/liveapi.yext.com\/v2\/accounts\/me\/answers\/query/;
+    const urlRegex = /^https:\/\/prod-cdn.us.yextapis.com\/v2\/accounts\/me\/search\/query/;
     return urlRegex.test(request.url) && request.method === 'get';
   })
   .respond((req, res) => {

--- a/tests/acceptance/fixtures/responses/vertical/autocomplete.js
+++ b/tests/acceptance/fixtures/responses/vertical/autocomplete.js
@@ -17,7 +17,7 @@ function generateAutoCompleteResponse (prompt) {
 
 export const MockedVerticalAutoCompleteRequest = RequestMock()
   .onRequestTo(async request => {
-    const urlRegex = /^https:\/\/liveapi-cached.yext.com\/v2\/accounts\/me\/answers\/vertical\/autocomplete/;
+    const urlRegex = /^https:\/\/prod-cdn.us.yextapis.com\/v2\/accounts\/me\/search\/vertical\/autocomplete/;
     return urlRegex.test(request.url) && request.method === 'get';
   })
   .respond((req, res) => {

--- a/tests/acceptance/fixtures/responses/vertical/search.js
+++ b/tests/acceptance/fixtures/responses/vertical/search.js
@@ -17,7 +17,7 @@ function generateVerticalSearchResponse (verticalKey, input, offset, filterParam
 
 export const MockedVerticalSearchRequest = RequestMock()
   .onRequestTo(async request => {
-    const urlRegex = /^https:\/\/liveapi.yext.com\/v2\/accounts\/me\/answers\/vertical\/query/;
+    const urlRegex = /^https:\/\/prod-cdn.us.yextapis.com\/v2\/accounts\/me\/search\/vertical\/query/;
     return urlRegex.test(request.url) && request.method === 'get';
   })
   .respond((req, res) => {

--- a/tests/core/utils/urlutils.js
+++ b/tests/core/utils/urlutils.js
@@ -2,7 +2,6 @@ import SearchParams from '../../../src/ui/dom/searchparams';
 import { PRODUCTION, SANDBOX } from '../../../src/core/constants';
 import {
   getLiveApiUrl,
-  getCachedLiveApiUrl,
   getAnalyticsUrl,
   replaceUrlParams,
   urlWithoutQueryParamsAndHash,
@@ -15,11 +14,9 @@ const baseUrl = 'https://yext.com/';
 describe('getUrlFunctions work', () => {
   it('differentiates sandbox from prod', () => {
     expect(getLiveApiUrl()).not.toEqual(expect.stringContaining('sandbox'));
-    expect(getCachedLiveApiUrl()).not.toEqual(expect.stringContaining('sandbox'));
     expect(getAnalyticsUrl()).not.toEqual(expect.stringContaining('sandbox'));
 
     expect(getLiveApiUrl(SANDBOX)).toEqual(expect.stringContaining('sandbox'));
-    expect(getCachedLiveApiUrl(SANDBOX)).toEqual(expect.stringContaining('sandbox'));
     expect(getAnalyticsUrl(SANDBOX)).toEqual(expect.stringContaining('sandbox'));
   });
 


### PR DESCRIPTION
This change uses the CloudRegion injected during the build
process and passes it to the Search Core config. It also
passes the environment using the environment provided from
the config rather than manually constructing the endpoints.

J=BACK-2269
TEST=manual

Manually tested the eu assets with an eu test site
and confirmed the requests were being made correctly. Also
tested the search-bar only integration in eu. Confirmed the
us build still worked as expected.
