### PR TITLE
Deduplicate generative answer sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-search-ui",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/mapbox-gl-language": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "description": "Javascript Search Programming Interface",
   "main": "dist/answers-umd.js",
   "repository": {

--- a/src/core/models/generativedirectanswer.js
+++ b/src/core/models/generativedirectanswer.js
@@ -24,10 +24,16 @@ export default class GenerativeDirectAnswer {
 
     const verticalKey = searcher === Searcher.UNIVERSAL ? '' : verticalResults[0].verticalKey;
 
+    const citationIds = new Set(gdaResponse.citations);
     const citationsData = verticalResults
       .flatMap(vr => vr.results)
-      .filter(result => result.rawData?.uid && result.id && result.name)
-      .filter(result => gdaResponse.citations.includes(result.rawData.uid))
+      .filter(result => {
+        if (!result.rawData?.uid || !result.id || !result.name || !citationIds.has(result.rawData.uid)) {
+          return false;
+        }
+        citationIds.delete(result.rawData.uid);
+        return true;
+      })
       .map(result => {
         return {
           id: result.id,

--- a/tests/core/models/generativedirectanswer.js
+++ b/tests/core/models/generativedirectanswer.js
@@ -189,4 +189,85 @@ describe('Constructs a generative direct answer from an answers-core generative 
 
     expect(actualGenerativeDirectAnswer).toMatchObject(expectedGenerativeDirectAnswer);
   });
+
+  it('GDA citations on universal search are deduplicated', () => {
+    const coreGenerativeDirectAnswerResponse = {
+      directAnswer: 'This is some generated text **with bold**.',
+      resultStatus: 'SUCCESS',
+      citations: ['uuid-1']
+    };
+
+    const verticalResults = [
+      {
+        results: [
+          {
+            id: 'entityid-1',
+            rawData: {
+              uid: 'uuid-1',
+              someField: 'someValue'
+            },
+            name: 'name-1',
+            description: 'description-1',
+            otherData: 'otherData'
+          }
+        ],
+        resultsCount: 1,
+        verticalKey: 'vertical-key-1'
+      },
+      {
+        results: [
+          {
+            id: 'entityid-1',
+            rawData: {
+              uid: 'uuid-1',
+              someField: 'someValue'
+            },
+            name: 'name-1',
+            description: 'description-1',
+            otherData: 'otherData'
+          },
+          {
+            id: 'entityid-2',
+            rawData: {
+              uid: 'uuid-2',
+              someField: 'someValue'
+            },
+            name: 'name-2',
+            description: 'description-2',
+            otherData: 'otherData'
+          }
+        ],
+        resultsCount: 2,
+        verticalKey: 'vertical-key-2'
+      }
+    ];
+
+    const directAnswerAsHTML = RichTextFormatter.format(coreGenerativeDirectAnswerResponse.directAnswer, 'gda-snippet');
+    const expectedGenerativeDirectAnswer = {
+      directAnswer: directAnswerAsHTML,
+      resultStatus: 'SUCCESS',
+      citations: ['uuid-1'],
+      searcher: Searcher.UNIVERSAL,
+      citationsData: [
+        {
+          id: 'entityid-1',
+          name: 'name-1',
+          description: 'description-1',
+          rawData: {
+            uid: 'uuid-1',
+            someField: 'someValue'
+          }
+        }
+      ],
+      verticalKey: ''
+    };
+
+    const actualGenerativeDirectAnswer = GenerativeDirectAnswer.fromCore(
+      coreGenerativeDirectAnswerResponse,
+      Searcher.UNIVERSAL,
+      verticalResults
+    );
+
+    expect(actualGenerativeDirectAnswer).toMatchObject(expectedGenerativeDirectAnswer);
+  });
 });


### PR DESCRIPTION
If an entity is present in search results more than once (e.g. returned by two different verticals) and is cited by the GDA, it appeared in the sources more than one. This change dedups the search results while determining the sources to prevent this.

TEST=auto,manual

Added unit test.

Served answers-search-ui locally with `npx serve dist --cors -p 5001`. Changed all usages of sdkAssetUrl in answers-hitchhiker-theme to point to my local bundle of answers-search-ui being served on port 5001. Saw that a search which previously had duplicate generative answer sources was no longer duplicated.