### PR TITLE
Fix i18n build artifact process for v1.16

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -15,7 +15,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - name: Download build-output-US artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-output-US
           path: dist/

--- a/.github/workflows/acceptance_search_bar.yml
+++ b/.github/workflows/acceptance_search_bar.yml
@@ -14,7 +14,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - name: Download build-output-US artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-output-US
           path: dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     - run: npm ci
     - run: npm run ${{ inputs.build_script }}
     - name: Create build-output-US artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: build-output-US
         path: dist/

--- a/.github/workflows/build_i18n.yml
+++ b/.github/workflows/build_i18n.yml
@@ -53,5 +53,5 @@ jobs:
     - name: Create build-output-${{ inputs.cloud_region }} artifact
       uses: actions/upload-artifact@v4
       with:
-        name: build-output-${{ inputs.cloud_region }}
+        name: build-output-${{ inputs.cloud_region }}-${{ matrix.language }}
         path: dist/

--- a/.github/workflows/build_i18n.yml
+++ b/.github/workflows/build_i18n.yml
@@ -51,7 +51,7 @@ jobs:
           npm run size
         fi
     - name: Create build-output-${{ inputs.cloud_region }} artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: build-output-${{ inputs.cloud_region }}
         path: dist/

--- a/.github/workflows/build_i18n.yml
+++ b/.github/workflows/build_i18n.yml
@@ -55,3 +55,30 @@ jobs:
       with:
         name: build-output-${{ inputs.cloud_region }}-${{ matrix.language }}
         path: dist/
+
+  merge_multiple_artifacts:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge into build-output-${{ inputs.cloud_region }}-temp Artifact
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: build-output-${{ inputs.cloud_region }}-temp
+          pattern: build-output-${{ inputs.cloud_region }}-*
+          delete-merged: true
+
+  overwrite_artifact:
+    needs: merge_multiple_artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build-output-${{ inputs.cloud_region }}-temp artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output-${{ inputs.cloud_region }}-temp
+          path: dist/
+      - name: Overwrite build-output-${{ inputs.cloud_region }} artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output-${{ inputs.cloud_region }}
+          path: dist/
+          overwrite: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download build-output-US artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-output-US
           path: dist/

--- a/.github/workflows/deploy_hold.yml
+++ b/.github/workflows/deploy_hold.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download build-output-US artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-output-US
           path: dist/
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download build-output-EU artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-output-EU
           path: dist/

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -16,7 +16,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - name: Download build-output-US artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-output-US
           path: dist/

--- a/conf/i18n/translations/messages.pot
+++ b/conf/i18n/translations/messages.pot
@@ -198,7 +198,7 @@ msgstr ""
 msgid "We're sorry, an error occurred."
 msgstr ""
 
-#: src/ui/templates/search/filtersearch.hbs:12
+#: src/ui/templates/search/filtersearch.hbs:14
 #: src/ui/templates/search/search.hbs:30
 msgid "When autocomplete results are available, use up and down arrows to review and enter to select."
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.16.7",
+  "version": "1.16.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-search-ui",
-      "version": "1.16.7",
+      "version": "1.16.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/mapbox-gl-language": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.16.7",
+  "version": "1.16.8",
   "description": "Javascript Search Programming Interface",
   "main": "dist/answers-umd.js",
   "repository": {

--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -495,14 +495,20 @@ export default class Component {
     const label = dataset.eventlabel;
     const middleclick = dataset.middleclick;
     const options = dataset.eventoptions ? JSON.parse(dataset.eventoptions) : {};
-
-    DOM.on(domComponent, 'mousedown', e => {
+    const handleClick = (e) => {
       if (e.button === 0 || (middleclick && e.button === 1)) {
         const event = new AnalyticsEvent(type, label);
         event.addOptions(this._analyticsOptions);
         event.addOptions(options);
         this.analyticsReporter.report(event);
       }
+    };
+
+    DOM.on(domComponent, 'click', e => {
+      handleClick(e);
+    });
+    DOM.on(domComponent, 'auxclick', e => {
+      handleClick(e);
     });
   }
 

--- a/src/ui/components/ctas/ctacomponent.js
+++ b/src/ui/components/ctas/ctacomponent.js
@@ -83,10 +83,16 @@ export default class CTAComponent extends Component {
   onMount () {
     const el = DOM.query(this._container, '.js-yxt-CTA');
     if (el && this._config.eventOptions) {
-      DOM.on(el, 'mousedown', e => {
+      const handleClick = (e) => {
         if (e.button === 0 || e.button === 1) {
           this.reportAnalyticsEvent();
         }
+      };
+      DOM.on(el, 'click', e => {
+        handleClick(e);
+      });
+      DOM.on(el, 'auxclick', e => {
+        handleClick(e);
       });
     }
   }

--- a/src/ui/templates/search/filtersearch.hbs
+++ b/src/ui/templates/search/filtersearch.hbs
@@ -1,13 +1,15 @@
 <h1>{{title}}</h1>
 <div class="yext-search-container">
-  <label for="query">{{searchText}}</label>
-  <input class="js-yext-query"
-         type="text"
-         name="query"
-         value="{{query}}"
-         {{#if _config.placeholderText}}placeholder="{{_config.placeholderText}}"{{/if}}
-         aria-describedby="instructions">
-  </input>
+  <label>
+    {{searchText}}
+    <input class="js-yext-query"
+           type="text"
+           name="query"
+           value="{{query}}"
+           {{#if _config.placeholderText}}placeholder="{{_config.placeholderText}}"{{/if}}
+           aria-describedby="instructions">
+    </input>
+  </label>
   <div id="instructions" class="yxt-SearchBar-instructions sr-only">
     {{translate
       phrase='When autocomplete results are available, use up and down arrows to review and enter to select.'

--- a/tests/acceptance/fixtures/html/facets.html
+++ b/tests/acceptance/fixtures/html/facets.html
@@ -1,7 +1,8 @@
-<html>
+<html lang="en">
 
 <head>
   <meta charset="utf-8" />
+  <title>Facets</title>
 
   <script src="http://localhost:9999/dist/answerstemplates.compiled.min.js"></script>
   <script src="http://localhost:9999/dist/answers.js"></script>
@@ -97,7 +98,7 @@
             {
               type: 'RELEVANCE',
               label: 'Price - High to Low'
-            }  
+            }
           ],
           verticalKey: 'people'
         });

--- a/tests/acceptance/fixtures/html/facetsonload.html
+++ b/tests/acceptance/fixtures/html/facetsonload.html
@@ -1,7 +1,8 @@
-<html>
+<html lang="en">
 
 <head>
   <meta charset="utf-8" />
+  <title>Facets On-Load</title>
 
   <script src="http://localhost:9999/dist/answerstemplates.compiled.min.js"></script>
   <script src="http://localhost:9999/dist/answers.js"></script>
@@ -96,7 +97,7 @@
             {
               type: 'RELEVANCE',
               label: 'Price - High to Low'
-            }  
+            }
           ],
           verticalKey: 'people'
         });

--- a/tests/acceptance/fixtures/html/filterbox.html
+++ b/tests/acceptance/fixtures/html/filterbox.html
@@ -1,7 +1,8 @@
-<html>
+<html lang="en">
 
 <head>
   <meta charset="utf-8" />
+  <title>Filter Box</title>
 
   <script src="http://localhost:9999/dist/answerstemplates.compiled.min.js"></script>
   <script src="http://localhost:9999/dist/answers.js"></script>
@@ -15,7 +16,7 @@
     .left {
       min-width: 300px;
     }
-  
+
     .right {
       flex-grow: 1;
     }

--- a/tests/acceptance/fixtures/html/no-unsafe-eval.html
+++ b/tests/acceptance/fixtures/html/no-unsafe-eval.html
@@ -1,8 +1,9 @@
-<html>
+<html lang="en">
 
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline';">
+  <title>No Unsafe Eval</title>
 
   <script src="http://localhost:9999/dist/answerstemplates.compiled.min.js"></script>
   <script src="http://localhost:9999/dist/answers.js"></script>

--- a/tests/acceptance/fixtures/html/searchbaronly.html
+++ b/tests/acceptance/fixtures/html/searchbaronly.html
@@ -1,6 +1,7 @@
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
+    <title>Search Bar Only</title>
     <script src="http://localhost:9999/dist/answerstemplates.compiled.min.js"></script>
     <script src="http://localhost:9999/dist/answers.js"></script>
     <link rel="stylesheet" type="text/css" href="http://localhost:9999/dist/answers-search-bar.css">

--- a/tests/acceptance/fixtures/html/universal.html
+++ b/tests/acceptance/fixtures/html/universal.html
@@ -1,7 +1,8 @@
-<html>
+<html lang="en">
 
 <head>
   <meta charset="utf-8" />
+  <title>Universal Search</title>
 
   <script src="http://localhost:9999/dist/answerstemplates.compiled.min.js"></script>
   <script src="http://localhost:9999/dist/answers.js"></script>

--- a/tests/acceptance/fixtures/html/universalinitialsearch.html
+++ b/tests/acceptance/fixtures/html/universalinitialsearch.html
@@ -1,7 +1,8 @@
-<html>
+<html lang="en">
 
 <head>
   <meta charset="utf-8" />
+  <title>Universal Search</title>
 
   <script src="http://localhost:9999/dist/answerstemplates.compiled.min.js"></script>
   <script src="http://localhost:9999/dist/answers.js"></script>

--- a/tests/acceptance/fixtures/html/vertical.html
+++ b/tests/acceptance/fixtures/html/vertical.html
@@ -1,7 +1,8 @@
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8" />
-    
+        <title>Universal Search</title>
+
         <script src="http://localhost:9999/dist/answerstemplates.compiled.min.js"></script>
         <script src="http://localhost:9999/dist/answers.js"></script>
         <link rel="stylesheet" type="text/css" href="http://localhost:9999/dist/answers.css">
@@ -14,7 +15,7 @@
             <div class="results-container"></div>
             <div class="pagination-container"></div>
         </div>
-    
+
         <script>
             ANSWERS.init({
                 apiKey: '<apiKey>',

--- a/tests/acceptance/percy/snapshots.js
+++ b/tests/acceptance/percy/snapshots.js
@@ -6,7 +6,10 @@ const PageNavigator = require('../pagenavigator');
 
 (async () => {
   const server = await setupServer();
-  const browser = await puppeteer.launch();
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox']
+  });
   const page = await browser.newPage();
   const navigator = new PageNavigator(page, 'http://localhost:9999/tests/acceptance/fixtures/html');
 

--- a/tests/acceptance/wcag/index.js
+++ b/tests/acceptance/wcag/index.js
@@ -34,7 +34,10 @@ async function setupServer () {
 
 async function wcagTester () {
   const server = await setupServer();
-  const browser = await puppeteer.launch();
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox']
+  });
   const page = await browser.newPage();
 
   page

--- a/tests/acceptance/wcag/index.js
+++ b/tests/acceptance/wcag/index.js
@@ -54,6 +54,7 @@ async function wcagTester () {
     results = await new WcagReporter(pageNavigator, analyzer).analyze();
   } catch (e) {
     console.log(e);
+    await page.close();
     await browser.close();
     await server.close();
     process.exit(1);
@@ -67,6 +68,7 @@ async function wcagTester () {
     }
   });
 
+  await page.close();
   await browser.close();
   await server.close();
 
@@ -77,4 +79,4 @@ async function wcagTester () {
   }
 }
 
-wcagTester();
+wcagTester().then(() => console.log('WCAG test completed'));

--- a/tests/ui/components/component.js
+++ b/tests/ui/components/component.js
@@ -78,9 +78,9 @@ describe('attaching analytics events', () => {
     const domOn = jest.spyOn(DOM, 'on');
 
     const wrapper = mount(component);
-    expect(domOn).toHaveBeenCalledTimes(1);
+    expect(domOn).toHaveBeenCalledTimes(2);
 
-    wrapper.find('#test').getDOMNode().dispatchEvent(new MouseEvent('mousedown', { button: 0 }));
+    wrapper.find('#test').getDOMNode().dispatchEvent(new MouseEvent('click', { button: 0 }));
     expect(mockAnalyticsReporter.report).toHaveBeenCalledTimes(1);
     const expectedEvent = new AnalyticsEvent('test_event');
     expectedEvent.addOptions({ name: 'Jesse' });
@@ -102,9 +102,9 @@ describe('attaching analytics events', () => {
     const domOn = jest.spyOn(DOM, 'on');
 
     const wrapper = mount(component);
-    expect(domOn).toHaveBeenCalledTimes(1);
+    expect(domOn).toHaveBeenCalledTimes(2);
 
-    wrapper.find('#test').getDOMNode().dispatchEvent(new MouseEvent('mousedown', { button: 0 }));
+    wrapper.find('#test').getDOMNode().dispatchEvent(new MouseEvent('click', { button: 0 }));
     expect(mockAnalyticsReporter.report).toHaveBeenCalledTimes(1);
     const expectedEvent = new AnalyticsEvent('test_event');
     expectedEvent.addOptions({ name: 'Vig' });
@@ -125,9 +125,9 @@ describe('attaching analytics events', () => {
     const domOn = jest.spyOn(DOM, 'on');
 
     const wrapper = mount(component);
-    expect(domOn).toHaveBeenCalledTimes(1);
+    expect(domOn).toHaveBeenCalledTimes(2);
 
-    wrapper.find('#test').getDOMNode().dispatchEvent(new MouseEvent('mousedown', { button: 0 }));
+    wrapper.find('#test').getDOMNode().dispatchEvent(new MouseEvent('click', { button: 0 }));
     expect(mockAnalyticsReporter.report).toHaveBeenCalledTimes(1);
     const expectedEvent = new AnalyticsEvent('test_event');
     expectedEvent.addOptions({

--- a/tests/ui/components/search/autocompletecomponent.js
+++ b/tests/ui/components/search/autocompletecomponent.js
@@ -51,7 +51,7 @@ describe('AUTO_COMPLETE_SELECTION analytics event fire as expected', () => {
     wrapper
       .find("[data-value='test prompt \"some text ...more text.\"  for TEST output']")
       .getDOMNode()
-      .dispatchEvent(new MouseEvent('mousedown', { button: 0 }));
+      .dispatchEvent(new MouseEvent('click', { button: 0 }));
 
     expect(mockAnalyticsReporter.report).toHaveBeenCalledTimes(1);
     const expectedEvent = {


### PR DESCRIPTION
This code was present in the most recent version, but I didn't realize it was necessary to include when I updated the script in #1949. 

Ultimately the reason we have to make this change is because the version of 'actions/[upload/download]-artifact' that we use in our GitHub workflow script was deprecated since the last time we had to deploy a new bundle for this minor version.