### PR TITLE
Added document vertical segment support

### DIFF
--- a/src/core/models/result.js
+++ b/src/core/models/result.js
@@ -137,7 +137,8 @@ export default class Result {
       distance: result.distance,
       distanceFromFilter: result.distanceFromFilter,
       highlighted: appliedHighlightedFields,
-      highlightedFields
+      highlightedFields,
+      segment: result.segment
     };
 
     if (result.source !== 'KNOWLEDGE_MANAGER') {


### PR DESCRIPTION
Added segment information to be returned in the result data and api response

J=[WAT-4164](https://yexttest.atlassian.net/browse/WAT-4164)
Test: Unit tests all passed and ran localhost to see segments in api response of document vertical search.