### PR TITLE
GDA handle empty query and error state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.18.0",
+  "version": "1.18.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-search-ui",
-      "version": "1.18.0",
+      "version": "1.18.1-beta.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/mapbox-gl-language": "^0.10.1",
@@ -3706,7 +3706,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.6.0.tgz",
       "integrity": "sha512-y3eHaD3ojbCcOa0DWvRk6Ox6SpwWxKWdPkDLeSJlIybbdjVqlNIJ4MpfZRtZ5ei/G36aEmpZ53gY7cRgH3u5Lg==",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"
@@ -8336,7 +8335,6 @@
       "resolved": "https://registry.npmjs.org/esotope-hammerhead/-/esotope-hammerhead-0.6.9.tgz",
       "integrity": "sha512-rD9Jbh0SFJzKe1RGfsbwpN5IBdubHKC61xRW7A5BPgBTtEnFxsWOqPITVhBaVDc4r5VPmh+Y1U1wmqReTfn1AQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "0.0.46"
       }
@@ -8345,8 +8343,7 @@
       "version": "0.0.46",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
       "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/espree": {
       "version": "9.6.1",
@@ -10118,6 +10115,32 @@
       "dev": true,
       "dependencies": {
         "rollup": "^1.4.1"
+      }
+    },
+    "node_modules/gulp-rollup-lightweight/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/gulp-rollup-lightweight/node_modules/rollup": {
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
       }
     },
     "node_modules/gulp-rtlcss": {
@@ -22150,7 +22173,6 @@
       "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-3.7.2.tgz",
       "integrity": "sha512-1XNc764DlIfmev7JHwzVP2l7ZHQin9nTsM9fBB0yd3naAJn+VUR9kUe7J1PSxk+nJkhkBvsSmQSlppj527JGAA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.23.2",
         "@babel/plugin-proposal-decorators": "^7.23.2",
@@ -22435,7 +22457,6 @@
       "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-31.7.5.tgz",
       "integrity": "sha512-XnDtvrpiwoxMPhC9A3eFOPeE0erDF0iae5t23yaYB4lVQCRuEoNfg5Lv4vGvDhbJ2n2fpzOre4Lhvz12mac0tw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@adobe/css-tools": "^4.3.0-rc.1",
         "@electron/asar": "^3.2.3",
@@ -22507,7 +22528,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
       "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": "20 || >=22"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.18.0",
+  "version": "1.18.1-beta.1",
   "description": "Javascript Search Programming Interface",
   "main": "dist/answers-umd.js",
   "repository": {

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -464,7 +464,7 @@ export default class Core {
         const generativeDirectAnswer = GenerativeDirectAnswer.fromCore(response, searcher, verticalResults);
         this.storage.set(StorageKeys.GENERATIVE_DIRECT_ANSWER, generativeDirectAnswer);
       }).catch(error => {
-        this.storage.delete(StorageKeys.GENERATIVE_DIRECT_ANSWER);
+        this.storage.set(StorageKeys.GENERATIVE_DIRECT_ANSWER, new GenerativeDirectAnswer({}));
         console.error('Failed to generate direct answer with the following error: ' + error);
       });
   }

--- a/src/core/statelisteners/resultsupdatelistener.js
+++ b/src/core/statelisteners/resultsupdatelistener.js
@@ -62,7 +62,8 @@ export default class ResultsUpdateListener {
      * @param {string} searcher the type of search that generated these results
      */
   _handleVerticalResultsUpdate (verticalResultsList, searcher) {
-    if (!verticalResultsList || verticalResultsList.length === 0) {
+    const searchTerm = this.core.storage.get(StorageKeys.QUERY);
+    if (!verticalResultsList || verticalResultsList.length === 0 || !searchTerm) {
       this.core.storage.set(StorageKeys.GENERATIVE_DIRECT_ANSWER, new GenerativeDirectAnswer({}));
       return;
     }

--- a/tests/core/statelisteners/resultsupdatelistener.js
+++ b/tests/core/statelisteners/resultsupdatelistener.js
@@ -183,12 +183,38 @@ describe('_handleVerticalResultsUpdate', () => {
     );
     expect(_handleVerticalResultsUpdate).toHaveBeenCalledTimes(0);
   });
+
+  it('is not called when the search term is empty', () => {
+    const resultsUpdateListener = initResultsUpdateListener();
+    const _handleVerticalResultsUpdate = jest.fn();
+    resultsUpdateListener._handleVerticalResultsUpdate = _handleVerticalResultsUpdate;
+    expect(_handleVerticalResultsUpdate).toHaveBeenCalledTimes(0);
+    const searchCoreDocument = {
+      field1: 'field1 of search document',
+      field2: 'field2 of search document'
+    };
+    const fakeVerticalResults = {
+      searchState: SearchStates.SEARCH_COMPLETE,
+      searchCoreDocument
+    };
+    resultsUpdateListener.core.storage.setWithPersist(
+      StorageKeys.QUERY,
+      ''
+    );
+    resultsUpdateListener.core.storage.setWithPersist(
+      StorageKeys.VERTICAL_RESULTS,
+      fakeVerticalResults
+    );
+    expect(resultsUpdateListener.core.generativeDirectAnswer).toHaveBeenCalledTimes(0);
+  });
 });
 
 function initResultsUpdateListener (config) {
+  const storage = new Storage().init();
+  storage.setWithPersist(StorageKeys.QUERY, 'something');
   const mockCore = {
     generativeDirectAnswer: jest.fn(),
-    storage: new Storage().init()
+    storage
   };
 
   return new ResultsUpdateListener(mockCore);


### PR DESCRIPTION
### Improve GDA error handling

This PR includes two changes:
1. Don't attempt GDA if the query is blank (this will cause an error)
2. If we get an error from the GDA endpoint, set the GDA state to an empty GDA object, rather than deleting the entry. Previously, if an error occurred, we would see `AI Generating Answer...` stuck at the top of the screen

J=[WAT-4682](https://yexttest.atlassian.net/browse/WAT-4682?atlOrigin=eyJpIjoiYmZlMjUxNzE5M2FmNGUzNzljNzA2NzIzZGM3ZGZkNDEiLCJwIjoiaiJ9)