### PR TITLE
Add GDA Object Model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.17.8",
+  "version": "1.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-search-ui",
-      "version": "1.17.8",
+      "version": "1.18.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/mapbox-gl-language": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.17.8",
+  "version": "1.18.0",
   "description": "Javascript Search Programming Interface",
   "main": "dist/answers-umd.js",
   "repository": {

--- a/src/core/models/generativedirectanswer.js
+++ b/src/core/models/generativedirectanswer.js
@@ -1,0 +1,36 @@
+/** @module GenerativeDirectAnswer */
+
+import SearchStates from '../storage/searchstates';
+
+export default class GenerativeDirectAnswer {
+  constructor (generativeDirectAnswer = {}) {
+    Object.assign(this, { searchState: SearchStates.SEARCH_COMPLETE }, generativeDirectAnswer);
+  }
+
+  /**
+   * Constructs an SDK GenerativeDirectAnswer from a search-core GenerativeDirectAnswerResponse
+   *
+   * @param {GenerativeDirectAnswerResponse} gdaResponse from search-core
+   * @param {string} searcher whether this generative direct answer is from a "UNIVERSAL" or "VERTICAL" search
+   * @returns {GenerativeDirectAnswer}
+   */
+  static fromCore (gdaResponse, searcher) {
+    if (!gdaResponse) {
+      return new GenerativeDirectAnswer();
+    }
+
+    const generativeDirectAnswerData = {
+      ...gdaResponse,
+      searcher
+    };
+    return new GenerativeDirectAnswer(generativeDirectAnswerData);
+  }
+
+  /**
+   * Construct a GenerativeDirectAnswer object representing loading result
+   * @return {GenerativeDirectAnswer}
+   */
+  static searchLoading () {
+    return new GenerativeDirectAnswer({ searchState: SearchStates.SEARCH_LOADING });
+  }
+}

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -13,6 +13,7 @@ const StorageKeys = {
   ALTERNATIVE_VERTICALS: 'alternative-verticals',
   AUTOCOMPLETE: 'autocomplete',
   DIRECT_ANSWER: 'direct-answer',
+  GENERATIVE_DIRECT_ANSWER: 'generative-direct-answer',
   FILTER: 'filter', // DEPRECATED
   PERSISTED_FILTER: 'filters',
   STATIC_FILTER_NODES: 'static-filter-nodes',

--- a/tests/core/models/generativedirectanswer.js
+++ b/tests/core/models/generativedirectanswer.js
@@ -1,0 +1,24 @@
+import GenerativeDirectAnswer from '../../../src/core/models/generativedirectanswer';
+import Searcher from '../../../src/core/models/searcher';
+
+it('constructs a generative direct answer from an answers-core generative direct answer response', () => {
+  const coreGenerativeDirectAnswerResponse = {
+    directAnswer: 'This is some generated text.',
+    resultStatus: 'SUCCESS',
+    citations: ['uuid-1', 'uuid-2', 'uuid-3']
+  };
+
+  const expectedGenerativeDirectAnswer = {
+    directAnswer: 'This is some generated text.',
+    resultStatus: 'SUCCESS',
+    citations: ['uuid-1', 'uuid-2', 'uuid-3'],
+    searcher: Searcher.UNIVERSAL
+  };
+
+  const actualGenerativeDirectAnswer = GenerativeDirectAnswer.fromCore(
+    coreGenerativeDirectAnswerResponse,
+    Searcher.UNIVERSAL
+  );
+
+  expect(actualGenerativeDirectAnswer).toMatchObject(expectedGenerativeDirectAnswer);
+});


### PR DESCRIPTION
Similar to the existing `DirectAnswer` model, we will take in an object from `search-core` (`GenerativeDirectAnswerResponse` in this case) and use it to construct a model.

J=WAT-4592
TEST=auto
Ran unit tests