### PR TITLE
ksearch: add cloud choice to analytics reporting

### DIFF
--- a/src/answers-search-bar.js
+++ b/src/answers-search-bar.js
@@ -177,7 +177,8 @@ class AnswersSearchBar {
         parsedConfig.businessId,
         parsedConfig.analyticsEventsEnabled,
         parsedConfig.analyticsOptions,
-        parsedConfig.environment);
+        parsedConfig.environment,
+        parsedConfig.cloudChoice);
 
       this.components.setAnalyticsReporter(this._analyticsReporterService);
     }

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -262,7 +262,8 @@ class Answers {
         parsedConfig.businessId,
         parsedConfig.analyticsEventsEnabled,
         parsedConfig.analyticsOptions,
-        parsedConfig.environment);
+        parsedConfig.environment,
+        parsedConfig.cloudChoice);
 
       // listen to query id updates
       storage.registerListener({

--- a/src/core/analytics/analyticsreporter.js
+++ b/src/core/analytics/analyticsreporter.js
@@ -19,7 +19,8 @@ export default class AnalyticsReporter {
     businessId,
     analyticsEventsEnabled,
     globalOptions = {},
-    environment = PRODUCTION) {
+    environment = PRODUCTION,
+    cloudChoice) {
     /**
      * The internal business identifier used for reporting
      * @type {number}
@@ -47,11 +48,18 @@ export default class AnalyticsReporter {
     this._environment = environment;
 
     /**
+     * The choice of Cloud Provider
+     * @type {string}
+     * @private
+     */
+    this._cloudChoice = cloudChoice;
+
+    /**
      * Base URL for the analytics API
      * @type {string}
      * @private
      */
-    this._baseUrl = getAnalyticsUrl(this._environment);
+    this._baseUrl = getAnalyticsUrl(this._environment, this._cloudChoice);
 
     /**
      * Boolean indicating if opted in or out of conversion tracking
@@ -134,6 +142,5 @@ export default class AnalyticsReporter {
   /** @inheritdoc */
   setConversionTrackingEnabled (isEnabled) {
     this._conversionTrackingEnabled = isEnabled;
-    this._baseUrl = getAnalyticsUrl(this._environment, isEnabled);
   }
 }

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -1,5 +1,5 @@
 import { CloudRegion } from '@yext/search-core';
-import { PRODUCTION, SANDBOX, CLOUD_REGION } from '../constants';
+import { PRODUCTION, SANDBOX, CLOUD_REGION, GLOBAL_MULTI, GLOBAL_GCP } from '../constants';
 import SearchParams from '../../ui/dom/searchparams';
 import StorageKeys from '../storage/storagekeys';
 import ComponentTypes from '../../ui/components/componenttypes';
@@ -14,21 +14,20 @@ export function getLiveApiUrl (env = PRODUCTION) {
 
 /**
  * Returns the base url for the analytics backend in the desired environment.
- * @param {string} env The desired environment.
- * @param {boolean} conversionTrackingEnabled If conversion tracking has been opted into.
+ * @param {string} env The desired environment.]
+ * @param {string} cloudChoice The choice of cloud provider.
  */
-export function getAnalyticsUrl (env = PRODUCTION, conversionTrackingEnabled = false) {
-  if (isEu()) {
-    return 'https://www.eu.yextevents.com';
+export function getAnalyticsUrl (env = PRODUCTION, cloudChoice = GLOBAL_MULTI) {
+  const cloudRegionString = isEu() ? 'eu' : 'us';
+  let envAndCloudChoice = '';
+  if (env === SANDBOX && cloudChoice === GLOBAL_GCP) {
+    envAndCloudChoice = 'sandbox-gcp.';
+  } else if (env === SANDBOX) {
+    envAndCloudChoice = 'sandbox.';
+  } else if (cloudChoice === GLOBAL_GCP) {
+    envAndCloudChoice = 'gcp.';
   }
-  if (conversionTrackingEnabled) {
-    return env === SANDBOX
-      ? 'https://sandbox-realtimeanalytics.yext.com'
-      : 'https://realtimeanalytics.yext.com';
-  }
-  return env === SANDBOX
-    ? 'https://sandbox-answers.yext-pixel.com'
-    : 'https://answers.yext-pixel.com';
+  return 'https://' + envAndCloudChoice + cloudRegionString + '.yextevents.com';
 }
 
 function isEu () {

--- a/tests/core/utils/urlutils.js
+++ b/tests/core/utils/urlutils.js
@@ -20,12 +20,12 @@ describe('getUrlFunctions work', () => {
     expect(getAnalyticsUrl(SANDBOX)).toEqual(expect.stringContaining('sandbox'));
   });
 
-  it('differentiates conversion tracking in analytics url', () => {
-    expect(getAnalyticsUrl(PRODUCTION, true)).toEqual(expect.stringContaining('realtimeanalytics'));
-    expect(getAnalyticsUrl(SANDBOX, true)).toEqual(expect.stringContaining('realtimeanalytics'));
+  it('differentiates gcp from global', () => {
+    expect(getAnalyticsUrl(PRODUCTION, 'gcp')).toEqual(expect.stringContaining('gcp'));
+    expect(getAnalyticsUrl(SANDBOX, 'gcp')).toEqual(expect.stringContaining('sandbox-gcp'));
 
-    expect(getAnalyticsUrl(PRODUCTION)).not.toEqual(expect.stringContaining('realtimeanalytics'));
-    expect(getAnalyticsUrl(SANDBOX)).not.toEqual(expect.stringContaining('realtimeanalytics'));
+    expect(getAnalyticsUrl(PRODUCTION)).not.toEqual(expect.stringContaining('gcp'));
+    expect(getAnalyticsUrl(SANDBOX)).not.toEqual(expect.stringContaining('sandbox-gcp'));
   });
 });
 


### PR DESCRIPTION
This PR leverages the new cloud provider-specific endpoints for analytics reporting. Also consolidates old logic now that one url is replacing all older ones.

J=WAT-4461
TEST=manual, auto

Updated unit tests. Ran locally with gcp and saw expected analytics endpoint hit.