### PR TITLE
ksearch: properly use cloudChoice

### DIFF
--- a/src/answers-search-bar.js
+++ b/src/answers-search-bar.js
@@ -194,7 +194,8 @@ class AnswersSearchBar {
       onVerticalSearch: parsedConfig.onVerticalSearch,
       onUniversalSearch: parsedConfig.onUniversalSearch,
       environment: parsedConfig.environment,
-      componentManager: this.components
+      componentManager: this.components,
+      cloudChoice: parsedConfig.cloudChoice
     });
 
     if (parsedConfig.onStateChange && typeof parsedConfig.onStateChange === 'function') {

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -293,7 +293,8 @@ class Answers {
       onUniversalSearch: parsedConfig.onUniversalSearch,
       environment: parsedConfig.environment,
       componentManager: this.components,
-      additionalHttpHeaders: parsedConfig.additionalHttpHeaders
+      additionalHttpHeaders: parsedConfig.additionalHttpHeaders,
+      cloudChoice: parsedConfig.cloudChoice
     });
 
     if (parsedConfig.onStateChange && typeof parsedConfig.onStateChange === 'function') {

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -11,10 +11,10 @@ export const SPEECH_RECOGNITION_LOCALES_SUPPORTED_BY_EDGE = '@@SPEECH_RECOGNITIO
 
 /** The cloud region being used, injected by the build process */
 export const CLOUD_REGION = '@@CLOUD_REGION';
-/** The identifier of the production environment */
+/** The identifier for all cloud providers */
 export const GLOBAL_MULTI = 'multi';
 
-/** The identifier of the sandbox environment */
+/** The identifier for using GCP */
 export const GLOBAL_GCP = 'gcp';
 
 /** The identifier of the production environment */

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -11,6 +11,11 @@ export const SPEECH_RECOGNITION_LOCALES_SUPPORTED_BY_EDGE = '@@SPEECH_RECOGNITIO
 
 /** The cloud region being used, injected by the build process */
 export const CLOUD_REGION = '@@CLOUD_REGION';
+/** The identifier of the production environment */
+export const GLOBAL_MULTI = 'multi';
+
+/** The identifier of the sandbox environment */
+export const GLOBAL_GCP = 'gcp';
 
 /** The identifier of the production environment */
 export const PRODUCTION = 'production';

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -19,7 +19,7 @@ import FilterRegistry from './filters/filterregistry';
 import DirectAnswer from './models/directanswer';
 import AutoCompleteResponseTransformer from './search/autocompleteresponsetransformer';
 
-import { PRODUCTION, LIB_VERSION, CLOUD_REGION, SANDBOX } from './constants';
+import { PRODUCTION, LIB_VERSION, CLOUD_REGION, SANDBOX, GLOBAL_MULTI, GLOBAL_GCP } from './constants';
 import { SearchParams } from '../ui';
 import SearchStates from './storage/searchstates';
 import Searcher from './models/searcher';
@@ -150,6 +150,7 @@ export default class Core {
    */
   init (config) {
     const environment = this._environment === SANDBOX ? Environment.SANDBOX : Environment.PROD;
+    const cloudChoice = this._cloudChoice === GLOBAL_GCP ? CloudChoice.GLOBAL_GCP : CloudChoice.GLOBAL_MULTI;
     const params = {
       ...(this._token && { token: this._token }),
       ...(this._apiKey && { apiKey: this._apiKey }),
@@ -160,7 +161,7 @@ export default class Core {
         jsLibVersion: LIB_VERSION
       },
       cloudRegion: this._cloudRegion,
-      cloudChoice: this._cloudChoice,
+      cloudChoice,
       environment,
       ...config
     };

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -124,7 +124,7 @@ export default class Core {
      * Determines the cloud choice of the api endpoints used when making search requests.
      * @type {string}
      */
-    this._cloudChoice = config.cloudChoice || CloudChoice.GLOBAL_MULTI;
+    this._cloudChoice = config.cloudChoice || GLOBAL_MULTI;
 
     /** @type {string} */
     this._verticalKey = config.verticalKey;


### PR DESCRIPTION
A previous change to add cloudChoice support wasn't quite right. This CR corrects the logic, and makes sure to pass it everywhere.

J=WAT-4375
TEST=manual

Linked a local theme to a local sdk, and saw the cloudChoice param be used correctly