### PR TITLE
Upgrade Node to 20 for tests, and ubuntu-latest

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 16
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           cache: 'npm'
       - run: npm ci
       - name: Download build-output-US artifact

--- a/.github/workflows/acceptance_search_bar.yml
+++ b/.github/workflows/acceptance_search_bar.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 16
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           cache: 'npm'
       - run: npm ci
       - name: Download build-output-US artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Use Node.js 16
+    - name: Use Node.js 20
       uses: actions/setup-node@v4
       with:
-        node-version: 16
+        node-version: 20
         cache: 'npm'
     - run: npm ci
     - run: npm run ${{ inputs.build_script }}

--- a/.github/workflows/build_i18n.yml
+++ b/.github/workflows/build_i18n.yml
@@ -23,7 +23,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-node@v4
       with:
-        node-version: 16
+        node-version: 20
         cache: 'npm'
     - id: set-matrix
       run: |
@@ -39,10 +39,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Use Node.js 16
+    - name: Use Node.js 20
       uses: actions/setup-node@v4
       with:
-        node-version: 16
+        node-version: 20
         cache: 'npm'
     - run: npm ci
     - run: LANGUAGE=${{ matrix.language }} CLOUD_REGION=${{ inputs.cloud_region }} npm run ${{ inputs.build_script }}
@@ -55,7 +55,7 @@ jobs:
       with:
         name: build-output-${{ inputs.cloud_region }}-${{ matrix.language }}
         path: dist/
-        
+
   merge_multiple_artifacts:
       needs: build
       runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   semgrep:
     name: semgrep/ci
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN_VACCINE }}
     container:

--- a/.github/workflows/miscellaneous_tests.yml
+++ b/.github/workflows/miscellaneous_tests.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 16
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           cache: 'npm'
       - run: npm ci
       - run: sudo apt-get install -qq gettext

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 16
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           cache: 'npm'
       - run: npm ci
       - name: Download build-output-US artifact


### PR DESCRIPTION
This PR is aimed to improve test reliability. At the very least, node 16 is deprecated so it's probably good to upgrade to 20 anyway.