### PR TITLE
Fix search result vertical list reversal before GDA call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.18.2",
+  "version": "1.18.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-search-ui",
-      "version": "1.18.2",
+      "version": "1.18.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/mapbox-gl-language": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.18.2",
+  "version": "1.18.3",
   "description": "Javascript Search Programming Interface",
   "main": "dist/answers-umd.js",
   "repository": {

--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -482,8 +482,8 @@ export default class Component {
       return;
     }
 
-    childData.reverse();
-    childData.forEach(data => {
+    const reversedChildData = childData.slice().reverse();
+    reversedChildData.forEach(data => {
       this.addChild(data, type, opts);
     });
   }

--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -482,8 +482,7 @@ export default class Component {
       return;
     }
 
-    const reversedChildData = childData.slice().reverse();
-    reversedChildData.forEach(data => {
+    childData.slice().reverse().forEach(data => {
       this.addChild(data, type, opts);
     });
   }


### PR DESCRIPTION
The list of each vertical of search results was being reversed before being sent to the backend for generative answers computation. This patch fixes an array reversal that was mutating the list of verticals when it should not have been.

J=TECHOPS-14115
TEST=manual

Served answers-search-ui bundle locally and spun up answers-hitchhiker-theme. Confirmed that search results render verticals in the correct order still and that the results we send to generative answers are also in the correct order.
