### PR TITLE
ksearch: update v1.14 to fire click events on click

### DIFF
--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -496,7 +496,7 @@ export default class Component {
     const middleclick = dataset.middleclick;
     const options = dataset.eventoptions ? JSON.parse(dataset.eventoptions) : {};
 
-    DOM.on(domComponent, 'mousedown', e => {
+    DOM.on(domComponent, 'click', e => {
       if (e.button === 0 || (middleclick && e.button === 1)) {
         const event = new AnalyticsEvent(type, label);
         event.addOptions(this._analyticsOptions);


### PR DESCRIPTION
The current click event listener is set up to track mousedown - this works for some elements, but many now only fire pointerdown. In all cases, a click event is still fired, so for that reason and for consistency with the new SDKs we adjust to 'click'
J=TECHOPS-14689