### PR TITLE
Bump Core to v2.4.0

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -487,7 +487,7 @@ CDN
 
 The following NPM package may be included in this product:
 
- - @yext/search-core@2.3.0
+ - @yext/search-core@2.4.0
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.16.2",
+  "version": "1.16.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-search-ui",
-      "version": "1.16.2",
+      "version": "1.16.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/mapbox-gl-language": "^0.10.1",
         "@yext/answers-storage": "^1.1.0",
         "@yext/rtf-converter": "^1.7.1",
-        "@yext/search-core": "^2.3.0",
+        "@yext/search-core": "^2.4.0",
         "bowser": "^2.11.0",
         "cross-fetch": "^3.1.5",
         "css-vars-ponyfill": "^2.4.3",
@@ -3302,9 +3302,9 @@
       }
     },
     "node_modules/@yext/search-core": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.3.0.tgz",
-      "integrity": "sha512-vSvNXWv9E/6s4oRB1og4zHfRTTEHrmUm2sh95Y1Dn94U2mkjNDGSsshEeamU2UIJO7Ee5oT6K6JDU7XAVOxC4A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.4.0.tgz",
+      "integrity": "sha512-slPiKO3lENIB8aqr509ljjkaHJ9UJXnBu0iSv8CAdFsoZomdXTQExlbGBPHVZ6q0rEBahDR4PSMWlvFp9b7yAQ==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"
@@ -25214,9 +25214,9 @@
       }
     },
     "@yext/search-core": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.3.0.tgz",
-      "integrity": "sha512-vSvNXWv9E/6s4oRB1og4zHfRTTEHrmUm2sh95Y1Dn94U2mkjNDGSsshEeamU2UIJO7Ee5oT6K6JDU7XAVOxC4A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.4.0.tgz",
+      "integrity": "sha512-slPiKO3lENIB8aqr509ljjkaHJ9UJXnBu0iSv8CAdFsoZomdXTQExlbGBPHVZ6q0rEBahDR4PSMWlvFp9b7yAQ==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.16.2",
+  "version": "1.16.4",
   "description": "Javascript Search Programming Interface",
   "main": "dist/answers-umd.js",
   "repository": {
@@ -30,7 +30,7 @@
     "@mapbox/mapbox-gl-language": "^0.10.1",
     "@yext/answers-storage": "^1.1.0",
     "@yext/rtf-converter": "^1.7.1",
-    "@yext/search-core": "^2.3.0",
+    "@yext/search-core": "^2.4.0",
     "bowser": "^2.11.0",
     "cross-fetch": "^3.1.5",
     "css-vars-ponyfill": "^2.4.3",


### PR DESCRIPTION
This PR bumps the `search-core` version to v2.4.0 to get support for new Rich Text & Markdown field types returned as
raw html in direct answers (see [release notes](https://github.com/yext/search-core/releases/tag/v2.4.0)). We had already added [support](https://github.com/yext/answers-hitchhiker-theme/pull/1138) to render these fields in the Theme, but without the Core update, a search that returns an `html` field type gives an error and doesn't actually get rendered.

J=TECHOPS-10638
TEST=manual

Point the site from the techops to a locally served version of the SDK with this version bump and see that an HTML field type for a featured snippet direct answer is properly rendered instead of throwing an error.

<img width="1728" alt="Screenshot 2023-11-30 at 4 55 46 PM" src="https://github.com/yext/answers-search-ui/assets/88398086/82233e9d-9d1e-4e26-960a-8b579a0eac4c">

Note: this PR is the same as #1843, but with a corrected version bump (v1.16.4 instead of v1.16.3)