### PR TITLE
Update Analytics for EU

### DIFF
--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -1,4 +1,5 @@
-import { PRODUCTION, SANDBOX } from '../constants';
+import { CloudRegion } from '@yext/search-core';
+import { PRODUCTION, SANDBOX, CLOUD_REGION } from '../constants';
 import SearchParams from '../../ui/dom/searchparams';
 import StorageKeys from '../storage/storagekeys';
 import ComponentTypes from '../../ui/components/componenttypes';
@@ -17,6 +18,9 @@ export function getLiveApiUrl (env = PRODUCTION) {
  * @param {boolean} conversionTrackingEnabled If conversion tracking has been opted into.
  */
 export function getAnalyticsUrl (env = PRODUCTION, conversionTrackingEnabled = false) {
+  if (isEu()) {
+    return 'https://www.eu.yextevents.com';
+  }
   if (conversionTrackingEnabled) {
     return env === SANDBOX
       ? 'https://sandbox-realtimeanalytics.yext.com'
@@ -25,6 +29,10 @@ export function getAnalyticsUrl (env = PRODUCTION, conversionTrackingEnabled = f
   return env === SANDBOX
     ? 'https://sandbox-answers.yext-pixel.com'
     : 'https://answers.yext-pixel.com';
+}
+
+function isEu () {
+  return CLOUD_REGION.toLowerCase() === CloudRegion.EU.toString();
 }
 
 /**


### PR DESCRIPTION
When the cloud region is EU, send analytics events to https://www.eu.yextevents.com

J=BACK-2362
TEST=manual

Build EU and US versions locally. Connected them to a test jambo site and confirmed the EU and US events fire properly. Checked the user_events table in the EU and confirmed the events are there.