### PR TITLE
Adjust GDA custom card logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.18.0-beta.1",
+  "version": "1.18.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-search-ui",
-      "version": "1.18.0-beta.1",
+      "version": "1.18.0-beta.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/mapbox-gl-language": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.18.0-beta.1",
+  "version": "1.18.0-beta.2",
   "description": "Javascript Search Programming Interface",
   "main": "dist/answers-umd.js",
   "repository": {

--- a/src/ui/components/results/generativedirectanswercomponent.js
+++ b/src/ui/components/results/generativedirectanswercomponent.js
@@ -168,7 +168,11 @@ export default class GenerativeDirectAnswerComponent extends Component {
     this.updateContainerClass(searchState);
     if (searchState !== SearchStates.SEARCH_COMPLETE || !data.directAnswer) {
       return super.setState(Object.assign({}, data, {
-        searchState
+        searchState,
+        generativeDirectAnswer: {
+          searchState
+        },
+        customCard: this._getCard()
       }));
     }
 
@@ -190,7 +194,8 @@ export default class GenerativeDirectAnswerComponent extends Component {
 
   addChild (data, type, opts) {
     if (type === this.getState('customCard')) {
-      return super.addChild(this.getState('generativeDirectAnswer'), type, {
+      const customCardData = this.getState('generativeDirectAnswer');
+      return super.addChild(customCardData, type, {
         ...this._userConfig,
         ...opts
       });


### PR DESCRIPTION
Previously if the GDA was in a loading state, we would still be using the default card even when a custom card was set up in the theme. Now we will use the custom card in this case.