### PR TITLE
Include full entity data in GDA citations

### DIFF
--- a/src/core/models/generativedirectanswer.js
+++ b/src/core/models/generativedirectanswer.js
@@ -33,7 +33,7 @@ export default class GenerativeDirectAnswer {
           id: result.id,
           name: result.name,
           description: result.description,
-          link: result.link
+          rawData: result.rawData
         };
       });
 

--- a/src/ui/templates/results/generativedirectanswer.hbs
+++ b/src/ui/templates/results/generativedirectanswer.hbs
@@ -26,7 +26,6 @@
       <div class="yxt-GenerativeDirectAnswer-citationsScroller">
           {{#each generativeDirectAnswer.citationsData}}
           <a class="yxt-GenerativeDirectAnswer-citationCard js-gda-citation"
-            {{#if this.link}}href={{this.link}}{{/if}}
             data-entityid={{this.id}}
             data-eventtype="CITATION_CLICK"
             data-is-analytics-attached="true"

--- a/tests/core/models/generativedirectanswer.js
+++ b/tests/core/models/generativedirectanswer.js
@@ -21,7 +21,6 @@ describe('Constructs a generative direct answer from an answers-core generative 
             },
             name: 'name-1',
             description: 'description-1',
-            link: 'link-1',
             otherData: 'otherData'
           }
         ],
@@ -38,7 +37,6 @@ describe('Constructs a generative direct answer from an answers-core generative 
             },
             name: 'name-2',
             description: 'description-2',
-            link: 'link-2',
             otherData: 'otherData'
           },
           {
@@ -48,7 +46,6 @@ describe('Constructs a generative direct answer from an answers-core generative 
               someField: 'someValue'
             },
             name: 'name-3',
-            link: 'link-3',
             otherData: 'otherData'
           },
           {
@@ -58,7 +55,6 @@ describe('Constructs a generative direct answer from an answers-core generative 
               someField: 'someValue'
             },
             name: 'name-4',
-            link: 'link-4',
             otherData: 'otherData'
           }
         ],
@@ -78,18 +74,27 @@ describe('Constructs a generative direct answer from an answers-core generative 
           id: 'entityid-1',
           name: 'name-1',
           description: 'description-1',
-          link: 'link-1'
+          rawData: {
+            uid: 'uuid-1',
+            someField: 'someValue'
+          }
         },
         {
           id: 'entityid-2',
           name: 'name-2',
           description: 'description-2',
-          link: 'link-2'
+          rawData: {
+            uid: 'uuid-2',
+            someField: 'someValue'
+          }
         },
         {
           id: 'entityid-3',
           name: 'name-3',
-          link: 'link-3'
+          rawData: {
+            uid: 'uuid-3',
+            someField: 'someValue'
+          }
         }
       ],
       verticalKey: ''
@@ -122,7 +127,6 @@ describe('Constructs a generative direct answer from an answers-core generative 
             },
             name: 'name-2',
             description: 'description-2',
-            link: 'link-2',
             otherData: 'otherData'
           },
           {
@@ -132,7 +136,6 @@ describe('Constructs a generative direct answer from an answers-core generative 
               someField: 'someValue'
             },
             name: 'name-3',
-            link: 'link-3',
             otherData: 'otherData'
           },
           {
@@ -142,7 +145,6 @@ describe('Constructs a generative direct answer from an answers-core generative 
               someField: 'someValue'
             },
             name: 'name-4',
-            link: 'link-4',
             otherData: 'otherData'
           }
         ],
@@ -162,12 +164,18 @@ describe('Constructs a generative direct answer from an answers-core generative 
           id: 'entityid-2',
           name: 'name-2',
           description: 'description-2',
-          link: 'link-2'
+          rawData: {
+            uid: 'uuid-2',
+            someField: 'someValue'
+          }
         },
         {
           id: 'entityid-3',
           name: 'name-3',
-          link: 'link-3'
+          rawData: {
+            uid: 'uuid-3',
+            someField: 'someValue'
+          }
         }
       ],
       verticalKey: 'vertical-key-2'

--- a/tests/ui/components/results/generativedirectanswercomponent.js
+++ b/tests/ui/components/results/generativedirectanswercomponent.js
@@ -17,12 +17,18 @@ const gdaSuccess = {
     {
       id: '123454321',
       name: 'Bob Kitty',
-      description: 'I am a cat'
+      description: 'I am a cat',
+      rawData: {
+        uid: '1234'
+      }
     },
     {
       id: '567898765',
       name: 'Joe Cat',
-      link: 'https://yext.com'
+      rawData: {
+        uid: '5678',
+        website: 'https://yext.com'
+      }
     }
   ],
   directAnswer: RichTextFormatter.format(directAnswerPlainText, 'gda-snippet'),
@@ -97,8 +103,6 @@ describe('GenerativeDirectAnswerComponent renders properly', () => {
     expect(firstCitationName).toEqual('Bob Kitty');
     const firstCitationDescription = firstCitation.find('.yxt-GenerativeDirectAnswer-citationDescription').text().trim();
     expect(firstCitationDescription).toEqual('I am a cat');
-    const firstCitationLink = firstCitation.prop('href');
-    expect(firstCitationLink).toBeUndefined();
     const firstEntityId = firstCitation.prop('data-entityid');
     expect(firstEntityId).toEqual('123454321');
     const firstCitationClickEventType = firstCitation.prop('data-eventtype');
@@ -109,8 +113,6 @@ describe('GenerativeDirectAnswerComponent renders properly', () => {
     expect(secondCitationName).toEqual('Joe Cat');
     const secondCitationDescription = secondCitation.find('.yxt-GenerativeDirectAnswer-citationDescription');
     expect(secondCitationDescription.exists()).toBeFalsy();
-    const secondCitationLink = secondCitation.prop('href');
-    expect(secondCitationLink).toEqual('https://yext.com');
     const secondEntityId = secondCitation.prop('data-entityid');
     expect(secondEntityId).toEqual('567898765');
     const secondCitationClickEventType = secondCitation.prop('data-eventtype');


### PR DESCRIPTION
In this change we have the following changes:
- Pass raw data from entity result to GDA component (this will allow customization of what data is shown or used in the GDA component)
- No longer include links on the citations in the default GDA template. This should not be an issue as no one should be using the default template from this repo
J=[WAT-4680](https://yexttest.atlassian.net/browse/WAT-4680?atlOrigin=eyJpIjoiMmE2Y2M2MzU5MTY1NDcxZThkYWIyY2I1YzVmMjdkMzMiLCJwIjoiaiJ9)