### PR TITLE
Create separate EU artifact in github actions

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -14,10 +14,10 @@ jobs:
           node-version: 16
           cache: 'npm'
       - run: npm ci
-      - name: Download build-output artifact
+      - name: Download build-output-US artifact
         uses: actions/download-artifact@v3
         with:
-          name: build-output
+          name: build-output-US
           path: dist/
       - run: ./.github/run_headless_acceptance.sh
 

--- a/.github/workflows/acceptance_search_bar.yml
+++ b/.github/workflows/acceptance_search_bar.yml
@@ -13,9 +13,9 @@ jobs:
           node-version: 16
           cache: 'npm'
       - run: npm ci
-      - name: Download build-output artifact
+      - name: Download build-output-US artifact
         uses: actions/download-artifact@v3
         with:
-          name: build-output
+          name: build-output-US
           path: dist/
       - run: npx testcafe -c 3 "chrome:headless,firefox:headless" --config-file ./.github/testcafe_search_bar.json -q

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run ${{ inputs.build_script }}
-    - name: Create build-output artifact
+    - name: Create build-output-US artifact
       uses: actions/upload-artifact@v3
       with:
-        name: build-output
+        name: build-output-US
         path: dist/

--- a/.github/workflows/build_and_deploy_hold.yml
+++ b/.github/workflows/build_and_deploy_hold.yml
@@ -10,13 +10,11 @@ jobs:
     uses: ./.github/workflows/build_i18n.yml
     with:
       cloud_region: US
-      output_dir: dist
 
   call_build_for_eu:
     uses: ./.github/workflows/build_i18n.yml
     with:
       cloud_region: EU
-      output_dir: dist-eu
 
   call_unit_test:
     uses: ./.github/workflows/unit_test.yml

--- a/.github/workflows/build_and_deploy_search_bar.yml
+++ b/.github/workflows/build_and_deploy_search_bar.yml
@@ -11,14 +11,12 @@ jobs:
     with:
       build_script: build-search-bar-only
       cloud_region: US
-      output_dir: dist
 
   call_build_for_eu:
     uses: ./.github/workflows/build_i18n.yml
     with:
       build_script: build-search-bar-only
       cloud_region: EU
-      output_dir: dist-eu
 
   call_misc_tests:
     uses: ./.github/workflows/miscellaneous_tests.yml

--- a/.github/workflows/build_i18n.yml
+++ b/.github/workflows/build_i18n.yml
@@ -11,10 +11,6 @@ on:
         required: false
         default: US
         type: string
-      output_dir:
-        required: false
-        default: dist
-        type: string
 
 jobs:
   create_language_matrix:
@@ -54,12 +50,8 @@ jobs:
         if [ "${{ matrix.language }}" == "en" ]; then 
           npm run size
         fi
-    - run: |
-        if [ "${{ inputs.output_dir }}" != "dist" ]; then 
-          mv dist ${{ inputs.output_dir }}
-        fi
-    - name: Create build-output artifact
+    - name: Create build-output-${{ inputs.cloud_region }} artifact
       uses: actions/upload-artifact@v3
       with:
-        name: build-output
-        path: ${{ inputs.output_dir }}
+        name: build-output-${{ inputs.cloud_region }}
+        path: dist/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Download build-output artifact
+      - name: Download build-output-US artifact
         uses: actions/download-artifact@v3
         with:
-          name: build-output
+          name: build-output-US
           path: dist/
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16

--- a/.github/workflows/deploy_hold.yml
+++ b/.github/workflows/deploy_hold.yml
@@ -28,10 +28,10 @@ jobs:
     environment: production # sets in github repo with reviewer requirement protection rule
     steps:
       - uses: actions/checkout@v3
-      - name: Download build-output artifact
+      - name: Download build-output-US artifact
         uses: actions/download-artifact@v3
         with:
-          name: build-output
+          name: build-output-US
           path: dist/
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -51,11 +51,11 @@ jobs:
     environment: production # sets in github repo with reviewer requirement protection rule
     steps:
       - uses: actions/checkout@v3
-      - name: Download build-output artifact
+      - name: Download build-output-EU artifact
         uses: actions/download-artifact@v3
         with:
-          name: build-output
-          path: dist-eu/
+          name: build-output-EU
+          path: dist/
       - name: Authenticate to Google Cloud
         id: auth
         uses: google-github-actions/auth@v0
@@ -64,7 +64,7 @@ jobs:
       - name: Deploy to GCP Bucket
         uses: google-github-actions/upload-cloud-storage@v0
         with:
-          path: dist-eu/
+          path: dist/
           parent: false
           destination: assets-eu.sitescdn.net/${{ inputs.bucket }}/${{ inputs.directory }}
           headers: |-

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -15,9 +15,9 @@ jobs:
           node-version: 16
           cache: 'npm'
       - run: npm ci
-      - name: Download build-output artifact
+      - name: Download build-output-US artifact
         uses: actions/download-artifact@v3
         with:
-          name: build-output
+          name: build-output-US
           path: dist/
       - run: npm run test


### PR DESCRIPTION
Previously the US and EU builds were using the same artifact, but
were using separate directories. There was an issue with the
acceptance tests which I suspect was a bug with this approach, so
I am updating the flow to use separate artificts for the different
regions instead.

J=BACK-2268
TEST=none

I will create a test tag version and confirm the deploy works
correctly
