### PR TITLE
Remove unused ENDPOINTS and update error reporter

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -23,12 +23,3 @@ export const COMPILED_TEMPLATES_URL = `https://assets.sitescdn.net/answers/${LIB
 
 /** The default query source reported with analytics */
 export const QUERY_SOURCE = 'STANDARD';
-
-export const ENDPOINTS = {
-  UNIVERSAL_SEARCH: '/v2/accounts/me/answers/query',
-  VERTICAL_SEARCH: '/v2/accounts/me/answers/vertical/query',
-  QUESTION_SUBMISSION: '/v2/accounts/me/createQuestion',
-  UNIVERSAL_AUTOCOMPLETE: '/v2/accounts/me/answers/autocomplete',
-  VERTICAL_AUTOCOMPLETE: '/v2/accounts/me/answers/vertical/autocomplete',
-  FILTER_SEARCH: '/v2/accounts/me/answers/filtersearch'
-};

--- a/src/core/errors/errorreporter.js
+++ b/src/core/errors/errorreporter.js
@@ -85,7 +85,7 @@ export default class ErrorReporter {
 
     if (this.sendToServer) {
       const requestConfig = {
-        endpoint: '/v2/accounts/me/answers/errors',
+        endpoint: '/v2/accounts/me/search/errors',
         apiKey: this.apiKey,
         version: 20190301,
         environment: this.environment,


### PR DESCRIPTION
In an effort to move the requests to /search instead of /answers, this PR does the following:
- remove ENDPOINTS in constants that's no longer used
- update the endpoint used in error reporter

J=BACK-2365
TEST=auto

Ran `npm run test`