### PR TITLE
fix: correct implementation of accesssible text for vertical result c…

### DIFF
--- a/conf/i18n/translations/messages.pot
+++ b/conf/i18n/translations/messages.pot
@@ -22,7 +22,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/ui/templates/results/resultsheader.hbs:19
-#: src/ui/templates/results/verticalresultscount.hbs:3
 msgid "[[start]] through [[end]] of [[resultsCount]]"
 msgstr ""
 
@@ -360,14 +359,14 @@ msgctxt "Example: 1-10 of 50"
 msgid "<span class=\"yxt-ResultsHeader-resultsCountStart\">[[start]]</span> <span class=\"yxt-ResultsHeader-resultsCountDash\">-</span> <span class=\"yxt-ResultsHeader-resultsCountEnd\">[[end]]</span> <span class=\"yxt-ResultsHeader-resultsCountOf\">of</span> <span class=\"yxt-ResultsHeader-resultsCountTotal\">[[resultsCount]]</span>"
 msgstr ""
 
-#: src/ui/templates/results/verticalresultscount.hbs:5
+#: src/ui/templates/results/verticalresultscount.hbs:3
 msgctxt "Example: 1-10 of 50"
 msgid ""
 "<span class=\"yxt-VerticalResultsCount-start\">[[start]]</span>\n"
-"<span class=\"yxt-VerticalResultsCount-dash\">-</span>\n"
-"<span class=\"yxt-VerticalResultsCount-end\">[[end]]</span>\n"
-"<span class=\"yxt-VerticalResultsCount-of\">of</span>\n"
-"<span class=\"yxt-VerticalResultsCount-total\">[[resultsCount]]</span>"
+"    <span class=\"yxt-VerticalResultsCount-dash\">-</span>\n"
+"    <span class=\"yxt-VerticalResultsCount-end\">[[end]]</span>\n"
+"    <span class=\"yxt-VerticalResultsCount-of\">of</span>\n"
+"    <span class=\"yxt-VerticalResultsCount-total\">[[resultsCount]]</span>"
 msgstr ""
 
 #: src/ui/components/search/spellcheckcomponent.js:9

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Javascript Search Programming Interface",
   "main": "dist/answers-umd.js",
   "repository": {

--- a/src/ui/templates/results/verticalresultscount.hbs
+++ b/src/ui/templates/results/verticalresultscount.hbs
@@ -1,19 +1,16 @@
 {{#unless isHidden}}
-  <div class="yxt-VerticalResultsCount"
-    aria-label="{{translate phrase='[[start]] through [[end]] of [[resultsCount]]' start=pageStart end=pageEnd resultsCount=total }}">
-    <div aria-hidden="true">
+  <div class="yxt-VerticalResultsCount">
       {{translate
         phrase=
-'<span class="yxt-VerticalResultsCount-start">[[start]]</span>
-<span class="yxt-VerticalResultsCount-dash">-</span>
-<span class="yxt-VerticalResultsCount-end">[[end]]</span>
-<span class="yxt-VerticalResultsCount-of">of</span>
-<span class="yxt-VerticalResultsCount-total">[[resultsCount]]</span>'
+    '<span class="yxt-VerticalResultsCount-start">[[start]]</span>
+    <span class="yxt-VerticalResultsCount-dash">-</span>
+    <span class="yxt-VerticalResultsCount-end">[[end]]</span>
+    <span class="yxt-VerticalResultsCount-of">of</span>
+    <span class="yxt-VerticalResultsCount-total">[[resultsCount]]</span>'
         context='Example: 1-10 of 50'
         start=pageStart
         end=pageEnd
         resultsCount=total
       }}
-    </div>
   </div>
 {{/unless}}


### PR DESCRIPTION
…ounts

The current implementation of verticalresultcount.hbs unnecessarily uses an aria-label and aria-hidden property to handle text that is already accessible for a non-interactive element.

J=TECHOPS-9030