### PR TITLE
Update Result object to maintain segment field

### DIFF
--- a/src/core/models/result.js
+++ b/src/core/models/result.js
@@ -146,7 +146,7 @@ export default class Result {
       segment: result.segment
     };
 
-    if (result.source !== 'KNOWLEDGE_MANAGER') {
+    if (result.source !== 'KNOWLEDGE_MANAGER' && result.source !== 'DOCUMENT_VERTICAL') {
       return new Result(resultData);
     }
 

--- a/src/core/models/result.js
+++ b/src/core/models/result.js
@@ -111,6 +111,11 @@ export default class Result {
      * @type {number}
      */
     this.distanceFromFilter = data.distanceFromFilter || null;
+    /**
+     * In the case of a Document Vertical result grouped by segments, the formatted segment data
+     * @type {Object}
+     */
+    this.segment = data.segment || null;
   }
 
   /**

--- a/tests/core/models/result.js
+++ b/tests/core/models/result.js
@@ -24,7 +24,13 @@ it('constructs a result from an answers-core result', () => {
         }]
       }
     },
-    entityType: 'ce_fruit'
+    entityType: 'ce_fruit',
+    segment: {
+      text: 'Some segment ',
+      score: 0.27316594,
+      segmentNumber: 3,
+      fieldId: 'c_segmentField'
+    }
   };
 
   const expectedResult = {
@@ -37,7 +43,13 @@ it('constructs a result from an answers-core result', () => {
     link: 'www.yext.com',
     id: 2,
     distance: 20,
-    distanceFromFilter: 30
+    distanceFromFilter: 30,
+    segment: {
+      text: 'Some segment ',
+      score: 0.27316594,
+      segmentNumber: 3,
+      fieldId: 'c_segmentField'
+    }
   };
 
   const actualResult = Result.fromCore(coreResult);


### PR DESCRIPTION
We recently added segment support to the result object, but without adding a segment field to the constructor the field is lost
J=WAT-4183
TEST=auto

Added to test