### PR TITLE
v1.18.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.18.7",
+  "version": "1.18.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-search-ui",
-      "version": "1.18.7",
+      "version": "1.18.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/mapbox-gl-language": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-search-ui",
-  "version": "1.18.7",
+  "version": "1.18.8",
   "description": "Javascript Search Programming Interface",
   "main": "dist/answers-umd.js",
   "repository": {

--- a/src/ui/templates/search/search.hbs
+++ b/src/ui/templates/search/search.hbs
@@ -49,7 +49,8 @@
           </button>
         {{/if}}
         <button {{#if useForm}}type="submit"{{else}}type="button"{{/if}}
-          class="js-yext-submit yxt-SearchBar-button">
+          class="js-yext-submit yxt-SearchBar-button"
+          aria-label="{{submitText}}">
           {{> icons/searchBarIcon}}
           <span class="yxt-SearchBar-buttonText sr-only">
             {{submitText}}
@@ -94,7 +95,8 @@
           </button>
         {{/if}}
         <button {{#if useForm}}type="submit"{{else}}type="button"{{/if}}
-          class="js-yext-submit yxt-SearchBar-button">
+          class="js-yext-submit yxt-SearchBar-button"
+          aria-label="{{submitText}}">
           {{> icons/searchBarIcon}}
           <span class="yxt-SearchBar-buttonText sr-only">
             {{submitText}}


### PR DESCRIPTION
**ksearch: add aria-label to submit buttons for the search bar**
As can be seen in the referenced item, there are concerns
that our submit buttons having aria-hidden svgs can mess with
screen readers, even with the sr-only submitText. This PR
adds an explicit aria-label to the submit button.

J=WAT-5037
TEST=manual

Ran site locally, and in the Accessibility section, saw
the Aria attribute 'Submit' as expected