### PR TITLE
Answers SDK: add cloudChoice support

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -487,7 +487,7 @@ CDN
 
 The following NPM package may be included in this product:
 
- - @yext/search-core@2.5.1
+ - @yext/search-core@2.5.4
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mapbox/mapbox-gl-language": "^0.10.1",
         "@yext/answers-storage": "^1.1.0",
         "@yext/rtf-converter": "^1.7.1",
-        "@yext/search-core": "^2.5.1",
+        "@yext/search-core": "^2.5.4",
         "bowser": "^2.11.0",
         "cross-fetch": "^3.1.5",
         "css-vars-ponyfill": "^2.4.3",
@@ -3611,9 +3611,9 @@
       }
     },
     "node_modules/@yext/search-core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.5.1.tgz",
-      "integrity": "sha512-Xdq5k1xuf1iueADcsoAGdtX5PV4NcZlMj03RYuDP9Jylm7rSSw+KDIUIh/lC7sFpzp3jKDW5jgH3NHz2dB3fZA==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.5.4.tgz",
+      "integrity": "sha512-KvBeBlBMq9rVrC83gvXw1JOpoILxiXdL1jndILvQbKsvVB8jK0qIa92khU3jUnRYkB9bRX9Iylzy8DIALjlCFw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"
@@ -25779,9 +25779,9 @@
       }
     },
     "@yext/search-core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.5.1.tgz",
-      "integrity": "sha512-Xdq5k1xuf1iueADcsoAGdtX5PV4NcZlMj03RYuDP9Jylm7rSSw+KDIUIh/lC7sFpzp3jKDW5jgH3NHz2dB3fZA==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.5.4.tgz",
+      "integrity": "sha512-KvBeBlBMq9rVrC83gvXw1JOpoILxiXdL1jndILvQbKsvVB8jK0qIa92khU3jUnRYkB9bRX9Iylzy8DIALjlCFw==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@mapbox/mapbox-gl-language": "^0.10.1",
     "@yext/answers-storage": "^1.1.0",
     "@yext/rtf-converter": "^1.7.1",
-    "@yext/search-core": "^2.5.1",
+    "@yext/search-core": "^2.5.4",
     "bowser": "^2.11.0",
     "cross-fetch": "^3.1.5",
     "css-vars-ponyfill": "^2.4.3",

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -1,7 +1,7 @@
 /** @module Core */
 import { provideCore } from '@yext/search-core/lib/commonjs';
 // Using the ESM build for importing the Environment enum due to an issue importing the commonjs version
-import { Environment } from '@yext/search-core';
+import { CloudChoice, Environment } from '@yext/search-core';
 import { generateUUID } from './utils/uuid';
 import SearchDataTransformer from './search/searchdatatransformer';
 
@@ -120,6 +120,12 @@ export default class Core {
      */
     this._cloudRegion = CLOUD_REGION;
 
+    /**
+     * Determines the cloud choice of the api endpoints used when making search requests.
+     * @type {string}
+     */
+    this._cloudChoice = config.cloudChoice || CloudChoice.GLOBAL_MULTI;
+
     /** @type {string} */
     this._verticalKey = config.verticalKey;
 
@@ -154,6 +160,7 @@ export default class Core {
         jsLibVersion: LIB_VERSION
       },
       cloudRegion: this._cloudRegion,
+      cloudChoice: this._cloudChoice,
       environment,
       ...config
     };


### PR DESCRIPTION
Now that cloudChoice is a param inside of search-core, this CR adds support for setting it in the SDK, in the init() function, including setting the old behavior as the default. It is not needed elsewhere like with the CLOUD_REGION setting, as that is used for things like analytics tracking.

J=WAT-4375
TEST=auto

Ran test suite