### PR TITLE
chore: mention max length for visitor idmethod in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ The visitor object ties a user's identity to their searches and actions. The vis
 
 ```js
     visitor: {
-      // Required, the ID associated with the user. This will be the yextUserId if Yext Auth is used.
+      // Required, the ID associated with the user. This will be the yextUserId if Yext Auth is used. Max of 64 characters.
       id: '123919',
       // Optional, the method used to generate the visitor ID. Max of 16 characters.
       idMethod: 'YEXT_USER',

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ The visitor object ties a user's identity to their searches and actions. The vis
     visitor: {
       // Required, the ID associated with the user. This will be the yextUserId if Yext Auth is used.
       id: '123919',
-      // Optional, the method used to generate the visitor ID.
+      // Optional, the method used to generate the visitor ID. Max of 16 characters.
       idMethod: 'YEXT_USER',
     },
 ```


### PR DESCRIPTION
Updating the README to mention that the max length of the visitor idmethod is 16 (taken from Snowflake table). Not planning on making a new release for this, and will instead wait for the next release to pick up this change.