### PR TITLE
Fix passing of cloud region env variable

### DIFF
--- a/.github/workflows/build_i18n.yml
+++ b/.github/workflows/build_i18n.yml
@@ -49,7 +49,7 @@ jobs:
         node-version: 16
         cache: 'npm'
     - run: npm ci
-    - run: LANGUAGE=${{ matrix.language }} CLOUD_REGION=${{ inputs.cloud-region }} npm run ${{ inputs.build_script }}
+    - run: LANGUAGE=${{ matrix.language }} CLOUD_REGION=${{ inputs.cloud_region }} npm run ${{ inputs.build_script }}
     - run: |
         if [ "${{ matrix.language }}" == "en" ]; then 
           npm run size


### PR DESCRIPTION
Fix passing of cloud region env variable

J=BACK-2268
TEST=none

I will create a test version tag and confirm it is passed correctly in github actions